### PR TITLE
phase2-extract: 29 new plugins (registry 31 → 60 — Phase 2 of #640)

### DIFF
--- a/plugins/about/about.test.ts
+++ b/plugins/about/about.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+const root = join(import.meta.dir, "../../..");
+
+mock.module(join(root, "commands/plugins/oracle/impl"), () => ({
+  cmdOracleAbout: async (oracle: string) => {
+    console.log(`Oracle — ${oracle}`);
+    console.log(`  Repo:      /home/neo/ghq/github.com/Soul-Brews-Studio/${oracle}-oracle`);
+    console.log(`  Session:   ${oracle}`);
+  },
+}));
+
+const { default: handler } = await import("./index");
+
+describe("about plugin", () => {
+  it("CLI — shows info for named oracle", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Oracle — neo");
+  });
+
+  it("CLI — missing oracle returns error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage");
+  });
+
+  it("API — oracle param shows info", async () => {
+    const ctx: InvokeContext = { source: "api", args: { oracle: "white" } };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("Oracle — white");
+  });
+
+  it("API — missing oracle returns error", async () => {
+    const ctx: InvokeContext = { source: "api", args: {} };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("oracle is required");
+  });
+});

--- a/plugins/about/index.ts
+++ b/plugins/about/index.ts
@@ -1,0 +1,46 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdOracleAbout } from "./internal/impl-about";
+
+export const command = {
+  name: ["about", "info"],
+  description: "Show information about an oracle (session, repo, windows).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let oracle: string;
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      if (!args[0]) {
+        return { ok: false, error: "usage: maw about <oracle>" };
+      }
+      oracle = args[0];
+    } else {
+      const args = ctx.args as Record<string, unknown>;
+      if (!args.oracle) {
+        return { ok: false, error: "oracle is required" };
+      }
+      oracle = args.oracle as string;
+    }
+
+    await cmdOracleAbout(oracle);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/about/internal/impl-about.ts
+++ b/plugins/about/internal/impl-about.ts
@@ -1,0 +1,98 @@
+import { listSessions, capture, FLEET_DIR } from "../../../../sdk";
+import { findWorktrees, detectSession } from "../../../shared/wake";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+import { resolveOracleSafe } from "./impl-helpers";
+import { UserError } from "../../../../core/util/user-error";
+
+export async function cmdOracleAbout(oracle: string) {
+  const name = oracle.toLowerCase();
+  const sessions = await listSessions();
+
+  // Gather all signals first so we can distinguish "real oracle, sparse data"
+  // from "no such oracle" — the latter must error rather than print an
+  // empty-but-valid-looking record (#390.2).
+  const { repoPath, repoName, parentDir } = await resolveOracleSafe(name);
+  const session = await detectSession(name);
+
+  const fleetDir = FLEET_DIR;
+  let fleetFile: string | null = null;
+  let fleetWindowCount = 0;
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json"))) {
+      const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      const hasOracle = (config.windows || []).some(
+        (w: any) => w.name.toLowerCase() === `${name}-oracle` || w.name.toLowerCase() === name
+      );
+      if (hasOracle) {
+        fleetFile = file;
+        fleetWindowCount = config.windows.length;
+        break;
+      }
+    }
+  } catch { /* expected: fleet dir may not exist */ }
+
+  if (!repoPath && !session && !fleetFile) {
+    throw new UserError(`no oracle named '${oracle}' — try: maw oracle ls`);
+  }
+
+  // Heading — preserve user input casing. Auto-capitalizing turned 'mawjs'
+  // into 'Mawjs', which is wrong (oracle names are lowercase by convention).
+  console.log(`\n  \x1b[36mOracle — ${oracle}\x1b[0m\n`);
+
+  // Repo
+  console.log(`  Repo:      ${repoPath || "(not found)"}`);
+
+  // Session + windows
+  if (session) {
+    const s = sessions.find(s => s.name === session);
+    const windows = s?.windows || [];
+    console.log(`  Session:   ${session} (${windows.length} windows)`);
+    for (const w of windows) {
+      let status = "\x1b[90m○\x1b[0m";
+      try {
+        const content = await capture(`${session}:${w.index}`, 3);
+        status = content.trim() ? "\x1b[32m●\x1b[0m" : "\x1b[33m●\x1b[0m";
+      } catch { /* expected: capture may fail for inactive pane */ }
+      console.log(`    ${status} ${w.name}`);
+    }
+  } else {
+    console.log(`  Session:   (none)`);
+  }
+
+  // Worktrees
+  if (parentDir) {
+    const wts = await findWorktrees(parentDir, repoName);
+    console.log(`  Worktrees: ${wts.length}`);
+    for (const wt of wts) {
+      console.log(`    ${wt.name} → ${wt.path}`);
+    }
+  }
+
+  // Fleet config
+  if (fleetFile) {
+    const actualWindows = session
+      ? (sessions.find(s => s.name === session)?.windows.length || 0)
+      : 0;
+    console.log(`  Fleet:     ${fleetFile} (${fleetWindowCount} registered, ${actualWindows} running)`);
+    if (actualWindows > fleetWindowCount) {
+      // Find which windows are unregistered
+      const fleetConfig = JSON.parse(readFileSync(join(fleetDir, fleetFile), "utf-8"));
+      const registeredNames = new Set((fleetConfig.windows || []).map((w: any) => w.name));
+      const runningWindows = sessions.find(s => s.name === session)?.windows || [];
+      const unregistered = runningWindows.filter(w => !registeredNames.has(w.name));
+
+      console.log(`  \x1b[33m⚠\x1b[0m  ${unregistered.length} window(s) not in fleet config — won't survive reboot`);
+      for (const w of unregistered) {
+        console.log(`    \x1b[33m→\x1b[0m ${w.name}`);
+      }
+      console.log(`\n  \x1b[90mFix: add to fleet/${fleetFile}\x1b[0m`);
+      console.log(`  \x1b[90m  maw fleet init          # regenerate all configs\x1b[0m`);
+      console.log(`  \x1b[90m  maw fleet validate      # check for problems\x1b[0m`);
+    }
+  } else {
+    console.log(`  Fleet:     (no config)`);
+  }
+
+  console.log();
+}

--- a/plugins/about/internal/impl-helpers.ts
+++ b/plugins/about/internal/impl-helpers.ts
@@ -1,0 +1,87 @@
+import { listSessions, FLEET_DIR, type OracleEntry } from "../../../../sdk";
+import { ghqFind } from "../../../../core/ghq";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+/** Like resolveOracle but returns null instead of throwing on miss */
+export async function resolveOracleSafe(oracle: string): Promise<{ repoPath: string; repoName: string; parentDir: string } | { parentDir: ""; repoName: ""; repoPath: "" }> {
+  // Try oracle-oracle pattern first, then direct name (e.g., homekeeper → homelab)
+  const repoPath = (await ghqFind(`/${oracle}-oracle$`)) ?? (await ghqFind(`/${oracle}$`));
+  if (!repoPath) return { parentDir: "", repoName: "", repoPath: "" };
+  const repoName = repoPath.split("/").pop()!;
+  const parentDir = repoPath.replace(/\/[^/]+$/, "");
+  return { repoPath, repoName, parentDir };
+}
+
+/** Discover oracles: union of fleet configs + running tmux sessions */
+export async function discoverOracles(): Promise<string[]> {
+  const names = new Set<string>();
+
+  // 1. Fleet configs (registered — includes sleeping)
+  const fleetDir = FLEET_DIR;
+  try {
+    for (const file of readdirSync(fleetDir).filter(f => f.endsWith(".json") && !f.endsWith(".disabled"))) {
+      const config = JSON.parse(readFileSync(join(fleetDir, file), "utf-8"));
+      for (const w of config.windows || []) {
+        if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
+      }
+    }
+  } catch { /* fleet dir may not exist */ }
+
+  // 2. Running tmux (actual state — catches unregistered oracles)
+  try {
+    const sessions = await listSessions();
+    for (const s of sessions) {
+      for (const w of s.windows) {
+        if (w.name.endsWith("-oracle")) names.add(w.name.replace(/-oracle$/, ""));
+      }
+    }
+  } catch { /* tmux not running */ }
+
+  return [...names].sort();
+}
+
+export interface OracleStatus {
+  name: string;
+  session: string | null;
+  windows: string[];
+  worktrees: number;
+  status: "awake" | "sleeping";
+}
+
+/**
+ * Source-lineage for an oracle entry — "why is this in the list?"
+ * Drives the icon column in the grouped `ls` view.
+ */
+export interface OracleLineage {
+  hasFleetConfig: boolean;   // ~/.config/maw/fleet/<name>.json exists
+  hasPsi: boolean;           // <repo>/ψ exists
+  isAwake: boolean;          // tmux session running
+  inAgents: boolean;         // appears in config.agents
+  federationNode?: string;   // from config.agents (or entry's federation_node)
+}
+
+export function lineageOf(
+  entry: OracleEntry,
+  awake: boolean,
+  agents: Record<string, string>,
+): OracleLineage {
+  return {
+    hasFleetConfig: entry.has_fleet_config,
+    hasPsi: entry.has_psi,
+    isAwake: awake,
+    inAgents: entry.name in agents,
+    federationNode: agents[entry.name] ?? entry.federation_node ?? undefined,
+  };
+}
+
+export function timeSince(iso: string): string {
+  const ms = Date.now() - new Date(iso).getTime();
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h`;
+  return `${Math.floor(h / 24)}d`;
+}

--- a/plugins/about/plugin.json
+++ b/plugins/about/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "about",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Show information about an oracle (session, repo, windows).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "about",
+    "aliases": [
+      "info"
+    ],
+    "help": "maw about <oracle> — show oracle info"
+  },
+  "api": {
+    "path": "/api/about",
+    "methods": [
+      "GET"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/archive/impl.ts
+++ b/plugins/archive/impl.ts
@@ -1,0 +1,91 @@
+import { hostExec } from "../../../sdk";
+import { getGhqRoot } from "../../../config/ghq-root";
+import { loadFleetEntries } from "../../shared/fleet-load";
+import { cmdSoulSync } from "./internal/soul-sync-impl";
+import { FLEET_DIR } from "../../../sdk";
+import { join } from "path";
+import { existsSync, renameSync } from "fs";
+
+/**
+ * maw archive <oracle> [--dry-run]
+ *
+ * Apoptosis — graceful oracle death.
+ *   1. Final soul-sync to all peers
+ *   2. Disable fleet config (.disabled)
+ *   3. Archive GitHub repo
+ *   4. Log death in family registry
+ */
+export async function cmdArchive(oracleName: string, opts: { dryRun?: boolean } = {}) {
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const entries = loadFleetEntries();
+
+  const entry = entries.find(e => e.session.name.replace(/^\d+-/, "") === oracleName);
+  if (!entry) {
+    throw new Error(`oracle '${oracleName}' not found in fleet config`);
+  }
+
+  const mainWindow = entry.session.windows[0];
+  const repoSlug = mainWindow?.repo || "";
+  const repoPath = repoSlug ? join(reposRoot, repoSlug) : "";
+
+  console.log(`\n  \x1b[36m⚰️  Archiving\x1b[0m — ${oracleName}\n`);
+
+  // 1. Final soul-sync to all peers
+  if (entry.session.sync_peers?.length) {
+    if (opts.dryRun) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would soul-sync to ${entry.session.sync_peers.join(", ")}`);
+    } else {
+      console.log(`  \x1b[36m⏳\x1b[0m final soul-sync to peers...`);
+      try {
+        if (repoPath) await cmdSoulSync(undefined, { cwd: repoPath });
+        console.log(`  \x1b[32m✓\x1b[0m soul-sync complete`);
+      } catch {
+        console.log(`  \x1b[33m⚠\x1b[0m soul-sync failed (peers may be offline)`);
+      }
+    }
+  } else {
+    console.log(`  \x1b[90m○\x1b[0m no sync_peers configured — knowledge stays local`);
+  }
+
+  // 2. Disable fleet config
+  const fleetFile = join(FLEET_DIR, entry.file);
+  const disabledFile = fleetFile + ".disabled";
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would disable: ${entry.file} → ${entry.file}.disabled`);
+  } else {
+    try {
+      renameSync(fleetFile, disabledFile);
+      console.log(`  \x1b[32m✓\x1b[0m fleet config disabled: ${entry.file}.disabled`);
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m could not disable fleet config: ${e.message}`);
+    }
+  }
+
+  // 3. Archive GitHub repo
+  if (repoSlug) {
+    if (opts.dryRun) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would archive: gh repo archive ${repoSlug}`);
+    } else {
+      try {
+        await hostExec(`gh repo archive ${repoSlug} --yes`);
+        console.log(`  \x1b[32m✓\x1b[0m GitHub repo archived: ${repoSlug}`);
+      } catch (e: any) {
+        console.log(`  \x1b[33m⚠\x1b[0m archive failed: ${e.message || e}`);
+      }
+    }
+  }
+
+  // 4. Death certificate
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would log death to family registry`);
+  } else {
+    console.log(`  \x1b[32m✓\x1b[0m ${oracleName} archived — ψ/ preserved locally, knowledge synced to peers`);
+  }
+
+  console.log();
+  if (!opts.dryRun) {
+    console.log(`  \x1b[90mNothing is deleted (Principle 1). ψ/ and git history remain.\x1b[0m`);
+    console.log(`  \x1b[90mTo unarchive: rename ${entry.file}.disabled → ${entry.file} + gh repo unarchive\x1b[0m`);
+  }
+  console.log();
+}

--- a/plugins/archive/index.ts
+++ b/plugins/archive/index.ts
@@ -1,0 +1,41 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdArchive } from "./impl";
+
+export const command = {
+  name: "archive",
+  description: "Archive an oracle's tmux session and data.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+  // Handle --help before monkey-patching so output always reaches stdout
+  if (args[0] === "--help" || args[0] === "-h") {
+    const help = "usage: maw archive <oracle> [--dry-run] — archive an oracle's tmux session and data";
+    if (ctx.writer) ctx.writer(help);
+    else console.log(help);
+    return { ok: true };
+  }
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    if (!args[0]) throw new Error("usage: maw archive <oracle> [--dry-run]");
+    await cmdArchive(args[0], { dryRun: args.includes("--dry-run") });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/archive/internal/resolve.ts
+++ b/plugins/archive/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/plugins/archive/internal/soul-sync-impl.ts
+++ b/plugins/archive/internal/soul-sync-impl.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "fs";
+import { join, basename } from "path";
+import { hostExec } from "../../../../sdk";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
+import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+export { syncDir, findPeers, findProjectsForOracle, syncProjectVault } from "./sync-helpers";
+export type { SoulSyncResult, ProjectSyncResult } from "./sync-helpers";
+export { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+/**
+ * maw soul-sync [peer] [--from <peer>] — push ψ/ to peers; --from reverses direction.
+ * maw ss <peer>       push to specific peer
+ * maw ss --from <p>   pull from specific peer
+ */
+export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?: string }): Promise<SoulSyncResult[]> {
+  const results: SoulSyncResult[] = [];
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  const cwdParts = cwd.split("/");
+  const repoName = cwdParts.pop() || "";
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
+
+  let oraclePath = cwd;
+  try {
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (commonDir && commonDir !== ".git") {
+      const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+      oraclePath = join(mainGit, "..");
+    }
+  } catch { /* use cwd */ }
+
+  const peers = target ? [target] : findPeers(oracleName);
+  if (peers.length === 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m soul-sync: no sync_peers configured for '${oracleName}'`);
+    console.log(`  \x1b[90mAdd "sync_peers": ["name"] to fleet config, or run: maw ss <peer>\x1b[0m`);
+    return results;
+  }
+
+  const direction = opts?.from ? "pull" : "push";
+  const label = direction === "pull"
+    ? `pulling ${peers[0]} → ${oracleName}`
+    : `pushing ${oracleName} → ${peers.join(", ")}`;
+  console.log(`\n  \x1b[36m⚡ Soul Sync\x1b[0m — ${label}\n`);
+
+  for (const peer of peers) {
+    const peerPath = await resolveOraclePath(peer);
+    if (!peerPath) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${peer}: repo not found, skipping`);
+      continue;
+    }
+
+    const [from, to, fromName, toName] = direction === "pull"
+      ? [peerPath, oraclePath, peer, oracleName]
+      : [oraclePath, peerPath, oracleName, peer];
+
+    const result = syncOracleVaults(from, to, fromName, toName);
+    results.push(result);
+
+    if (result.total === 0) {
+      console.log(`  \x1b[90m○\x1b[0m ${fromName} → ${toName}: nothing new`);
+    } else {
+      const parts = Object.entries(result.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+      console.log(`  \x1b[32m✓\x1b[0m ${fromName} → ${toName}: ${parts.join(", ")}`);
+    }
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) synced.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+
+  return results;
+}
+
+/**
+ * maw soul-sync --project — absorb project ψ/ into oracle ψ/ (inward only).
+ * Oracle cwd: absorbs from each project_repos entry.
+ * Project cwd: pushes ψ/ to the oracle that owns this repo.
+ */
+export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<ProjectSyncResult[]> {
+  const results: ProjectSyncResult[] = [];
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  let repoRoot = cwd;
+  try {
+    const top = (await hostExec(`git -C '${cwd}' rev-parse --show-toplevel`)).trim();
+    if (top) repoRoot = top;
+  } catch { /* not a git repo */ }
+
+  const repoSlug = resolveProjectSlug(repoRoot, reposRoot);
+  const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
+  const isOracle = repoBase.endsWith("-oracle");
+
+  console.log(`\n  \x1b[36m⚡ Soul Sync (project)\x1b[0m — ${isOracle ? "absorbing into" : "exporting from"} ${repoBase}\n`);
+
+  if (isOracle) {
+    const oracleName = repoBase.replace(/-oracle$/, "");
+    const projects = findProjectsForOracle(oracleName);
+    if (projects.length === 0) {
+      console.log(`  \x1b[33m⚠\x1b[0m no project_repos configured for '${oracleName}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["org/repo"] to fleet config for ${oracleName}.\x1b[0m\n`);
+      return results;
+    }
+    for (const projectRepo of projects) {
+      const projectPath = join(reposRoot, projectRepo);
+      if (!existsSync(projectPath)) {
+        console.log(`  \x1b[33m⚠\x1b[0m ${projectRepo}: not found at ${projectPath}, skipping`);
+        continue;
+      }
+      const result = syncProjectVault(projectPath, repoRoot, projectRepo, oracleName);
+      results.push(result);
+      reportProjectResult(result);
+    }
+  } else {
+    if (!repoSlug) {
+      console.log(`  \x1b[33m⚠\x1b[0m cannot resolve project slug from ${repoRoot} (not under repos root ${reposRoot})\n`);
+      return results;
+    }
+    const oracleName = findOracleForProject(repoSlug);
+    if (!oracleName) {
+      console.log(`  \x1b[33m⚠\x1b[0m no oracle owns project '${repoSlug}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["${repoSlug}"] to an oracle's fleet config.\x1b[0m\n`);
+      return results;
+    }
+    const oraclePath = await resolveOraclePath(oracleName);
+    if (!oraclePath) {
+      console.log(`  \x1b[33m⚠\x1b[0m oracle '${oracleName}' repo not found locally\n`);
+      return results;
+    }
+    const result = syncProjectVault(repoRoot, oraclePath, repoSlug, oracleName);
+    results.push(result);
+    reportProjectResult(result);
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) absorbed.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+  return results;
+}

--- a/plugins/archive/internal/sync-helpers.ts
+++ b/plugins/archive/internal/sync-helpers.ts
@@ -1,0 +1,150 @@
+import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadFleet } from "../../../shared/fleet-load";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+/**
+ * Find peer oracle names for a given oracle from fleet config.
+ * Flat lookup — each oracle declares its own sync_peers.
+ */
+export function findPeers(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName && sess.sync_peers) return sess.sync_peers;
+  }
+  return [];
+}
+
+/**
+ * Find project repos this oracle absorbs from.
+ */
+export function findProjectsForOracle(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName) return sess.project_repos || [];
+  }
+  return [];
+}
+
+export interface SoulSyncResult {
+  from: string;
+  to: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from one oracle repo to another (new files only).
+ */
+export function syncOracleVaults(fromPath: string, toPath: string, fromName: string, toName: string): SoulSyncResult {
+  const fromVault = join(fromPath, "ψ");
+  const toVault = join(toPath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(fromVault, subdir);
+    const dst = join(toVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(toVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | ${fromName} → ${toName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { from: fromName, to: toName, synced, total };
+}
+
+export interface ProjectSyncResult {
+  project: string;
+  oracle: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from a project repo into an oracle repo.
+ * Knowledge flows inward through the membrane — project → oracle, new files only.
+ */
+export function syncProjectVault(
+  projectPath: string,
+  oraclePath: string,
+  projectRepo: string,
+  oracleName: string,
+): ProjectSyncResult {
+  const projectVault = join(projectPath, "ψ");
+  const oracleVault = join(oraclePath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(projectVault, subdir);
+    const dst = join(oracleVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(oracleVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | project:${projectRepo} → ${oracleName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { project: projectRepo, oracle: oracleName, synced, total };
+}
+
+export function reportProjectResult(r: ProjectSyncResult) {
+  if (r.total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m project:${r.project} → ${r.oracle}: nothing new`);
+  } else {
+    const parts = Object.entries(r.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+    console.log(`  \x1b[32m✓\x1b[0m project:${r.project} → ${r.oracle}: ${parts.join(", ")}`);
+  }
+}

--- a/plugins/archive/plugin.json
+++ b/plugins/archive/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "archive",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Archive an oracle's tmux session and data.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "archive",
+    "help": "maw archive <oracle> [--dry-run] — archive an oracle's tmux session and data"
+  },
+  "weight": 50
+}

--- a/plugins/artifact-manager/README.md
+++ b/plugins/artifact-manager/README.md
@@ -1,0 +1,54 @@
+# artifact-manager
+
+> TS plugin — no WASM, no compilation. Pure TypeScript.
+
+## Install
+
+```bash
+maw plugins install ./src/commands/plugins/artifact-manager
+```
+
+Or symlink directly:
+```bash
+ln -s $(pwd)/src/commands/plugins/artifact-manager ~/.oracle/commands/artifact-manager
+```
+
+## Usage
+
+```bash
+maw art ls                          # list all artifacts
+maw art ls plugin-pkg               # filter by team
+maw art ls --json                   # machine-readable
+
+maw art get plugin-pkg 2            # show full artifact
+maw art get plugin-pkg 2 --json     # JSON output
+
+maw art write my-team 1 "Done!"     # write result.md
+maw art attach my-team 1 report.pdf # add attachment
+maw art init my-team 1 "Build X" "Description here"  # create manually
+```
+
+## Why TS, not WASM?
+
+This plugin needs full access to maw-js internals (`src/lib/artifacts.ts`).
+WASM plugins are sandboxed — they can only use host functions (maw_print, maw_identity, etc.).
+TS plugins import directly. Different trust levels:
+
+| | TS Plugin | WASM Plugin |
+|---|---|---|
+| Access | Full maw-js internals | Sandboxed host functions only |
+| Build | None — runs as-is | Compile Rust/AS → .wasm |
+| Use case | Internal tools | Community/external plugins |
+
+## Plugin manifest
+
+`plugin.json` uses `entry` instead of `wasm`:
+
+```json
+{
+  "name": "artifact-manager",
+  "entry": "./index.ts",
+  "cli": { "command": "art" },
+  "api": { "path": "/api/plugins/artifact-manager", "methods": ["GET", "POST"] }
+}
+```

--- a/plugins/artifact-manager/index.ts
+++ b/plugins/artifact-manager/index.ts
@@ -1,0 +1,133 @@
+/**
+ * artifact-manager — TS plugin for task artifact lifecycle.
+ *
+ * Drop this in ~/.oracle/commands/ or install via `maw plugins install`.
+ * No WASM, no compilation — pure TypeScript, full access to maw-js internals.
+ *
+ * Usage:
+ *   maw art ls [team]                    # list artifacts
+ *   maw art get <team> <task-id>         # show full artifact
+ *   maw art write <team> <task-id> <msg> # write result
+ *   maw art attach <team> <task-id> <file> # add attachment
+ *   maw art init <team> <task-id> <subject> <desc> # create manually
+ */
+
+import {
+  createArtifact,
+  updateArtifact,
+  writeResult,
+  addAttachment,
+  listArtifacts,
+  getArtifact,
+  artifactDir,
+} from "../../../lib/artifacts";
+import { readFileSync } from "fs";
+import { basename } from "path";
+
+export const command = {
+  name: ["art", "artifact-manager"],
+  description: "Task artifact manager — ls, get, write, attach, init",
+  flags: {
+    "--json": Boolean,
+    "--team": String,
+  },
+};
+
+export default async function handler(args: string[], flags: Record<string, any>) {
+  const sub = args[0] ?? "ls";
+  const json = flags["--json"];
+
+  switch (sub) {
+    case "ls":
+    case "list": {
+      const team = args[1] ?? flags["--team"];
+      const items = listArtifacts(team);
+      if (json) { console.log(JSON.stringify(items, null, 2)); return; }
+      if (items.length === 0) { console.log("No artifacts."); return; }
+
+      const w = { team: 16, id: 6, status: 12, owner: 14, files: 6, result: 8 };
+      console.log(
+        col("TEAM", w.team) + col("ID", w.id) + col("STATUS", w.status) +
+        col("OWNER", w.owner) + col("FILES", w.files) + col("RESULT", w.result) + "SUBJECT",
+      );
+      console.log("─".repeat(80));
+      for (const a of items) {
+        const st = a.status === "completed" ? "\x1b[32m✓\x1b[0m done" :
+                   a.status === "in_progress" ? "\x1b[33m⚡\x1b[0m wip" : "pending";
+        const res = a.hasResult ? "\x1b[32myes\x1b[0m" : "\x1b[90m—\x1b[0m";
+        console.log(
+          col(a.team, w.team) + col(a.taskId, w.id) + col(st, w.status) +
+          col(a.owner ?? "—", w.owner) + col(String(a.files), w.files) +
+          col(res, w.result) + a.subject.slice(0, 36),
+        );
+      }
+      break;
+    }
+
+    case "get":
+    case "show": {
+      const [, team, taskId] = args;
+      if (!team || !taskId) { console.error("usage: maw art get <team> <task-id>"); return; }
+      const art = getArtifact(team, taskId);
+      if (!art) { console.error(`not found: ${team}/${taskId}`); return; }
+      if (json) { console.log(JSON.stringify(art, null, 2)); return; }
+
+      console.log(`\x1b[1m${art.meta.subject}\x1b[0m`);
+      console.log(`${art.meta.team}/${art.meta.taskId} · ${art.meta.status} · ${art.meta.owner ?? "unowned"}`);
+      if (art.meta.commitHash) console.log(`commit: ${art.meta.commitHash}`);
+      console.log("");
+      console.log("\x1b[36m─── spec ───\x1b[0m");
+      console.log(art.spec.trim().slice(0, 500));
+      if (art.result) {
+        console.log("\n\x1b[32m─── result ───\x1b[0m");
+        console.log(art.result.trim().slice(0, 1000));
+      }
+      if (art.attachments.length) {
+        console.log(`\n\x1b[33m─── attachments (${art.attachments.length}) ───\x1b[0m`);
+        art.attachments.forEach(a => console.log(`  📎 ${a}`));
+      }
+      console.log(`\n\x1b[90m${art.dir}\x1b[0m`);
+      break;
+    }
+
+    case "write": {
+      const [, team, taskId, ...rest] = args;
+      if (!team || !taskId || rest.length === 0) {
+        console.error("usage: maw art write <team> <task-id> <message...>");
+        return;
+      }
+      writeResult(team, taskId, rest.join(" "));
+      console.log(`\x1b[32m✓\x1b[0m result written → ${artifactDir(team, taskId)}/result.md`);
+      break;
+    }
+
+    case "attach": {
+      const [, team, taskId, filePath] = args;
+      if (!team || !taskId || !filePath) {
+        console.error("usage: maw art attach <team> <task-id> <file-path>");
+        return;
+      }
+      const data = readFileSync(filePath);
+      const dest = addAttachment(team, taskId, basename(filePath), data);
+      console.log(`\x1b[32m✓\x1b[0m attached → ${dest}`);
+      break;
+    }
+
+    case "init":
+    case "create": {
+      const [, team, taskId, subject, ...descParts] = args;
+      if (!team || !taskId || !subject) {
+        console.error("usage: maw art init <team> <task-id> <subject> [description...]");
+        return;
+      }
+      const dir = createArtifact(team, taskId, subject, descParts.join(" ") || subject);
+      console.log(`\x1b[32m✓\x1b[0m artifact created → ${dir}`);
+      break;
+    }
+
+    default:
+      console.error("usage: maw art [ls|get|write|attach|init] [--json]");
+  }
+}
+
+function col(s: string, n: number): string { return s.padEnd(n); }

--- a/plugins/artifact-manager/plugin.json
+++ b/plugins/artifact-manager/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "artifact-manager",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Task artifact lifecycle — ls, get, write, attach, init. Pure TypeScript, no WASM.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "art",
+    "help": "maw art [ls|get|write|attach|init] — task artifact manager"
+  },
+  "api": {
+    "path": "/api/plugins/artifact-manager",
+    "methods": [
+      "GET",
+      "POST"
+    ]
+  },
+  "weight": 50
+}

--- a/plugins/avengers/avengers.test.ts
+++ b/plugins/avengers/avengers.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "bun:test";
+import type { InvokeContext } from "../../../plugin/types";
+import handler, { command } from "./index";
+
+describe("avengers plugin — smoke", () => {
+  it("exports command metadata", () => {
+    expect(command.name).toBe("avengers");
+    expect(command.description).toBeTruthy();
+  });
+
+  it("CLI — --help returns ok and writes usage via writer", async () => {
+    const writes: string[] = [];
+    const ctx: InvokeContext = {
+      source: "cli",
+      args: ["--help"],
+      writer: (...a: unknown[]) => { writes.push(a.map(String).join(" ")); },
+    };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(writes.join("\n")).toContain("usage:");
+    expect(writes.join("\n")).toContain("maw avengers");
+  });
+
+  it("CLI — -h short flag also returns ok via writer", async () => {
+    const writes: string[] = [];
+    const ctx: InvokeContext = {
+      source: "cli",
+      args: ["-h"],
+      writer: (...a: unknown[]) => { writes.push(a.map(String).join(" ")); },
+    };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(writes.join("\n")).toContain("usage:");
+  });
+
+  it("CLI — --help without writer still returns ok (prints to stdout)", async () => {
+    // The --help branch early-returns before logs[] capture, so stdout is used
+    // when no writer is provided. Smoke: handler should not throw + returns ok.
+    const ctx: InvokeContext = { source: "cli", args: ["--help"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/plugins/avengers/impl.ts
+++ b/plugins/avengers/impl.ts
@@ -1,0 +1,101 @@
+/**
+ * maw avengers — rate limit monitor integration with ARRA-01/avengers.
+ */
+
+import { loadConfig } from "../../../config";
+
+function getAvengersUrl(): string | null {
+  return (loadConfig() as any).avengers || null;
+}
+
+export async function cmdAvengers(sub: string) {
+  const base = getAvengersUrl();
+
+  if (!base) {
+    throw new Error(`Avengers not configured. Add to maw.config.json:\n  "avengers": "http://white.local:8090"`);
+  }
+
+  if (sub === "status" || sub === "all") {
+    await showStatus(base);
+  } else if (sub === "best") {
+    await showBest(base);
+  } else if (sub === "traffic") {
+    await showTraffic(base);
+  } else if (sub === "health") {
+    await showHealth(base);
+  } else {
+    console.log(`\x1b[36mmaw avengers\x1b[0m — ARRA-01 rate limit monitor\n`);
+    console.log(`  maw avengers status    All accounts + rate limits`);
+    console.log(`  maw avengers best      Account with most capacity`);
+    console.log(`  maw avengers traffic   Traffic stats`);
+    console.log(`  maw avengers health    Quick connectivity check\n`);
+  }
+}
+
+async function showStatus(base: string) {
+  try {
+    const res = await fetch(`${base}/all`, { signal: AbortSignal.timeout(5000) });
+    const accounts = await res.json();
+
+    console.log(`\n\x1b[36;1mAvengers Status\x1b[0m  \x1b[90m${base}\x1b[0m\n`);
+
+    if (Array.isArray(accounts)) {
+      for (const acc of accounts) {
+        const name = acc.name || acc.email || acc.id || "?";
+        const remaining = acc.remaining ?? acc.requests_remaining ?? "?";
+        const limit = acc.limit ?? acc.requests_limit ?? "?";
+        const pct = typeof remaining === "number" && typeof limit === "number" && limit > 0
+          ? Math.round((remaining / limit) * 100) : null;
+        const color = pct !== null ? (pct > 50 ? "\x1b[32m" : pct > 20 ? "\x1b[33m" : "\x1b[31m") : "\x1b[37m";
+        const bar = pct !== null ? `${color}${remaining}/${limit} (${pct}%)\x1b[0m` : `${remaining}`;
+        console.log(`  ${color}●\x1b[0m  ${String(name).padEnd(30)}  ${bar}`);
+      }
+    } else {
+      console.log(JSON.stringify(accounts, null, 2));
+    }
+    console.log();
+  } catch (err: any) {
+    console.error(`\x1b[31merror\x1b[0m: avengers unreachable at ${base}: ${err.message}`);
+  }
+}
+
+async function showBest(base: string) {
+  try {
+    const res = await fetch(`${base}/best`, { signal: AbortSignal.timeout(5000) });
+    const best = await res.json();
+    console.log(`\n\x1b[36;1mBest Account\x1b[0m\n`);
+    console.log(`  ${JSON.stringify(best, null, 2)}`);
+    console.log();
+  } catch (err: any) {
+    console.error(`\x1b[31merror\x1b[0m: ${err.message}`);
+  }
+}
+
+async function showTraffic(base: string) {
+  try {
+    const res = await fetch(`${base}/traffic-stats`, { signal: AbortSignal.timeout(5000) });
+    const traffic = await res.json();
+    console.log(`\n\x1b[36;1mTraffic Stats\x1b[0m\n`);
+    console.log(JSON.stringify(traffic, null, 2));
+    console.log();
+  } catch (err: any) {
+    console.error(`\x1b[31merror\x1b[0m: ${err.message}`);
+  }
+}
+
+async function showHealth(base: string) {
+  const start = Date.now();
+  try {
+    const res = await fetch(`${base}/all`, { signal: AbortSignal.timeout(3000) });
+    const latency = Date.now() - start;
+    const accounts = await res.json();
+    const count = Array.isArray(accounts) ? accounts.length : 0;
+
+    console.log(`\n\x1b[32m●\x1b[0m  Avengers \x1b[32monline\x1b[0m  \x1b[90m${latency}ms · ${count} account${count !== 1 ? "s" : ""}\x1b[0m`);
+    console.log(`   \x1b[90m${base}\x1b[0m\n`);
+  } catch {
+    const latency = Date.now() - start;
+    console.log(`\n\x1b[31m●\x1b[0m  Avengers \x1b[31moffline\x1b[0m  \x1b[90m${latency}ms\x1b[0m`);
+    console.log(`   \x1b[90m${base}\x1b[0m\n`);
+  }
+}

--- a/plugins/avengers/index.ts
+++ b/plugins/avengers/index.ts
@@ -1,0 +1,49 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "avengers",
+  description: "Manage the Avengers multi-agent team.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { cmdAvengers } = await import("./impl");
+
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+  // Handle --help before monkey-patching so output always reaches stdout
+  if (args[0] === "--help" || args[0] === "-h") {
+    const help = [
+      "usage: maw avengers [status|best|traffic|health] — ARRA-01 rate limit monitor",
+      "",
+      "  maw avengers status    All accounts + rate limits",
+      "  maw avengers best      Account with most capacity",
+      "  maw avengers traffic   Traffic stats",
+      "  maw avengers health    Quick connectivity check",
+    ].join("\n");
+    if (ctx.writer) ctx.writer(help);
+    else console.log(help);
+    return { ok: true };
+  }
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    await cmdAvengers(args[0] || "status");
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/avengers/plugin.json
+++ b/plugins/avengers/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "avengers",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Manage the Avengers multi-agent team.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "avengers",
+    "aliases": [
+      "avg"
+    ],
+    "help": "maw avengers [status|assemble|disband] — Manage the Avengers multi-agent team"
+  },
+  "weight": 50
+}

--- a/plugins/bud/bud-init.ts
+++ b/plugins/bud/bud-init.ts
@@ -1,0 +1,129 @@
+import { join } from "path";
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
+import { loadFleetEntries } from "../../shared/fleet-load";
+import { FLEET_DIR } from "../../../sdk";
+
+/** Step 2: Create ψ/ vault directory structure. Returns the psiDir path. */
+export function initVault(budRepoPath: string): string {
+  const psiDir = join(budRepoPath, "ψ");
+  const psiDirs = [
+    "memory/learnings", "memory/retrospectives", "memory/traces",
+    "memory/resonance", "memory/collaborations", "inbox", "outbox", "plans",
+  ];
+  for (const d of psiDirs) {
+    mkdirSync(join(psiDir, d), { recursive: true });
+  }
+  console.log(`  \x1b[32m✓\x1b[0m ψ/ vault initialized`);
+  return psiDir;
+}
+
+/** Step 3: Generate CLAUDE.md stub with identity + Rule 6 template. */
+export function generateClaudeMd(budRepoPath: string, name: string, parentName: string | null): void {
+  const claudeMd = join(budRepoPath, "CLAUDE.md");
+  if (existsSync(claudeMd)) return;
+  const now = new Date().toISOString().slice(0, 10);
+  const lineageHeader = parentName
+    ? `> Budded from **${parentName}** on ${now}`
+    : `> Root oracle — born ${now} (no parent lineage)`;
+  const lineageField = parentName
+    ? `- **Budded from**: ${parentName}`
+    : `- **Origin**: root (no parent)`;
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  writeFileSync(claudeMd, `# ${name}-oracle
+
+${lineageHeader}
+
+## Identity
+- **Name**: ${name}
+- **Purpose**: (to be defined by /awaken)
+${lineageField}
+- **Federation tag**: \`[<host>:${name}]\` — replace \`<host>\` with your runtime host
+  (e.g. \`mba\`, \`oracle-world\`, \`white\`, \`clinic-nat\`) when signing federation messages
+
+## Principles (inherited from Oracle)
+1. Nothing is Deleted
+2. Patterns Over Intentions
+3. External Brain, Not Command
+4. Curiosity Creates Existence
+5. Form and Formless
+
+## Rule 6: Oracle Never Pretends to Be Human
+
+The convention has THREE complementary signature contexts. Use the right one for the audience:
+
+### 1. Internal federation messages (\`maw hey\`, \`maw broadcast\`)
+
+Form: \`[<host>:${name}]\` — for example \`[mba:${name}]\` or \`[oracle-world:${name}]\`
+
+- ALWAYS use the host:agent form, NEVER bare \`[${name}]\`
+- The host context disambiguates when the same oracle name has multiple bodies on different hosts
+- Established 2026-04-07 (Phase 5 of the convention)
+
+### 2. Public-facing artifacts (GitHub issues/PRs, forums, blog comments, Slack)
+
+Form: \`🤖 ตอบโดย ${name} จาก [Human] → ${name}-oracle\`
+
+- "ตอบโดย" = "answered by", "จาก" = "from"
+- The 🤖 emoji + Oracle name + Human creator + source repo
+- Established 2026-01-25 (Phase 2 of the convention)
+- Thai principle: *"กระจกไม่แกล้งเป็นคน"* — a mirror doesn't pretend to be a person
+
+### 3. Git commit trailers
+
+Form: \`Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\`
+
+- Standard Anthropic attribution
+- Add to the commit trailer when ${name} authors the commit
+
+Run \`/awaken\` for the full identity setup ceremony.
+`);
+  console.log(`  \x1b[32m✓\x1b[0m CLAUDE.md generated`);
+}
+
+/** Step 4: Create or update fleet config. Returns the fleet file path. */
+export function configureFleet(name: string, org: string, budRepoName: string, parentName: string | null): string {
+  // #202 — idempotent, always writes lineage
+  const entries = loadFleetEntries();
+  const existing = entries.find(e => e.session.name.replace(/^\d+-/, "") === name);
+  let fleetFile: string;
+
+  if (existing) {
+    fleetFile = join(FLEET_DIR, existing.file);
+    const cfg = JSON.parse(readFileSync(fleetFile, "utf-8"));
+    let updated = false;
+    if (!cfg.budded_from && parentName) { cfg.budded_from = parentName; updated = true; }
+    if (!cfg.budded_at && parentName) { cfg.budded_at = new Date().toISOString(); updated = true; }
+    if (updated) {
+      writeFileSync(fleetFile, JSON.stringify(cfg, null, 2) + "\n");
+      console.log(`  \x1b[32m✓\x1b[0m fleet config updated with lineage: ${fleetFile}`);
+    } else {
+      console.log(`  \x1b[90m○\x1b[0m fleet config exists: ${fleetFile}`);
+    }
+  } else {
+    const maxNum = entries.reduce((max, e) => Math.max(max, e.num), 0);
+    const budNum = maxNum + 1;
+    fleetFile = join(FLEET_DIR, `${String(budNum).padStart(2, "0")}-${name}.json`);
+    const fleetConfig: Record<string, unknown> = {
+      name: `${String(budNum).padStart(2, "0")}-${name}`,
+      windows: [{ name: `${name}-oracle`, repo: `${org}/${budRepoName}` }],
+      sync_peers: parentName ? [parentName] : [],
+    };
+    if (parentName) {
+      fleetConfig.budded_from = parentName;
+      fleetConfig.budded_at = new Date().toISOString();
+    }
+    writeFileSync(fleetFile, JSON.stringify(fleetConfig, null, 2) + "\n");
+    console.log(`  \x1b[32m✓\x1b[0m fleet config: ${fleetFile}`);
+  }
+  return fleetFile;
+}
+
+/** Step 4.5: Write birth note to ψ/memory/learnings/ if a note was provided. */
+export function writeBirthNote(psiDir: string, name: string, parentName: string | null, note: string): void {
+  const birthFrom = parentName ? `Budded from: ${parentName}` : "Root oracle — no parent";
+  writeFileSync(
+    join(psiDir, "memory", "learnings", `${new Date().toISOString().slice(0, 10)}_birth-note.md`),
+    `---\npattern: Birth note${parentName ? ` from ${parentName}` : ""}\ndate: ${new Date().toISOString().slice(0, 10)}\nsource: maw bud\n---\n\n# Why ${name} was born\n\n${note}\n\n${birthFrom}\n`
+  );
+  console.log(`  \x1b[32m✓\x1b[0m birth note written`);
+}

--- a/plugins/bud/bud-repo.test.ts
+++ b/plugins/bud/bud-repo.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Regression for #630 — config.ghqRoot can drift from the real `ghq root`
+// (e.g. stale override: "/tmp/nope"). When that happens, ensureBudRepo must
+// trust ghq's landing dir, not the predicted path.
+
+type ExecCall = string;
+const execCalls: ExecCall[] = [];
+// Sequential return values for successive `ghq list` calls.
+let ghqListQueue: string[] = [];
+
+mock.module("../../../sdk", () => ({
+  hostExec: async (cmd: string) => {
+    execCalls.push(cmd);
+    if (cmd.startsWith("ghq list")) return ghqListQueue.shift() ?? "";
+    if (cmd.startsWith("gh repo view")) return ""; // triggers create path
+    if (cmd.startsWith("gh repo create")) return "";
+    if (cmd.startsWith("ghq get")) return "";
+    return "";
+  },
+}));
+
+describe("ensureBudRepo (#630)", () => {
+  beforeEach(() => {
+    execCalls.length = 0;
+    ghqListQueue = [];
+  });
+
+  it("returns ghq's actual clone path when it diverges from predicted", async () => {
+    const actualClone = mkdtempSync(join(tmpdir(), "maw-bud-real-clone-"));
+    // First ghq list = pre-clone check (empty), second = post-clone resolve.
+    ghqListQueue = ["", actualClone + "\n"];
+
+    const { ensureBudRepo } = await import("./bud-repo");
+    const predicted = "/tmp/nope/Soul-Brews-Studio/widget-oracle";
+
+    try {
+      const resolved = await ensureBudRepo(
+        "Soul-Brews-Studio/widget-oracle",
+        predicted,
+        "widget-oracle",
+        "Soul-Brews-Studio",
+      );
+
+      expect(resolved).toBe(actualClone);
+      expect(resolved).not.toBe(predicted);
+      expect(execCalls.some(c => c.startsWith("ghq get github.com/Soul-Brews-Studio/widget-oracle"))).toBe(true);
+      expect(execCalls.some(c => c.includes("ghq list --exact --full-path"))).toBe(true);
+    } finally {
+      rmSync(actualClone, { recursive: true, force: true });
+    }
+  });
+
+  it("throws if ghq list cannot find the repo after ghq get", async () => {
+    ghqListQueue = ["", ""]; // pre-check empty, post-clone also empty
+    const { ensureBudRepo } = await import("./bud-repo");
+
+    await expect(
+      ensureBudRepo(
+        "Soul-Brews-Studio/ghost-oracle",
+        "/tmp/nope/Soul-Brews-Studio/ghost-oracle",
+        "ghost-oracle",
+        "Soul-Brews-Studio",
+      ),
+    ).rejects.toThrow(/ghq get succeeded but ghq list cannot find/);
+  });
+
+  it("short-circuits when repo is already cloned (via ghq) at a non-predicted path", async () => {
+    const preExisting = mkdtempSync(join(tmpdir(), "maw-bud-pre-clone-"));
+    ghqListQueue = [preExisting + "\n"];
+    const { ensureBudRepo } = await import("./bud-repo");
+
+    try {
+      const resolved = await ensureBudRepo(
+        "Soul-Brews-Studio/existing-oracle",
+        "/tmp/nope/Soul-Brews-Studio/existing-oracle",
+        "existing-oracle",
+        "Soul-Brews-Studio",
+      );
+
+      expect(resolved).toBe(preExisting);
+      // No gh/ghq-get should run when a pre-existing clone is found
+      expect(execCalls.some(c => c.startsWith("gh repo create"))).toBe(false);
+      expect(execCalls.some(c => c.startsWith("ghq get"))).toBe(false);
+    } finally {
+      rmSync(preExisting, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/bud/bud-repo.ts
+++ b/plugins/bud/bud-repo.ts
@@ -1,0 +1,84 @@
+import { hostExec } from "../../../sdk";
+import { existsSync } from "fs";
+
+/**
+ * Ask ghq where it parked a repo. Authoritative over `config.ghqRoot` —
+ * which can drift (stale overrides, cross-host config sync). #630
+ */
+async function resolveGhqPath(slug: string): Promise<string | null> {
+  try {
+    const out = await hostExec(`ghq list --exact --full-path github.com/${slug}`);
+    const first = out.split("\n").map(s => s.trim()).find(Boolean);
+    return first && existsSync(first) ? first : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Step 1: Ensure the oracle's GitHub repo exists and is cloned locally.
+ * Idempotent — skips creation/clone if already present.
+ *
+ * Returns the ACTUAL clone path reported by ghq, not the predicted
+ * `budRepoPath`. The two diverge when `config.ghqRoot` is stale or
+ * overridden (#630) — ghq always honors its own `ghq root`, so trust it.
+ */
+export async function ensureBudRepo(
+  budRepoSlug: string,
+  budRepoPath: string,
+  budRepoName: string,
+  org: string,
+): Promise<string> {
+  if (existsSync(budRepoPath)) {
+    console.log(`  \x1b[90m○\x1b[0m repo already exists: ${budRepoPath}`);
+    return budRepoPath;
+  }
+  // Pre-check ghq in case the repo is already cloned but at a different path
+  // than config.ghqRoot predicts — avoid re-creating on GitHub.
+  const preExisting = await resolveGhqPath(budRepoSlug);
+  if (preExisting) {
+    console.log(`  \x1b[90m○\x1b[0m repo already cloned (via ghq): ${preExisting}`);
+    return preExisting;
+  }
+  console.log(`  \x1b[36m⏳\x1b[0m creating repo: ${budRepoSlug}...`);
+  try {
+    // Pre-check: if repo already exists on GitHub, skip creation
+    const viewCheck = await hostExec(`gh repo view ${budRepoSlug} --json name 2>/dev/null`).catch(() => "");
+    if (viewCheck.includes(budRepoName)) {
+      console.log(`  \x1b[90m○\x1b[0m repo already exists on GitHub`);
+    } else {
+      await hostExec(`gh repo create ${budRepoSlug} --private --add-readme`);
+      console.log(`  \x1b[32m✓\x1b[0m repo created on GitHub`);
+    }
+  } catch (e: any) {
+    if (e.message?.includes("already exists")) {
+      console.log(`  \x1b[90m○\x1b[0m repo already exists on GitHub`);
+    } else if (e.message?.includes("403") || e.message?.includes("admin")) {
+      throw new Error(
+        `no permission to create repos in ${org} — ask an org admin to create ${budRepoSlug} first, then re-run maw bud`,
+      );
+    } else {
+      throw e;
+    }
+  }
+  await hostExec(`ghq get github.com/${budRepoSlug}`);
+  // #630 — trust `ghq list`, not `config.ghqRoot`. The config value can be
+  // stale or overridden (observed: ghqRoot="/tmp/nope" while real ghq root was
+  // /home/neo/Code), which stranded the bud mid-scaffold. Resolve the real
+  // landing path and use that for all downstream ψ/ + fleet + wake steps.
+  const actualPath = await resolveGhqPath(budRepoSlug);
+  if (!actualPath) {
+    throw new Error(
+      `ghq get succeeded but ghq list cannot find github.com/${budRepoSlug}.\n` +
+      `  Check: ghq list | grep ${budRepoName}\n` +
+      `  This indicates a broken ghq install or a reroute intercepting the URL.`,
+    );
+  }
+  if (actualPath !== budRepoPath) {
+    console.log(`  \x1b[33m⚠\x1b[0m config.ghqRoot predicted ${budRepoPath}`);
+    console.log(`  \x1b[33m  but ghq parked the clone at ${actualPath}\x1b[0m`);
+    console.log(`  \x1b[90m  using ghq's location — run 'maw init --force' to refresh config\x1b[0m`);
+  }
+  console.log(`  \x1b[32m✓\x1b[0m cloned via ghq → ${actualPath}`);
+  return actualPath;
+}

--- a/plugins/bud/bud-wake.ts
+++ b/plugins/bud/bud-wake.ts
@@ -1,0 +1,142 @@
+import { hostExec } from "../../../sdk";
+import { cmdSoulSync } from "./internal/soul-sync-impl";
+import { cmdWake } from "../../shared/wake";
+import { loadFleetEntries } from "../../shared/fleet-load";
+import { FLEET_DIR } from "../../../sdk";
+import { getGhqRoot } from "../../../config/ghq-root";
+import { join } from "path";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+
+export interface BudFinalizeCtx {
+  name: string;
+  parentName: string | null;
+  org: string;
+  budRepoName: string;
+  budRepoPath: string;
+  psiDir: string;
+  fleetFile: string;
+  opts: {
+    seed?: boolean;
+    issue?: number;
+    repo?: string;
+    split?: boolean;
+    fast?: boolean;
+  };
+}
+
+/** Steps 5-8.5: soul-sync, initial commit, sync_peers update, wake, split, copy ψ/. */
+export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
+  const { name, parentName, org, budRepoName, budRepoPath, psiDir, opts } = ctx;
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  // 5. Soul-sync: consent-based model.
+  // Default: born blank — child pulls memory later via `maw soul-sync <parent> --from`.
+  // Opt-in: --seed explicitly requests bulk push from parent at birth.
+  // Legacy: --blank still accepted (no-op, birth is already blank by default).
+  if (opts.seed && parentName) {
+    console.log(`  \x1b[36m⏳\x1b[0m --seed: bulk soul-sync from ${parentName}...`);
+    try {
+      await cmdSoulSync(parentName, { from: true, cwd: budRepoPath });
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m soul-sync seed failed (parent may have empty ψ/)`);
+    }
+  } else if (parentName) {
+    console.log(`  \x1b[90m○\x1b[0m born blank — pull memory when ready: maw soul-sync ${parentName} --from`);
+  } else {
+    console.log(`  \x1b[90m○\x1b[0m root oracle — no parent`);
+  }
+
+  // 6. Initial git commit + push
+  try {
+    await hostExec(`git -C '${budRepoPath}' add -A`);
+    await hostExec(`git -C '${budRepoPath}' commit -m 'feat: birth — ${parentName ? `budded from ${parentName}` : "root oracle"}'`);
+    await hostExec(`git -C '${budRepoPath}' push -u origin HEAD`);
+    console.log(`  \x1b[32m✓\x1b[0m initial commit pushed`);
+  } catch {
+    console.log(`  \x1b[33m⚠\x1b[0m git push failed (may need manual setup)`);
+  }
+
+  // 7. Update parent's sync_peers (skip for root buds)
+  if (!parentName) {
+    console.log(`  \x1b[90m○\x1b[0m root oracle — no parent sync_peers to update`);
+  }
+  for (const entry of parentName ? loadFleetEntries() : []) {
+    const entryName = entry.session.name.replace(/^\d+-/, "");
+    if (entryName === parentName) {
+      const parentFile = join(FLEET_DIR, entry.file);
+      const parentConfig = JSON.parse(readFileSync(parentFile, "utf-8"));
+      const peers: string[] = parentConfig.sync_peers || [];
+      if (!peers.includes(name)) {
+        peers.push(name);
+        parentConfig.sync_peers = peers;
+        writeFileSync(parentFile, JSON.stringify(parentConfig, null, 2) + "\n");
+        console.log(`  \x1b[32m✓\x1b[0m added ${name} to ${parentName}'s sync_peers`);
+      }
+      break;
+    }
+  }
+
+  // 8. Wake the bud
+  // #835 — consult unified shouldAutoWake helper. bud's policy is "always
+  // wake" — a freshly-cloned bud has no session yet and the whole point of
+  // bud is to spawn one. The helper makes that explicit and auditable.
+  const { shouldAutoWake } = await import("../../shared/should-auto-wake");
+  const decision = shouldAutoWake(name, { site: "bud" });
+  if (!decision.wake) {
+    // Defensive — site=bud never returns wake=false today. Preserve the
+    // future-policy escape hatch with a clear log.
+    console.log(`  \x1b[33m⚠\x1b[0m wake skipped: ${decision.reason}`);
+    return;
+  }
+  console.log(`  \x1b[36m⏳\x1b[0m waking ${name}...`);
+  // #421 — pass the exact cloned path so wake doesn't re-resolve via ghqFind,
+  // which would match any same-named repo in any org (stale-clone bug).
+  const wakeOpts: any = { noAttach: true, repoPath: budRepoPath };
+  if (opts.issue) {
+    const { fetchIssuePrompt } = await import("../../shared/wake");
+    wakeOpts.prompt = await fetchIssuePrompt(opts.issue, `${org}/${budRepoName}`);
+    wakeOpts.task = `issue-${opts.issue}`;
+  }
+  if (opts.repo) {
+    // Clone the target repo via ghq (resolve-first, no worktree).
+    // Previously set wakeOpts.incubate which auto-created a worktree — see #271.
+    const { ensureCloned } = await import("../../shared/wake-target");
+    await ensureCloned(opts.repo);
+  }
+  try {
+    await cmdWake(name, wakeOpts);
+    console.log(`  \x1b[32m✓\x1b[0m ${name} is alive`);
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m wake failed: ${e.message || e}`);
+    console.log(`  \x1b[90m  try: maw wake ${name}\x1b[0m`);
+  }
+
+  // 8.25. Optional --split: show the child in a right-side pane so parent watches it awaken.
+  // Delegates to cmdSplit — single canonical impl, so the TMUX= env-inheritance fix
+  // applies here automatically. Previously inlined the tmux shell-out which silently
+  // failed inside tmux (nested attach-session refused to nest, pane died immediately).
+  if (opts.split && process.env.TMUX) {
+    try {
+      const { cmdSplit } = await import("./internal/split-impl");
+      await cmdSplit(name);
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m split failed: ${e.message || e}`);
+    }
+  } else if (opts.split && !process.env.TMUX) {
+    console.log(`  \x1b[33m⚠\x1b[0m --split requires tmux session (TMUX env var not set)`);
+  }
+
+  // 8.5. Copy local project ψ/ if --repo was used and it exists
+  if (opts.repo) {
+    const localPsi = join(reposRoot, opts.repo, "ψ", "memory");
+    if (existsSync(localPsi)) {
+      const { syncDir } = await import("./internal/soul-sync-impl");
+      for (const sub of ["learnings", "retrospectives", "traces"]) {
+        const src = join(localPsi, sub);
+        const dst = join(psiDir, "memory", sub);
+        if (existsSync(src)) { try { syncDir(src, dst); } catch {} }
+      }
+      console.log(`  \x1b[32m✓\x1b[0m copied local project ψ/ from ${opts.repo}`);
+    }
+  }
+}

--- a/plugins/bud/bud.test.ts
+++ b/plugins/bud/bud.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, mock, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+// Capture real modules BEFORE any mock.module rewrites the cache.
+// Namespace imports are live bindings, so we copy function references into
+// locals to survive the rewrite (otherwise delegating to them would recurse
+// into the mock itself).
+import * as rawImpl from "./impl";
+import * as rawBudRepo from "./bud-repo";
+import * as rawBudWake from "./bud-wake";
+import * as rawBudInit from "./bud-init";
+import * as rawConfig from "../../../config";
+import * as rawGhqRoot from "../../../config/ghq-root";
+
+const realCmdBud = rawImpl.cmdBud;
+const realEnsureBudRepo = rawBudRepo.ensureBudRepo;
+const realFinalizeBud = rawBudWake.finalizeBud;
+const realInitVault = rawBudInit.initVault;
+const realGenerateClaudeMd = rawBudInit.generateClaudeMd;
+const realConfigureFleet = rawBudInit.configureFleet;
+const realWriteBirthNote = rawBudInit.writeBirthNote;
+const realConfigModule = { ...rawConfig };
+const realGhqRootModule = { ...rawGhqRoot };
+
+let lastOpts: any = null;
+let useReal = false;
+let budRepoPath = "";
+
+function installMocks() {
+  mock.module("../../../config", () => ({
+    ...realConfigModule,
+    loadConfig: () => ({ githubOrg: "Soul-Brews-Studio", env: {}, commands: {}, sessions: {} }),
+  }));
+  // #680 — getGhqRoot moved to leaf module config/ghq-root.
+  // The test never hits disk under ghqRoot (ensureBudRepo is fully mocked),
+  // so "/tmp/nope" is inert — just feeds the predicted-path string.
+  mock.module("../../../config/ghq-root", () => ({
+    ...realGhqRootModule,
+    getGhqRoot: () => "/tmp/nope",
+  }));
+  mock.module("./impl", () => ({
+    cmdBud: async (name: string, opts: any) => {
+      lastOpts = opts;
+      if (useReal) return realCmdBud(name, opts);
+      console.log(`budding ${name}`);
+    },
+  }));
+  mock.module("./bud-repo", () => ({
+    ensureBudRepo: async () => budRepoPath,
+  }));
+  mock.module("./bud-wake", () => ({
+    finalizeBud: async () => {},
+  }));
+  mock.module("./bud-init", () => {
+    const { mkdirSync } = require("fs");
+    const { join } = require("path");
+    return {
+      initVault: (p: string) => {
+        const psi = join(p, "ψ");
+        mkdirSync(psi, { recursive: true });
+        return psi;
+      },
+      generateClaudeMd: () => {},
+      configureFleet: () => "/tmp/fake-fleet.json",
+      writeBirthNote: () => {},
+    };
+  });
+}
+
+function restoreMocks() {
+  // Re-register the real modules — bun has no "unmock" primitive, so we
+  // install passthrough mocks that point back at the real implementations.
+  mock.module("../../../config", () => realConfigModule);
+  mock.module("../../../config/ghq-root", () => realGhqRootModule);
+  mock.module("./impl", () => ({ cmdBud: realCmdBud }));
+  mock.module("./bud-repo", () => ({ ensureBudRepo: realEnsureBudRepo }));
+  mock.module("./bud-wake", () => ({ finalizeBud: realFinalizeBud }));
+  mock.module("./bud-init", () => ({
+    initVault: realInitVault,
+    generateClaudeMd: realGenerateClaudeMd,
+    configureFleet: realConfigureFleet,
+    writeBirthNote: realWriteBirthNote,
+  }));
+}
+
+describe("bud plugin", () => {
+  let handler: (ctx: InvokeContext) => Promise<any>;
+
+  beforeAll(() => installMocks());
+  afterAll(() => restoreMocks());
+
+  beforeEach(async () => {
+    lastOpts = null;
+    useReal = false;
+    const mod = await import("./index");
+    handler = mod.default;
+  });
+
+  it("cli: basic bud", async () => {
+    const result = await handler({ source: "cli", args: ["myoracle"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("budding myoracle");
+  });
+
+  it("cli: bud with flags", async () => {
+    const result = await handler({ source: "cli", args: ["newbud", "--from", "neo", "--dry-run"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("budding newbud");
+  });
+
+  it("cli: name starts with dash returns error", async () => {
+    const result = await handler({ source: "cli", args: ["--unknown-flag"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("looks like a flag");
+  });
+
+  it("cli: --nickname flag reaches cmdBud opts (#643 Phase 3)", async () => {
+    const result = await handler({
+      source: "cli",
+      args: ["myplugin", "--nickname", "Bloom Two", "--dry-run"],
+    });
+    expect(result.ok).toBe(true);
+    expect(lastOpts).not.toBeNull();
+    expect(lastOpts.nickname).toBe("Bloom Two");
+  });
+
+  it("api: nickname passes through", async () => {
+    const result = await handler({
+      source: "api",
+      args: { name: "myplugin", nickname: "Bloom Two", dryRun: true },
+    });
+    expect(result.ok).toBe(true);
+    expect(lastOpts.nickname).toBe("Bloom Two");
+  });
+});
+
+// ─── Integration: cmdBud --nickname writes ψ/nickname at birth (#643 Phase 3) ─
+//
+// Runs the real cmdBud (via `useReal = true`) but with repo/fleet/wake seams
+// stubbed above. Verifies the authoritative on-disk write.
+
+describe("cmdBud --nickname (#643 Phase 3)", () => {
+  let prevMawHome: string | undefined;
+  let sandbox: string;
+
+  beforeAll(() => installMocks());
+  afterAll(() => restoreMocks());
+
+  beforeEach(() => {
+    useReal = true;
+    sandbox = mkdtempSync(join(tmpdir(), "maw-bud-nickname-"));
+    budRepoPath = join(sandbox, "repo");
+    mkdirSync(budRepoPath, { recursive: true });
+    prevMawHome = process.env.MAW_HOME;
+    process.env.MAW_HOME = join(sandbox, "home");
+    mkdirSync(process.env.MAW_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    useReal = false;
+    if (prevMawHome === undefined) delete process.env.MAW_HOME;
+    else process.env.MAW_HOME = prevMawHome;
+    rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it("writes ψ/nickname when --nickname is provided", async () => {
+    await realCmdBud("myplugin", { from: "mawjs", nickname: "Bloom Two" });
+
+    const file = join(budRepoPath, "ψ", "nickname");
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, "utf-8")).toBe("Bloom Two\n");
+  });
+
+  it("does NOT write ψ/nickname when --nickname is absent", async () => {
+    await realCmdBud("plainbud", { from: "mawjs" });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
+  });
+
+  it("trims surrounding whitespace before writing", async () => {
+    await realCmdBud("trimmed", { from: "mawjs", nickname: "  Bloom  " });
+    expect(readFileSync(join(budRepoPath, "ψ", "nickname"), "utf-8")).toBe("Bloom\n");
+  });
+
+  it("rejects multi-line nickname before touching repo", async () => {
+    await expect(
+      realCmdBud("badbud", { from: "mawjs", nickname: "line1\nline2" }),
+    ).rejects.toThrow(/single line/);
+  });
+
+  it("whitespace-only nickname is a no-op (no file written)", async () => {
+    await realCmdBud("whitespace", { from: "mawjs", nickname: "   " });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
+  });
+
+  it("dry-run previews the nickname without writing", async () => {
+    await realCmdBud("previewbud", { from: "mawjs", nickname: "Bloom", dryRun: true });
+    expect(existsSync(join(budRepoPath, "ψ", "nickname"))).toBe(false);
+  });
+});

--- a/plugins/bud/from-repo-exec.ts
+++ b/plugins/bud/from-repo-exec.ts
@@ -1,0 +1,172 @@
+/**
+ * Executor for `maw bud --from-repo <local-path> --stem <stem>` (#588).
+ *
+ * Scope: LOCAL-PATH only. URL clone / --pr / --force / fleet wiring deferred.
+ *
+ * Design: docs/bud/from-repo-design.md, docs/bud/from-repo-impl.md
+ *
+ * Write order is fail-before-mutate:
+ *   1. ψ/ dir tree
+ *   2. .claude/settings.local.json (if absent)
+ *   3. CLAUDE.md (append under marker if exists; full write if absent)
+ *
+ * No rollback on mid-run failure — partial state is preserved so the caller
+ * can inspect it. See `docs/bud/from-repo-impl.md` section (b).
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { FromRepoOpts, InjectionPlan } from "./types";
+
+/** Matches the dir list in planFromRepoInjection — same 8 subpaths. */
+const PSI_SUBDIRS = [
+  "memory/learnings",
+  "memory/retrospectives",
+  "memory/traces",
+  "memory/resonance",
+  "memory/collaborations",
+  "inbox",
+  "outbox",
+  "plans",
+];
+
+/** HTML-comment fence prefix. Scoped by stem so re-seed under a different stem still appends. */
+export function oracleMarkerBegin(stem: string): string {
+  return `<!-- oracle-scaffold: begin stem=${stem} -->`;
+}
+export function oracleMarkerEnd(stem: string): string {
+  return `<!-- oracle-scaffold: end stem=${stem} -->`;
+}
+
+/** Full CLAUDE.md template — used when target repo has no CLAUDE.md. */
+function fullClaudeMd(stem: string, today: string, parent?: string): string {
+  const lineageHeader = parent
+    ? `> Budded from **${parent}** on ${today} via \`maw bud --from-repo\``
+    : `> Oracle scaffolding injected on ${today} via \`maw bud --from-repo\``;
+  const originLine = parent
+    ? `- **Budded from**: ${parent}\n<!-- oracle-lineage: parent=${parent} -->`
+    : `- **Origin**: injected into existing repo (not budded from a parent)`;
+  return `# ${stem}-oracle
+
+${lineageHeader}
+
+## Identity
+- **Name**: ${stem}
+- **Purpose**: (to be defined by /awaken)
+${originLine}
+
+## Principles (inherited from Oracle)
+1. Nothing is Deleted
+2. Patterns Over Intentions
+3. External Brain, Not Command
+4. Curiosity Creates Existence
+5. Form and Formless
+
+## Rule 6: Oracle Never Pretends to Be Human
+
+Run \`/awaken\` for the full identity setup ceremony.
+`;
+}
+
+/** The appended block — fenced with markers so re-runs are idempotent. */
+function appendBlock(stem: string, today: string, parent?: string): string {
+  const lineageBullet = parent
+    ? `\n- **Budded from**: ${parent}\n<!-- oracle-lineage: parent=${parent} -->`
+    : "";
+  return `\n${oracleMarkerBegin(stem)}
+## Oracle scaffolding
+
+> Budded into this repo on ${today} via \`maw bud --from-repo --stem ${stem}\`
+
+- **Oracle stem**: ${stem}${lineageBullet}
+- **Rule 6**: Oracle Never Pretends to Be Human — sign federation messages as \`[<host>:${stem}]\`
+- Run \`/awaken\` for the full identity setup ceremony.
+${oracleMarkerEnd(stem)}
+`;
+}
+
+/** Report one line per action. Caller passes a logger (defaults to console.log). */
+type Log = (msg: string) => void;
+const defaultLog: Log = (m) => console.log(m);
+
+/** mkdir ψ/ tree. Recursive + idempotent. */
+function writeVault(target: string, log: Log): void {
+  const psiDir = join(target, "ψ");
+  for (const d of PSI_SUBDIRS) {
+    mkdirSync(join(psiDir, d), { recursive: true });
+  }
+  log(`  \x1b[32m✓\x1b[0m ψ/ vault initialized (${PSI_SUBDIRS.length} dirs)`);
+}
+
+/** Write .claude/settings.local.json only if absent. */
+function writeSettings(target: string, log: Log): void {
+  const claudeDir = join(target, ".claude");
+  const settings = join(claudeDir, "settings.local.json");
+  if (existsSync(settings)) {
+    log(`  \x1b[90m○\x1b[0m .claude/settings.local.json exists — untouched`);
+    return;
+  }
+  mkdirSync(claudeDir, { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  writeFileSync(settings, "{}\n");
+  log(`  \x1b[32m✓\x1b[0m .claude/settings.local.json written`);
+}
+
+/** Write or append CLAUDE.md. Idempotent via HTML-comment marker. */
+function writeClaudeMd(target: string, stem: string, today: string, log: Log, parent?: string): void {
+  const claudePath = join(target, "CLAUDE.md");
+  if (!existsSync(claudePath)) {
+    // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+    writeFileSync(claudePath, fullClaudeMd(stem, today, parent));
+    log(`  \x1b[32m✓\x1b[0m CLAUDE.md written (full template)${parent ? ` — lineage: ${parent}` : ""}`);
+    return;
+  }
+  const existing = readFileSync(claudePath, "utf-8");
+  if (existing.includes(oracleMarkerBegin(stem))) {
+    log(`  \x1b[90m○\x1b[0m CLAUDE.md already has oracle block for stem=${stem} — skip`);
+    return;
+  }
+  const sep = existing.endsWith("\n") ? "" : "\n";
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  writeFileSync(claudePath, existing + sep + appendBlock(stem, today, parent));
+  log(`  \x1b[32m✓\x1b[0m CLAUDE.md appended oracle-scaffold block for stem=${stem}${parent ? ` — lineage: ${parent}` : ""}`);
+}
+
+/**
+ * Append `ψ/` to .gitignore unless --track-vault. Idempotent — skip if any
+ * non-comment line already matches `^ψ/?$`.
+ */
+function writeGitignore(target: string, log: Log): void {
+  const path = join(target, ".gitignore");
+  const existing = existsSync(path) ? readFileSync(path, "utf-8") : "";
+  const lines = existing.split("\n").map(l => l.trim());
+  if (lines.some(l => l === "ψ" || l === "ψ/")) {
+    log(`  \x1b[90m○\x1b[0m .gitignore already ignores ψ/ — skip`);
+    return;
+  }
+  const sep = existing.length === 0 || existing.endsWith("\n") ? "" : "\n";
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  writeFileSync(path, existing + sep + "ψ/\n");
+  log(`  \x1b[32m✓\x1b[0m .gitignore now ignores ψ/ (pass --track-vault to keep tracked)`);
+}
+
+/**
+ * Apply the injection plan. Throws on blockers; writes otherwise.
+ * Safe to call on clean or partially-injected repos (idempotent on CLAUDE.md).
+ */
+export async function applyFromRepoInjection(
+  plan: InjectionPlan,
+  opts: FromRepoOpts,
+  log: Log = defaultLog,
+): Promise<void> {
+  if (plan.blockers.length > 0) {
+    throw new Error(`cannot apply — plan has ${plan.blockers.length} blocker(s): ${plan.blockers.join("; ")}`);
+  }
+  const today = new Date().toISOString().slice(0, 10);
+  log(`\n  \x1b[36m🌱 injecting oracle scaffolding\x1b[0m — ${opts.stem} → ${plan.target}\n`);
+  writeVault(plan.target, log);
+  writeSettings(plan.target, log);
+  writeClaudeMd(plan.target, opts.stem, today, log, opts.from);
+  if (!opts.trackVault) writeGitignore(plan.target, log);
+  log(`\n  \x1b[32m✓ done\x1b[0m — run \`maw wake ${opts.stem}\` to start a session\n`);
+}

--- a/plugins/bud/from-repo-fleet.test.ts
+++ b/plugins/bud/from-repo-fleet.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { parseRemoteUrl, readOriginRemote, resolveSlug } from "./from-repo-fleet";
+
+function mkGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-fleet-test-"));
+  mkdirSync(join(dir, ".git"));
+  return dir;
+}
+
+describe("from-repo-fleet: parseRemoteUrl", () => {
+  it("parses git@github.com:org/repo.git", () => {
+    expect(parseRemoteUrl("git@github.com:Soul-Brews-Studio/maw-js.git"))
+      .toEqual({ org: "Soul-Brews-Studio", repo: "maw-js" });
+  });
+
+  it("parses https URL with .git suffix", () => {
+    expect(parseRemoteUrl("https://github.com/Soul-Brews-Studio/maw-js.git"))
+      .toEqual({ org: "Soul-Brews-Studio", repo: "maw-js" });
+  });
+
+  it("parses https URL without .git suffix", () => {
+    expect(parseRemoteUrl("https://github.com/x/y"))
+      .toEqual({ org: "x", repo: "y" });
+  });
+
+  it("returns null on garbage", () => {
+    expect(parseRemoteUrl("not-a-url")).toBeNull();
+  });
+});
+
+describe("from-repo-fleet: resolveSlug", () => {
+  it("falls back to <unknown>/<basename> when no remote", () => {
+    const dir = mkGitRepo();
+    try {
+      const slug = resolveSlug(dir);
+      expect(slug.org).toBe("<unknown>");
+      expect(slug.repo).toBe(basename(dir));
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo-fleet: readOriginRemote shell-injection guard (#474)", () => {
+  // execFileSync + argv ensures shell metacharacters in `target` are treated
+  // as literal path bytes, not shell syntax. Regression guard for the
+  // js/indirect-command-line-injection sink on line 38 (pre-fix).
+  it("does not execute injected commands via target path", () => {
+    const sentinel = mkdtempSync(join(tmpdir(), "maw-inject-sentinel-"));
+    const marker = join(sentinel, "pwned");
+    try {
+      // A shell-interpreted execSync(`git -C ${target} …`) would run `touch`
+      // through $(…) substitution. With execFileSync + argv, the whole
+      // string is passed as a single -C path → git fails, marker stays absent.
+      const malicious = `/tmp/nonexistent$(touch ${marker})`;
+      const result = readOriginRemote(malicious);
+      expect(result).toBeNull();
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      rmSync(sentinel, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null for a path with no git repo (benign)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-no-git-"));
+    try {
+      expect(readOriginRemote(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/bud/from-repo-fleet.ts
+++ b/plugins/bud/from-repo-fleet.ts
@@ -1,0 +1,132 @@
+/**
+ * Fleet-entry registration for `maw bud --from-repo` (#588).
+ *
+ * Only module that touches FLEET_DIR for the from-repo flow. Tests can
+ * `mock.module("./from-repo-fleet", …)` to assert wiring without
+ * writing to ~/.config/maw/fleet/.
+ *
+ * Design: docs/bud/from-repo-impl.md section (h).
+ */
+
+import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, join } from "path";
+import { execFileSync } from "child_process";
+import { FLEET_DIR } from "../../../core/paths";
+
+/** Parsed `org/repo` slug from a remote URL. */
+export interface RepoSlug {
+  org: string;
+  repo: string;
+}
+
+/**
+ * Extract `org/repo` from a git remote URL.
+ *  - `git@github.com:org/repo.git` → `{org, repo}`
+ *  - `https://github.com/org/repo(.git)?` → `{org, repo}`
+ * Returns null if the URL doesn't match a recognized shape.
+ */
+export function parseRemoteUrl(url: string): RepoSlug | null {
+  const trimmed = url.trim();
+  let m = trimmed.match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?$/);
+  if (!m) return null;
+  return { org: m[1], repo: m[2] };
+}
+
+/**
+ * Read `git -C <target> remote get-url origin`; returns null on any failure.
+ *
+ * Uses execFileSync + argv to avoid shell interpretation of `target`
+ * (js/indirect-command-line-injection, #474). Matches the pattern proven
+ * in view/impl.ts (#604) and wake.ts attachToSession.
+ */
+export function readOriginRemote(target: string): string | null {
+  try {
+    return execFileSync("git", ["-C", target, "remote", "get-url", "origin"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve org/repo for the target; falls back to `<unknown>/<basename>`. */
+export function resolveSlug(target: string): RepoSlug {
+  const url = readOriginRemote(target);
+  if (url) {
+    const parsed = parseRemoteUrl(url);
+    if (parsed) return parsed;
+  }
+  return { org: "<unknown>", repo: basename(target) };
+}
+
+/** Find the next NN prefix by scanning existing fleet entries. */
+function nextFleetNum(): number {
+  if (!existsSync(FLEET_DIR)) return 1;
+  let max = 0;
+  for (const f of readdirSync(FLEET_DIR)) {
+    if (!f.endsWith(".json") || f.endsWith(".disabled")) continue;
+    const m = f.match(/^(\d+)-/);
+    if (m) max = Math.max(max, parseInt(m[1], 10));
+  }
+  return max + 1;
+}
+
+/** Find an existing fleet file for this stem (matches `NN-<stem>.json`). */
+function findExistingForStem(stem: string): string | null {
+  if (!existsSync(FLEET_DIR)) return null;
+  for (const f of readdirSync(FLEET_DIR)) {
+    if (f.endsWith(`-${stem}.json`)) return f;
+  }
+  return null;
+}
+
+export interface RegisterFleetOpts {
+  stem: string;
+  /** Local target dir — used to read git remote for slug. */
+  target: string;
+  /** Optional parent stem — sets `budded_from` + `budded_at`. */
+  parent?: string;
+}
+
+export interface RegisterFleetResult {
+  file: string;
+  created: boolean;
+  slug: RepoSlug;
+}
+
+/**
+ * Idempotent fleet registration. If `<NN>-<stem>.json` already exists,
+ * leave it alone (and merge lineage if `--from` adds it to a previously
+ * lineage-less entry). Otherwise create a new `<NN>-<stem>.json`.
+ */
+export function registerFleetEntry(opts: RegisterFleetOpts): RegisterFleetResult {
+  const slug = resolveSlug(opts.target);
+  const existing = findExistingForStem(opts.stem);
+  if (existing) {
+    const path = join(FLEET_DIR, existing);
+    const cfg = JSON.parse(readFileSync(path, "utf-8"));
+    let updated = false;
+    if (opts.parent && !cfg.budded_from) {
+      cfg.budded_from = opts.parent;
+      cfg.budded_at = new Date().toISOString();
+      updated = true;
+    }
+    if (updated) writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+    return { file: path, created: false, slug };
+  }
+  const num = nextFleetNum();
+  const padded = String(num).padStart(2, "0");
+  const file = join(FLEET_DIR, `${padded}-${opts.stem}.json`);
+  const cfg: Record<string, unknown> = {
+    name: `${padded}-${opts.stem}`,
+    windows: [{ name: `${opts.stem}-oracle`, repo: `${slug.org}/${slug.repo}` }],
+    sync_peers: [],
+  };
+  if (opts.parent) {
+    cfg.budded_from = opts.parent;
+    cfg.budded_at = new Date().toISOString();
+  }
+  writeFileSync(file, JSON.stringify(cfg, null, 2) + "\n");
+  return { file, created: true, slug };
+}

--- a/plugins/bud/from-repo-git.ts
+++ b/plugins/bud/from-repo-git.ts
@@ -1,0 +1,87 @@
+/**
+ * Git + gh shell-outs for `maw bud --from-repo` (#588).
+ *
+ * Only module that shells out for git/gh. Kept small so tests can
+ * swap the whole module via `mock.module("./from-repo-git", …)`.
+ *
+ * Design: docs/bud/from-repo-impl.md sections (c) and (g).
+ */
+
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { hostExec } from "../../../sdk";
+
+/** Single-quote escape for bash. Safe for unknown input (URLs, paths, branches). */
+function sh(s: string): string {
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+/** Deterministic branch name for the scaffold PR. */
+export function scaffoldBranchName(stem: string): string {
+  return `oracle/scaffold-${stem}`;
+}
+
+/**
+ * `git clone --depth 1 <url> <tmpdir>` — returns the tmpdir path.
+ *
+ * On clone failure the tmpdir is removed before the error bubbles, so
+ * the caller never has to clean up a half-cloned tree.
+ */
+export async function cloneShallow(url: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "maw-bud-from-repo-"));
+  try {
+    await hostExec(`git clone --depth 1 ${sh(url)} ${sh(dir)}`);
+  } catch (e) {
+    rmSync(dir, { recursive: true, force: true });
+    throw e;
+  }
+  return dir;
+}
+
+/** Recursively `rmSync` a tmpdir. Idempotent — never throws on missing. */
+export function cleanupClone(dir: string): void {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+/** Log callback shape — mirrors from-repo-exec.ts. */
+type Log = (msg: string) => void;
+
+/**
+ * After injection: branch → add → commit → push → `gh pr create`.
+ * Returns the PR URL printed by gh.
+ *
+ * No rollback on failure: the operator owns git state. If push or
+ * `gh pr create` fails the branch stays local, fully committed; re-run
+ * after fixing the underlying cause (auth, remote, etc).
+ */
+export async function branchCommitPushPR(
+  cwd: string,
+  stem: string,
+  log: Log,
+): Promise<string> {
+  const branch = scaffoldBranchName(stem);
+  const cd = `cd ${sh(cwd)}`;
+  const msg = `oracle: scaffold from maw bud --from-repo (stem=${stem})`;
+
+  log(`  \x1b[36m⏳\x1b[0m creating branch ${branch}...`);
+  await hostExec(`${cd} && git checkout -b ${sh(branch)}`);
+  await hostExec(`${cd} && git add -A`);
+  await hostExec(`${cd} && git commit -m ${sh(msg)}`);
+  log(`  \x1b[32m✓\x1b[0m commit created on ${branch}`);
+
+  log(`  \x1b[36m⏳\x1b[0m pushing ${branch} to origin...`);
+  await hostExec(`${cd} && git push -u origin ${sh(branch)}`);
+
+  log(`  \x1b[36m⏳\x1b[0m opening PR via gh...`);
+  const out = await hostExec(`${cd} && gh pr create --fill --head ${sh(branch)}`);
+  const prUrl = extractPrUrl(out);
+  log(`  \x1b[32m✓\x1b[0m PR opened: ${prUrl}`);
+  return prUrl;
+}
+
+/** Pull the first `https://…` URL out of gh's output. Falls back to trimmed output. */
+function extractPrUrl(out: string): string {
+  const m = out.match(/https?:\/\/\S+/);
+  return m ? m[0] : out.trim();
+}

--- a/plugins/bud/from-repo-seed.ts
+++ b/plugins/bud/from-repo-seed.ts
@@ -1,0 +1,75 @@
+/**
+ * File-copy helpers for `maw bud --from-repo` (#588 final pair).
+ *
+ *   seedFromParent     — copy parent oracle's ψ/memory/ into target's ψ/memory/
+ *   copyPeersSnapshot  — snapshot host peers.json into <target>/ψ/peers.json
+ *
+ * Both are dest-biased ("Nothing is Deleted") — pre-existing target files
+ * are preserved, missing source is a logged skip (never a throw), and
+ * neither mutates `~/.maw/` or any path outside <target>.
+ *
+ * Design: docs/bud/from-repo-impl.md section (i).
+ */
+
+import { cpSync, copyFileSync, existsSync, mkdirSync, statSync } from "fs";
+import { join } from "path";
+import { loadConfig } from "../../../config";
+import { getGhqRoot } from "../../../config/ghq-root";
+import { peersPath } from "./internal/peers-store";
+
+type Log = (msg: string) => void;
+
+/** Resolve parent oracle's ψ/memory/ path via on-demand ghq root (#680). */
+export function parentMemoryPath(parentStem: string): string {
+  const cfg = loadConfig();
+  const org = cfg.githubOrg || "Soul-Brews-Studio";
+  return join(getGhqRoot(), "github.com", org, `${parentStem}-oracle`, "ψ", "memory");
+}
+
+/**
+ * Copy parent's ψ/memory/ into target's ψ/memory/.
+ *
+ * - Requires target's ψ/memory/ to already exist (writeVault runs first).
+ * - `force: false` preserves pre-existing target files ("Nothing is Deleted").
+ * - Missing parent vault is a logged skip — injection continues.
+ */
+export function seedFromParent(
+  target: string,
+  parentStem: string,
+  log: Log,
+): void {
+  const src = parentMemoryPath(parentStem);
+  if (!existsSync(src)) {
+    log(`  \x1b[33m!\x1b[0m --seed: parent ${parentStem} has no ψ/memory/ at ${src} — skip`);
+    return;
+  }
+  if (!statSync(src).isDirectory()) {
+    log(`  \x1b[33m!\x1b[0m --seed: parent ψ/memory is not a directory — skip`);
+    return;
+  }
+  const dst = join(target, "ψ", "memory");
+  mkdirSync(dst, { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  cpSync(src, dst, { recursive: true, errorOnExist: false, force: false });
+  log(`  \x1b[32m✓\x1b[0m --seed: copied parent ${parentStem}'s ψ/memory/ → ${dst}`);
+}
+
+/**
+ * Snapshot host peers.json into <target>/ψ/peers.json. Meant as a portable
+ * seed — other hosts that later clone the target can import the file.
+ *
+ * - Source: peersPath() (respects PEERS_FILE / MAW_HOME / default).
+ * - Missing source: logged skip.
+ */
+export function copyPeersSnapshot(target: string, log: Log): void {
+  const src = peersPath();
+  if (!existsSync(src)) {
+    log(`  \x1b[33m!\x1b[0m --sync-peers: no peers.json at ${src} — skip`);
+    return;
+  }
+  const dst = join(target, "ψ", "peers.json");
+  mkdirSync(join(target, "ψ"), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: scaffold dest is user-owned, see docs/security/file-system-race-stance.md
+  copyFileSync(src, dst);
+  log(`  \x1b[32m✓\x1b[0m --sync-peers: snapshot peers.json → ${dst}`);
+}

--- a/plugins/bud/from-repo.test.ts
+++ b/plugins/bud/from-repo.test.ts
@@ -1,0 +1,705 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+import { planFromRepoInjection, looksLikeUrl, cmdBudFromRepo } from "./from-repo";
+import { applyFromRepoInjection, oracleMarkerBegin } from "./from-repo-exec";
+
+// Hermetic default: stub the fleet module so the test suite never writes to
+// the real ~/.config/maw/fleet/. Individual describe blocks override as needed.
+const fleetCalls: { stem: string; target: string; parent?: string }[] = [];
+mock.module("./from-repo-fleet", () => ({
+  registerFleetEntry: (opts: { stem: string; target: string; parent?: string }) => {
+    fleetCalls.push(opts);
+    return { file: `/tmp/fake-fleet/${opts.stem}.json`, created: true, slug: { org: "fake", repo: "fake" } };
+  },
+  parseRemoteUrl: (_: string) => null,
+  resolveSlug: (_: string) => ({ org: "fake", repo: "fake" }),
+  readOriginRemote: (_: string) => null,
+}));
+
+function mkGitRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), "maw-from-repo-test-"));
+  mkdirSync(join(dir, ".git"));
+  return dir;
+}
+
+describe("from-repo: looksLikeUrl", () => {
+  it("https URL", () => expect(looksLikeUrl("https://github.com/x/y")).toBe(true));
+  it("git@ URL", () => expect(looksLikeUrl("git@github.com:x/y.git")).toBe(true));
+  it("org/repo slug", () => expect(looksLikeUrl("Soul-Brews-Studio/maw-js")).toBe(true));
+  it("absolute path", () => expect(looksLikeUrl("/home/nat/code/repo")).toBe(false));
+  it("relative path", () => expect(looksLikeUrl("./repo")).toBe(false));
+});
+
+describe("from-repo: planFromRepoInjection", () => {
+  it("plans a clean local repo (no CLAUDE.md, no ψ/)", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers).toEqual([]);
+      const kinds = plan.actions.map(a => `${a.kind}:${a.path}`);
+      expect(kinds).toContain("mkdir:ψ/memory/learnings");
+      expect(kinds).toContain("mkdir:ψ/inbox");
+      expect(kinds).toContain("write:CLAUDE.md");
+      expect(kinds).toContain("write:.claude/settings.local.json");
+      expect(kinds).toContain("append:.gitignore");
+      expect(kinds.some(k => k.startsWith("write:fleet/"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("appends (not overwrites) when CLAUDE.md already exists", () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# existing\n");
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      const claude = plan.actions.find(a => a.path === "CLAUDE.md");
+      expect(claude?.kind).toBe("append");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when ψ/ already present", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers.length).toBeGreaterThan(0);
+      expect(plan.blockers[0]).toContain("ψ/ already present");
+      expect(plan.actions).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when target is not a git repo", () => {
+    const dir = mkdtempSync(join(tmpdir(), "maw-nongit-"));
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers.some(b => b.includes("not a git repo"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("blocks when target path does not exist", () => {
+    const plan = planFromRepoInjection({
+      target: "/nonexistent/path/for-maw-test",
+      stem: "demo", isUrl: false, pr: false, dryRun: true,
+    });
+    expect(plan.blockers.some(b => b.includes("does not exist"))).toBe(true);
+  });
+
+  it("blocks URL dry-run (clone is a side-effect)", () => {
+    const plan = planFromRepoInjection({
+      target: "https://github.com/x/y", stem: "demo", isUrl: true, pr: false, dryRun: true,
+    });
+    expect(plan.blockers.some(b => b.includes("dry-run"))).toBe(true);
+  });
+});
+
+describe("from-repo: cmdBudFromRepo", () => {
+  it("dry-run on clean repo completes without throwing", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("dry-run on blocked target throws with blocker count", async () => {
+    const dir = mkGitRepo();
+    mkdirSync(join(dir, "ψ"));
+    try {
+      await expect(cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      })).rejects.toThrow(/blocker/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("non-dry-run on clean repo writes ψ/, CLAUDE.md, .claude/settings.local.json", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      expect(statSync(join(dir, "ψ", "inbox")).isDirectory()).toBe(true);
+      expect(statSync(join(dir, "ψ", "memory", "learnings")).isDirectory()).toBe(true);
+      expect(existsSync(join(dir, "CLAUDE.md"))).toBe(true);
+      expect(readFileSync(join(dir, "CLAUDE.md"), "utf-8")).toContain("demo-oracle");
+      expect(readFileSync(join(dir, ".claude", "settings.local.json"), "utf-8")).toBe("{}\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("non-dry-run refuses on collision (existing ψ/) without partial write", async () => {
+    const dir = mkGitRepo();
+    mkdirSync(join(dir, "ψ"));
+    try {
+      await expect(cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+      })).rejects.toThrow(/blocker/);
+      // CLAUDE.md not touched
+      expect(existsSync(join(dir, "CLAUDE.md"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo: applyFromRepoInjection (executor)", () => {
+  it("appends under marker when CLAUDE.md exists and preserves original content", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# host project\n\nPre-existing host content.\n");
+      const plan = planFromRepoInjection({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      await applyFromRepoInjection(plan, { target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false }, () => {});
+      const content = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(content).toContain("# host project");
+      expect(content).toContain("Pre-existing host content.");
+      expect(content).toContain(oracleMarkerBegin("demo"));
+      expect(content).toContain("Oracle scaffolding");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("idempotent re-run — second apply does not re-append CLAUDE.md", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# host\n");
+      const opts = { target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false };
+      const plan = planFromRepoInjection(opts);
+      await applyFromRepoInjection(plan, opts, () => {});
+      const firstContent = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      // Re-plan: ψ/ now exists, so planner would block — but executor alone should be idempotent on CLAUDE.md
+      const replan = { ...plan, blockers: [] }; // simulate a re-apply path (stem match → skip)
+      await applyFromRepoInjection(replan, opts, () => {});
+      const secondContent = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(secondContent).toBe(firstContent);
+      // Count markers — exactly one
+      const markerCount = (secondContent.match(new RegExp(oracleMarkerBegin("demo").replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g")) || []).length;
+      expect(markerCount).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves existing .claude/settings.local.json", async () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, ".claude"));
+      writeFileSync(join(dir, ".claude", "settings.local.json"), `{"keep":true}\n`);
+      const opts = { target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false };
+      const plan = planFromRepoInjection(opts);
+      await applyFromRepoInjection(plan, opts, () => {});
+      expect(readFileSync(join(dir, ".claude", "settings.local.json"), "utf-8")).toBe(`{"keep":true}\n`);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("throws when invoked with a blocker'd plan", async () => {
+    const opts = { target: "/nonexistent/zzz", stem: "demo", isUrl: false, pr: false, dryRun: false };
+    const plan = planFromRepoInjection(opts);
+    await expect(applyFromRepoInjection(plan, opts, () => {})).rejects.toThrow(/blocker/);
+  });
+});
+
+describe("from-repo: URL-mode + --pr (mocked git/gh)", () => {
+  let cmdBudFromRepoMocked: typeof cmdBudFromRepo;
+  let calls: { fn: string; args: any[] }[] = [];
+
+  beforeEach(async () => {
+    calls = [];
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async (url: string) => {
+        calls.push({ fn: "cloneShallow", args: [url] });
+        const d = mkGitRepo();
+        return d;
+      },
+      cleanupClone: (dir: string) => {
+        calls.push({ fn: "cleanupClone", args: [dir] });
+        rmSync(dir, { recursive: true, force: true });
+      },
+      branchCommitPushPR: async (cwd: string, stem: string, _log: any) => {
+        calls.push({ fn: "branchCommitPushPR", args: [cwd, stem] });
+        return `https://github.com/fake/pr/1`;
+      },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    cmdBudFromRepoMocked = mod.cmdBudFromRepo;
+  });
+
+  it("URL target: clones, injects, opens PR, cleans up", async () => {
+    await cmdBudFromRepoMocked({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: false,
+    });
+    const fns = calls.map(c => c.fn);
+    expect(fns).toContain("cloneShallow");
+    expect(fns).toContain("branchCommitPushPR");
+    expect(fns).toContain("cleanupClone");
+    // order: clone must precede PR, which must precede cleanup
+    expect(fns.indexOf("cloneShallow")).toBeLessThan(fns.indexOf("branchCommitPushPR"));
+    expect(fns.indexOf("branchCommitPushPR")).toBeLessThan(fns.indexOf("cleanupClone"));
+    // PR passed the stem, not the URL
+    const prCall = calls.find(c => c.fn === "branchCommitPushPR")!;
+    expect(prCall.args[1]).toBe("demo");
+  });
+
+  it("URL target dry-run throws without cloning", async () => {
+    await expect(cmdBudFromRepoMocked({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: true,
+    })).rejects.toThrow(/blocker/);
+    expect(calls.some(c => c.fn === "cloneShallow")).toBe(false);
+  });
+
+  it("URL target cleans up even when PR fails", async () => {
+    // Re-mock: branchCommitPushPR throws
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async (url: string) => {
+        calls.push({ fn: "cloneShallow", args: [url] });
+        return mkGitRepo();
+      },
+      cleanupClone: (dir: string) => {
+        calls.push({ fn: "cleanupClone", args: [dir] });
+        rmSync(dir, { recursive: true, force: true });
+      },
+      branchCommitPushPR: async () => {
+        calls.push({ fn: "branchCommitPushPR", args: [] });
+        throw new Error("gh pr create failed");
+      },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    await expect(mod.cmdBudFromRepo({
+      target: "https://github.com/fake/repo", stem: "demo",
+      isUrl: true, pr: false, dryRun: false,
+    })).rejects.toThrow(/gh pr create failed/);
+    expect(calls.some(c => c.fn === "cleanupClone")).toBe(true);
+  });
+
+  it("local path + --pr: injects then opens PR without cloning", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepoMocked({
+        target: dir, stem: "demo", isUrl: false, pr: true, dryRun: false,
+      });
+      const fns = calls.map(c => c.fn);
+      expect(fns).not.toContain("cloneShallow");
+      expect(fns).not.toContain("cleanupClone");
+      expect(fns).toContain("branchCommitPushPR");
+      // Injection actually happened
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+      // PR was opened against the local path, not a tmpdir
+      const prCall = calls.find(c => c.fn === "branchCommitPushPR")!;
+      expect(prCall.args[0]).toBe(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("local path without --pr: no PR helper called", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepoMocked({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+      });
+      expect(calls.some(c => c.fn === "branchCommitPushPR")).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("local + --pr: PR failure does NOT swallow the error", async () => {
+    mock.module("./from-repo-git", () => ({
+      scaffoldBranchName: (stem: string) => `oracle/scaffold-${stem}`,
+      cloneShallow: async () => { throw new Error("should not clone"); },
+      cleanupClone: () => {},
+      branchCommitPushPR: async () => { throw new Error("push rejected"); },
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    const mod = await import("./from-repo");
+    const dir = mkGitRepo();
+    try {
+      await expect(mod.cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: true, dryRun: false,
+      })).rejects.toThrow(/push rejected/);
+      // injection happened before PR attempt — ψ/ present
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo: handler wiring", () => {
+  let handler: (ctx: InvokeContext) => Promise<any>;
+
+  beforeEach(async () => {
+    mock.module("./impl", () => ({
+      cmdBud: async (name: string) => { console.log(`budding ${name}`); },
+    }));
+    // re-import to pick up mock
+    delete (require.cache as any)[require.resolve("./index")];
+    const mod = await import("./index");
+    handler = mod.default;
+  });
+
+  it("--from-repo without --stem returns error", async () => {
+    const result = await handler({ source: "cli", args: ["--from-repo", "/tmp/x"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("--stem");
+  });
+
+  it("--stem ending with -oracle rejected", async () => {
+    const result = await handler({
+      source: "cli",
+      args: ["--from-repo", "/tmp/x", "--stem", "foo-oracle"],
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("-oracle");
+  });
+
+  it("--from-repo --dry-run on clean local repo succeeds", async () => {
+    const dir = mkGitRepo();
+    try {
+      const result = await handler({
+        source: "cli",
+        args: ["--from-repo", dir, "--stem", "demo", "--dry-run"],
+      });
+      expect(result.ok).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo: --force / --from / --track-vault (#588 continuation)", () => {
+  it("--force lifts the ψ/ collision blocker", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true, force: true,
+      });
+      expect(plan.blockers).toEqual([]);
+      expect(plan.actions.find(a => a.path === "ψ/memory/learnings")?.kind).toBe("mkdir");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("without --force the ψ/ collision blocker mentions --force as a remedy", () => {
+    const dir = mkGitRepo();
+    try {
+      mkdirSync(join(dir, "ψ"));
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+      });
+      expect(plan.blockers[0]).toContain("--force");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--from <parent> embeds lineage marker in CLAUDE.md (full-write path)", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const claude = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(claude).toContain("Budded from");
+      expect(claude).toContain("neo");
+      expect(claude).toContain("<!-- oracle-lineage: parent=neo -->");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--from <parent> embeds lineage marker in CLAUDE.md (append path)", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, "CLAUDE.md"), "# host\n");
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const claude = readFileSync(join(dir, "CLAUDE.md"), "utf-8");
+      expect(claude).toContain("# host");
+      expect(claude).toContain("Budded from");
+      expect(claude).toContain("<!-- oracle-lineage: parent=neo -->");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("default appends `ψ/` to .gitignore (creates file if absent)", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      const gi = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(gi).toContain("ψ/");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--track-vault skips the .gitignore write", async () => {
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false, trackVault: true,
+      });
+      expect(existsSync(join(dir, ".gitignore"))).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it(".gitignore append is idempotent", async () => {
+    const dir = mkGitRepo();
+    try {
+      writeFileSync(join(dir, ".gitignore"), "node_modules/\nψ/\n");
+      await cmdBudFromRepo({ target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false });
+      const gi = readFileSync(join(dir, ".gitignore"), "utf-8");
+      expect(gi.match(/ψ\//g)?.length).toBe(1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("plan reflects --track-vault as skip:.gitignore", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true, trackVault: true,
+      });
+      const gi = plan.actions.find(a => a.path === ".gitignore");
+      expect(gi?.kind).toBe("skip");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("plan reflects --seed + --sync-peers when set", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+        from: "parent", seed: true, syncPeers: true,
+      });
+      const kinds = plan.actions.map(a => `${a.kind}:${a.path}`);
+      expect(kinds.some(k => k.includes("ψ/memory/ (seeded from parent)"))).toBe(true);
+      expect(kinds).toContain("write:ψ/peers.json");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("plan shows --seed without --from as a skip", () => {
+    const dir = mkGitRepo();
+    try {
+      const plan = planFromRepoInjection({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: true,
+        seed: true,
+      });
+      const seedAction = plan.actions.find(a => a.path === "ψ/memory/ (seed)");
+      expect(seedAction?.kind).toBe("skip");
+      expect(seedAction?.reason).toContain("--from");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("orchestrator wires registerFleetEntry with stem/target/parent", async () => {
+    const before = fleetCalls.length;
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "lineage-test", isUrl: false, pr: false, dryRun: false, from: "neo",
+      });
+      const newCalls = fleetCalls.slice(before);
+      expect(newCalls.length).toBe(1);
+      expect(newCalls[0].stem).toBe("lineage-test");
+      expect(newCalls[0].target).toBe(dir);
+      expect(newCalls[0].parent).toBe("neo");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("from-repo: --seed + --sync-peers (file-copy pair)", () => {
+  let prevPeersFile: string | undefined;
+
+  beforeEach(() => {
+    prevPeersFile = process.env.PEERS_FILE;
+  });
+
+  // --seed mocks the config barrel so parent tree resolves inside a tmp ghq root.
+  // Post #680 the bud code calls getGhqRoot() + "github.com", so the mock
+  // exports both loadConfig (for githubOrg) and a fake getGhqRoot, and fixtures
+  // live at <ghqRoot>/github.com/<org>/...
+  async function installConfigMock(ghqRoot: string) {
+    mock.module("../../../config", () => ({
+      loadConfig: () => ({ githubOrg: "Fake-Org" }),
+    }));
+    // #680 — getGhqRoot moved to leaf module config/ghq-root.
+    mock.module("../../../config/ghq-root", () => ({
+      getGhqRoot: () => ghqRoot,
+    }));
+    delete (require.cache as any)[require.resolve("./from-repo-seed")];
+    delete (require.cache as any)[require.resolve("./from-repo")];
+    return await import("./from-repo");
+  }
+
+  it("--seed copies parent's ψ/memory/ into target", async () => {
+    const ghqRoot = mkdtempSync(join(tmpdir(), "maw-ghq-"));
+    const parentMem = join(ghqRoot, "github.com", "Fake-Org", "parent-oracle", "ψ", "memory");
+    mkdirSync(join(parentMem, "learnings"), { recursive: true });
+    writeFileSync(join(parentMem, "learnings", "a.md"), "hello from parent\n");
+    writeFileSync(join(parentMem, "root.txt"), "root memory\n");
+
+    const dir = mkGitRepo();
+    try {
+      const mod = await installConfigMock(ghqRoot);
+      await mod.cmdBudFromRepo({
+        target: dir, stem: "child", isUrl: false, pr: false, dryRun: false,
+        from: "parent", seed: true,
+      });
+      expect(readFileSync(join(dir, "ψ", "memory", "learnings", "a.md"), "utf-8")).toBe("hello from parent\n");
+      expect(readFileSync(join(dir, "ψ", "memory", "root.txt"), "utf-8")).toBe("root memory\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(ghqRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("--seed is dest-biased: pre-existing target file is NOT overwritten", async () => {
+    const ghqRoot = mkdtempSync(join(tmpdir(), "maw-ghq-"));
+    const parentMem = join(ghqRoot, "github.com", "Fake-Org", "parent-oracle", "ψ", "memory");
+    mkdirSync(join(parentMem, "learnings"), { recursive: true });
+    writeFileSync(join(parentMem, "learnings", "collide.md"), "parent wins\n");
+
+    const dir = mkGitRepo();
+    try {
+      // Pre-seed the child with conflicting content (simulate prior work)
+      mkdirSync(join(dir, "ψ", "memory", "learnings"), { recursive: true });
+      writeFileSync(join(dir, "ψ", "memory", "learnings", "collide.md"), "child keeps\n");
+
+      const mod = await installConfigMock(ghqRoot);
+      await mod.cmdBudFromRepo({
+        target: dir, stem: "child", isUrl: false, pr: false, dryRun: false,
+        from: "parent", seed: true, force: true,
+      });
+      // Child's pre-existing file wins
+      expect(readFileSync(join(dir, "ψ", "memory", "learnings", "collide.md"), "utf-8")).toBe("child keeps\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(ghqRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("--seed without --from is a no-op (no parent to seed)", async () => {
+    const ghqRoot = mkdtempSync(join(tmpdir(), "maw-ghq-"));
+    const dir = mkGitRepo();
+    try {
+      const mod = await installConfigMock(ghqRoot);
+      await mod.cmdBudFromRepo({
+        target: dir, stem: "child", isUrl: false, pr: false, dryRun: false,
+        seed: true, // no from
+      });
+      // Vault exists (from normal injection) but empty — no parent memory to copy
+      expect(existsSync(join(dir, "ψ", "memory"))).toBe(true);
+      // Spot-check: no files under learnings (only dirs from writeVault)
+      // (The dir is created, just empty of files.)
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(ghqRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("--seed with missing parent vault is a logged skip (no throw)", async () => {
+    const ghqRoot = mkdtempSync(join(tmpdir(), "maw-ghq-"));
+    // Note: no parent tree created
+    const dir = mkGitRepo();
+    try {
+      const mod = await installConfigMock(ghqRoot);
+      await mod.cmdBudFromRepo({
+        target: dir, stem: "child", isUrl: false, pr: false, dryRun: false,
+        from: "ghost-parent", seed: true,
+      });
+      // Injection still succeeds — vault exists
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(ghqRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("--sync-peers copies host peers.json to <target>/ψ/peers.json", async () => {
+    const peersDir = mkdtempSync(join(tmpdir(), "maw-peers-"));
+    const peersSrc = join(peersDir, "peers.json");
+    const content = JSON.stringify({ version: 1, peers: { alice: { url: "https://a.example", node: "a", addedAt: "2026-04-19T00:00:00Z", lastSeen: null } } }, null, 2) + "\n";
+    writeFileSync(peersSrc, content);
+    process.env.PEERS_FILE = peersSrc;
+
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+        syncPeers: true,
+      });
+      const dst = join(dir, "ψ", "peers.json");
+      expect(existsSync(dst)).toBe(true);
+      expect(readFileSync(dst, "utf-8")).toBe(content);
+    } finally {
+      if (prevPeersFile === undefined) delete process.env.PEERS_FILE;
+      else process.env.PEERS_FILE = prevPeersFile;
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(peersDir, { recursive: true, force: true });
+    }
+  });
+
+  it("--sync-peers with no source peers.json is a logged skip", async () => {
+    const peersDir = mkdtempSync(join(tmpdir(), "maw-peers-"));
+    process.env.PEERS_FILE = join(peersDir, "does-not-exist.json");
+
+    const dir = mkGitRepo();
+    try {
+      await cmdBudFromRepo({
+        target: dir, stem: "demo", isUrl: false, pr: false, dryRun: false,
+        syncPeers: true,
+      });
+      expect(existsSync(join(dir, "ψ", "peers.json"))).toBe(false);
+      // Injection still succeeded
+      expect(existsSync(join(dir, "ψ", "inbox"))).toBe(true);
+    } finally {
+      if (prevPeersFile === undefined) delete process.env.PEERS_FILE;
+      else process.env.PEERS_FILE = prevPeersFile;
+      rmSync(dir, { recursive: true, force: true });
+      rmSync(peersDir, { recursive: true, force: true });
+    }
+  });
+});
+

--- a/plugins/bud/from-repo.ts
+++ b/plugins/bud/from-repo.ts
@@ -1,0 +1,264 @@
+/**
+ * `maw bud --from-repo <target> --stem <stem>` — planner + orchestrator.
+ *
+ * SCOPE: local-path + URL clone + `--pr` + `--force` + `--from` lineage +
+ * `--track-vault` + fleet-entry registration (#588). Deferred: --seed, sync_peers.
+ * Writes live in from-repo-exec.ts; git/gh shell-outs in from-repo-git.ts;
+ * fleet writes in from-repo-fleet.ts. Planner stays pure / read-only.
+ *
+ * Design: docs/bud/from-repo-design.md + docs/bud/from-repo-impl.md
+ */
+
+import { existsSync, statSync } from "fs";
+import { join, isAbsolute } from "path";
+import type { FromRepoOpts, InjectionAction, InjectionPlan } from "./types";
+import { applyFromRepoInjection } from "./from-repo-exec";
+import { cloneShallow, cleanupClone, branchCommitPushPR } from "./from-repo-git";
+import { registerFleetEntry } from "./from-repo-fleet";
+import { seedFromParent, copyPeersSnapshot } from "./from-repo-seed";
+
+/** Heuristic: is `target` a URL or `org/repo` slug rather than a local path? */
+export function looksLikeUrl(target: string): boolean {
+  if (target.startsWith("http://") || target.startsWith("https://")) return true;
+  if (target.startsWith("git@")) return true;
+  // `org/repo` slug — exactly one slash, no leading dot/slash, no absolute path
+  if (!isAbsolute(target) && !target.startsWith(".") && target.split("/").length === 2) return true;
+  return false;
+}
+
+/** The directory tree that `ψ/` injection needs to create — mirrors bud-init.ts. */
+const PSI_DIRS = [
+  "ψ/memory/learnings",
+  "ψ/memory/retrospectives",
+  "ψ/memory/traces",
+  "ψ/memory/resonance",
+  "ψ/memory/collaborations",
+  "ψ/inbox",
+  "ψ/outbox",
+  "ψ/plans",
+];
+
+/**
+ * Compute the injection plan for a target repo. Pure / read-only —
+ * never writes, never mutates. The returned plan is safe to print.
+ *
+ * Blockers are hard stops that the caller must refuse to proceed past.
+ */
+export function planFromRepoInjection(opts: FromRepoOpts): InjectionPlan {
+  const blockers: string[] = [];
+  const actions: InjectionAction[] = [];
+
+  // URL / slug targets: the orchestrator resolves them to a tmpdir via
+  // cloneShallow and calls the planner again with isUrl=false. If a URL
+  // reaches the planner directly, it's a dry-run — surface a blocker so
+  // we don't attempt a clone during a read-only preview.
+  if (opts.isUrl) {
+    blockers.push(
+      `URL / org-slug dry-run not supported — clone would be a side effect. Re-run without --dry-run.`,
+    );
+    return { target: opts.target, stem: opts.stem, actions, blockers };
+  }
+
+  const target = opts.target;
+  if (!existsSync(target)) {
+    blockers.push(`target path does not exist: ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+  if (!statSync(target).isDirectory()) {
+    blockers.push(`target is not a directory: ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+  if (!existsSync(join(target, ".git"))) {
+    blockers.push(`target is not a git repo (no .git): ${target}`);
+    return { target, stem: opts.stem, actions, blockers };
+  }
+
+  // Collision: ψ/ already present. --force downgrades the blocker to a warning.
+  const psiExists = existsSync(join(target, "ψ"));
+  if (psiExists && !opts.force) {
+    blockers.push(
+      `ψ/ already present at ${target} — looks like an existing oracle repo. Use maw soul-sync, maw wake, or pass --force to merge into the existing vault.`,
+    );
+    return { target, stem: opts.stem, actions, blockers };
+  }
+
+  // 1. ψ/ vault directories
+  for (const d of PSI_DIRS) {
+    actions.push({
+      kind: "mkdir",
+      path: d,
+      reason: psiExists ? "ψ/ exists — --force: mkdir is idempotent, merge into existing vault" : undefined,
+    });
+  }
+
+  // 2. CLAUDE.md — write if absent, append if present
+  const claudePath = join(target, "CLAUDE.md");
+  if (existsSync(claudePath)) {
+    actions.push({
+      kind: "append",
+      path: "CLAUDE.md",
+      reason: "exists — will append ## Oracle scaffolding section (never overwrite)",
+    });
+  } else {
+    actions.push({
+      kind: "write",
+      path: "CLAUDE.md",
+      reason: "absent — will write full oracle identity + Rule 6 template",
+    });
+  }
+
+  // 3. .claude/settings.local.json — minimal, only if absent
+  const settingsPath = join(target, ".claude", "settings.local.json");
+  if (existsSync(settingsPath)) {
+    actions.push({ kind: "skip", path: ".claude/settings.local.json", reason: "exists — leave untouched" });
+  } else {
+    actions.push({ kind: "write", path: ".claude/settings.local.json", reason: "empty {} scaffold" });
+  }
+
+  // 4. .gitignore — append `ψ/` unless --track-vault. Idempotent; reflected in
+  //    plan even if the line is already present (executor de-dupes).
+  if (opts.trackVault) {
+    actions.push({
+      kind: "skip",
+      path: ".gitignore",
+      reason: "--track-vault — leaving ψ/ unignored",
+    });
+  } else {
+    actions.push({
+      kind: "append",
+      path: ".gitignore",
+      reason: "add `ψ/` (default; pass --track-vault to keep ψ/ tracked)",
+    });
+  }
+
+  // 5. fleet entry — registered after the executor lands. Plan reflects intent.
+  actions.push({
+    kind: "write",
+    path: `fleet/<NN>-${opts.stem}.json`,
+    reason: opts.from
+      ? `register in ~/.config/maw/fleet/ with budded_from=${opts.from}`
+      : "register in ~/.config/maw/fleet/",
+  });
+
+  // 6. --seed: pre-load parent's ψ/memory (#588 final pair). Requires --from.
+  if (opts.seed) {
+    if (opts.from) {
+      actions.push({
+        kind: "write",
+        path: "ψ/memory/ (seeded from parent)",
+        reason: `--seed: copy ${opts.from}'s ψ/memory/ into target (dest-biased, no overwrite)`,
+      });
+    } else {
+      actions.push({
+        kind: "skip",
+        path: "ψ/memory/ (seed)",
+        reason: "--seed requires --from <parent> — nothing to seed from",
+      });
+    }
+  }
+
+  // 7. --sync-peers: snapshot host peers.json into target. Non-destructive.
+  if (opts.syncPeers) {
+    actions.push({
+      kind: "write",
+      path: "ψ/peers.json",
+      reason: "--sync-peers: snapshot host peers.json (portable seed, no ~/.maw/ mutation)",
+    });
+  }
+
+  return { target, stem: opts.stem, actions, blockers };
+}
+
+/** Render the plan for human reading. Caller prints — no side effects here. */
+export function formatPlan(plan: InjectionPlan): string {
+  const lines: string[] = [];
+  lines.push(`\n  \x1b[36m🧪 Oracle scaffold plan\x1b[0m — ${plan.stem} → ${plan.target}\n`);
+  if (plan.blockers.length > 0) {
+    lines.push(`  \x1b[31m✗ blocked:\x1b[0m`);
+    for (const b of plan.blockers) lines.push(`    - ${b}`);
+    return lines.join("\n") + "\n";
+  }
+  for (const a of plan.actions) {
+    const tag = a.kind === "mkdir" ? "mkdir" : a.kind === "write" ? "write" : a.kind === "append" ? "append" : "skip ";
+    const color = a.kind === "skip" ? "\x1b[90m" : "\x1b[36m";
+    const reason = a.reason ? `  \x1b[90m(${a.reason})\x1b[0m` : "";
+    lines.push(`  ${color}${tag}\x1b[0m  ${a.path}${reason}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Orchestrator.
+ * - Dry-run (local only): print the plan and return.
+ * - Local path: print plan, apply injection; if --pr, open PR afterwards.
+ * - URL / slug: shallow-clone → tmpdir, delegate to local-path flow, always
+ *   open PR (the tmpdir is ephemeral so committing-only would be lost),
+ *   cleanup tmpdir on both success and failure.
+ */
+export async function cmdBudFromRepo(opts: FromRepoOpts): Promise<void> {
+  if (opts.isUrl) {
+    if (opts.dryRun) {
+      // Preserve the dry-run safety rail (planner surfaces the blocker).
+      const plan = planFromRepoInjection(opts);
+      console.log(formatPlan(plan));
+      throw new Error(`plan has ${plan.blockers.length} blocker(s) — see above`);
+    }
+    console.log(`\n  \x1b[36m⚡\x1b[0m cloning ${opts.target}...`);
+    const tmp = await cloneShallow(opts.target);
+    console.log(`  \x1b[32m✓\x1b[0m cloned → ${tmp}`);
+    const localOpts: FromRepoOpts = { ...opts, target: tmp, isUrl: false, pr: true };
+    try {
+      await runLocal(localOpts);
+    } finally {
+      cleanupClone(tmp);
+      console.log(`  \x1b[90m○\x1b[0m cleaned up temp clone`);
+    }
+    return;
+  }
+  await runLocal(opts);
+}
+
+/** Local-path path — also used after URL clone. */
+async function runLocal(opts: FromRepoOpts): Promise<void> {
+  const plan = planFromRepoInjection(opts);
+  console.log(formatPlan(plan));
+  if (plan.blockers.length > 0) {
+    throw new Error(`plan has ${plan.blockers.length} blocker(s) — see above`);
+  }
+  if (opts.dryRun) return;
+  await applyFromRepoInjection(plan, opts);
+  // --seed: pre-load parent's ψ/memory/ after the vault exists. Requires --from.
+  if (opts.seed) {
+    if (!opts.from) {
+      console.log(`  \x1b[33m!\x1b[0m --seed ignored (no --from <parent> to seed from)`);
+    } else {
+      try {
+        seedFromParent(opts.target, opts.from, (m) => console.log(m));
+      } catch (e: any) {
+        console.log(`  \x1b[33m!\x1b[0m --seed failed: ${e.message} — injection still complete`);
+      }
+    }
+  }
+  // --sync-peers: snapshot host peers.json into target vault.
+  if (opts.syncPeers) {
+    try {
+      copyPeersSnapshot(opts.target, (m) => console.log(m));
+    } catch (e: any) {
+      console.log(`  \x1b[33m!\x1b[0m --sync-peers failed: ${e.message} — injection still complete`);
+    }
+  }
+  // Fleet entry — register the budded oracle so `maw wake <stem>` works.
+  // Failure to register is logged but never blocks the injection (the repo
+  // is the canonical artifact; fleet is a convenience index).
+  try {
+    const result = registerFleetEntry({ stem: opts.stem, target: opts.target, parent: opts.from });
+    const verb = result.created ? "registered" : "updated";
+    console.log(`  \x1b[32m✓\x1b[0m fleet entry ${verb}: ${result.file}`);
+  } catch (e: any) {
+    console.log(`  \x1b[33m!\x1b[0m fleet entry skipped: ${e.message}`);
+  }
+  if (opts.pr) {
+    const url = await branchCommitPushPR(opts.target, opts.stem, (m) => console.log(m));
+    console.log(`\n  \x1b[32m🎉 PR opened:\x1b[0m ${url}\n`);
+  }
+}

--- a/plugins/bud/impl.ts
+++ b/plugins/bud/impl.ts
@@ -1,0 +1,193 @@
+import { loadConfig } from "../../../config";
+import { getGhqRoot } from "../../../config/ghq-root";
+import { parseWakeTarget, ensureCloned } from "../../shared/wake-target";
+import { normalizeTarget } from "../../../core/matcher/normalize-target";
+import { assertValidOracleName } from "../../../core/fleet/validate";
+import { hostExec } from "../../../sdk";
+import { ensureBudRepo } from "./bud-repo";
+import { initVault, generateClaudeMd, configureFleet, writeBirthNote } from "./bud-init";
+import { finalizeBud } from "./bud-wake";
+import { writeSignal } from "../../../core/fleet/leaf";
+import { validateNickname, writeNickname, setCachedNickname } from "../../../core/fleet/nicknames";
+import { join } from "path";
+
+export interface BudOpts {
+  from?: string;
+  repo?: string;
+  org?: string;
+  issue?: number;
+  fast?: boolean;
+  root?: boolean;
+  dryRun?: boolean;
+  note?: string;
+  split?: boolean;
+  /** @deprecated Use --seed for explicit inheritance. Birth is blank by default now. */
+  blank?: boolean;
+  /** Opt-in: pre-load parent's ψ at birth (bulk push). Default is blank — child
+   *  pulls memory later via `maw soul-sync <parent> --from` after /awaken. */
+  seed?: boolean;
+  /** Drop a "birth" signal into the parent oracle's ψ/memory/signals/ on creation. */
+  signalOnBirth?: boolean;
+  /** Pretty display name — written to ψ/nickname at birth (#643 Phase 3). */
+  nickname?: string;
+}
+
+// TinyBudOpts removed — --tiny deprecated, code moved to deprecated/tiny-bud-209/
+// See #209 for history. Full buds with --blank (alpha.38) are now as lightweight.
+
+/**
+ * maw bud <name> [--from <parent>] [--org <org>] [--repo org/repo] [--issue N] [--fast] [--dry-run]
+ *
+ * Yeast budding — any oracle can spawn a new oracle.
+ *
+ * Target org resolution (first wins):
+ *   1. --org <org>                    — per-invocation override (#235)
+ *   2. config.githubOrg               — per-machine default from config
+ *   3. "Soul-Brews-Studio"            — hard-coded fallback
+ *
+ * Note: --repo is an INCUBATION flag (seeds the bud from an existing local
+ * project's ψ/), NOT a target-org override. Use --org to target a different
+ * GitHub org for the bud's own repo.
+ */
+export async function cmdBud(name: string, opts: BudOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` from tab-completion/paste.
+  name = normalizeTarget(name);
+  // Oracle names: alphanumeric + hyphens only, must start with a letter
+  if (!/^[a-zA-Z][a-zA-Z0-9-]*$/.test(name)) {
+    throw new Error(
+      `invalid oracle name: "${name}" — names must start with a letter and contain only letters, numbers, hyphens`,
+    );
+  }
+  // #358 — reject -view suffix (reserved for ephemeral grouped sessions).
+  try {
+    assertValidOracleName(name);
+  } catch (e: any) {
+    throw new Error(e.message);
+  }
+
+  // Runtime guard: stem must NOT end with -oracle (the plugin auto-appends it).
+  // This prevents arra-oracle-v3 → arra-oracle-v3-oracle (correct)
+  // from being confused with arra-oracle-v3-oracle → arra-oracle-v3-oracle-oracle (triple).
+  if (name.endsWith("-oracle")) {
+    throw new Error(
+      `\x1b[31m✗\x1b[0m bud stem must NOT end with '-oracle' — got '${name}'\n` +
+      `  The plugin auto-appends '-oracle' to produce the repo name.\n` +
+      `  Try: maw bud ${name.replace(/-oracle$/, "")}\n` +
+      `  This produces repo: ${name.replace(/-oracle$/, "")}-oracle`,
+    );
+  }
+
+  // Validate nickname early — fail fast before any repo work (#643 Phase 3).
+  let nicknameValue = "";
+  if (opts.nickname !== undefined) {
+    const v = validateNickname(opts.nickname);
+    if (!v.ok) throw new Error(v.error);
+    nicknameValue = v.value;
+  }
+
+  const config = loadConfig();
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const org = opts.org || config.githubOrg || "Soul-Brews-Studio";
+
+  // Resolve parent oracle (skip for --root)
+  let parentName: string | null = opts.from || null;
+  // If --from is a URL or org/repo slug, extract oracle name and clone (#280)
+  const fromTarget = parentName ? parseWakeTarget(parentName) : null;
+  if (fromTarget) {
+    parentName = fromTarget.oracle;
+    if (!opts.repo) await ensureCloned(fromTarget.slug);
+  }
+  if (!parentName && !opts.root) {
+    try {
+      const cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+      const repoName = cwd.split("/").pop() || "";
+      parentName = repoName.replace(/\.wt-.*$/, "").replace(/-oracle$/, "");
+    } catch {
+      throw new Error("could not detect parent oracle. Use --from <oracle> or --root");
+    }
+  }
+
+  const budRepoName = `${name}-oracle`;
+  const budRepoSlug = `${org}/${budRepoName}`;
+  // Predicted path — may drift from ghq's actual landing dir when
+  // the ghq root is stale (#630, #680). ensureBudRepo returns the authoritative
+  // post-clone path; use that for all scaffolding below.
+  const predictedRepoPath = join(reposRoot, org, budRepoName);
+
+  const nickSuffix = nicknameValue ? ` (${nicknameValue})` : "";
+  if (opts.root) {
+    console.log(`\n  \x1b[36m🌱 Root Bud\x1b[0m — ${name}${nickSuffix} (no parent lineage)\n`);
+  } else {
+    console.log(`\n  \x1b[36m🧬 Budding\x1b[0m — ${parentName} → ${name}${nickSuffix}\n`);
+  }
+
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create repo: ${budRepoSlug}`);
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would init ψ/ vault at: ${predictedRepoPath}`);
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would generate CLAUDE.md`);
+    if (nicknameValue) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would write nickname: ${nicknameValue}`);
+    }
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would create fleet config`);
+    if (opts.seed && parentName) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] --seed: would bulk soul-sync from ${parentName}`);
+    } else if (parentName) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] born blank — pull memory later: maw soul-sync ${parentName} --from`);
+    } else {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] root oracle — no parent`);
+    }
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would wake ${name}`);
+    if (parentName) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would add ${name} to ${parentName}'s sync_peers`);
+    }
+    console.log();
+    return;
+  }
+
+  // 1. Create oracle repo — returns the ACTUAL clone path per ghq (#630).
+  const budRepoPath = await ensureBudRepo(budRepoSlug, predictedRepoPath, budRepoName, org);
+
+  // 2-4.5. Initialize vault, CLAUDE.md, nickname, fleet config, birth note
+  const psiDir = initVault(budRepoPath);
+  generateClaudeMd(budRepoPath, name, parentName);
+  if (nicknameValue) {
+    // Authoritative on-disk write (staged by finalizeBud's `git add -A`),
+    // then refresh the read-through cache so /info + peers pick it up immediately.
+    writeNickname(budRepoPath, nicknameValue);
+    setCachedNickname(name, nicknameValue);
+    console.log(`  \x1b[32m✓\x1b[0m nickname set: \x1b[33m${nicknameValue}\x1b[0m`);
+  }
+  const fleetFile = configureFleet(name, org, budRepoName, parentName);
+  if (opts.note) writeBirthNote(psiDir, name, parentName, opts.note);
+
+  // 5-8.5. Soul-sync, commit, sync peers, wake, split, copy
+  await finalizeBud({
+    name, parentName, org, budRepoName, budRepoPath, psiDir, fleetFile,
+    opts: { seed: opts.seed, issue: opts.issue, repo: opts.repo, split: opts.split, fast: opts.fast },
+  });
+
+  // Optional: drop birth signal into parent's ψ/
+  if (opts.signalOnBirth && parentName) {
+    const parentRepoPath = join(reposRoot, org, `${parentName}-oracle`);
+    writeSignal(parentRepoPath, name, {
+      kind: "info",
+      message: `bud born: ${name}`,
+      context: { budRepoSlug: `${org}/${budRepoName}`, budRepoPath },
+    });
+    console.log(`  \x1b[36m⬡\x1b[0m signal dropped → ${parentName}'s ψ/memory/signals/`);
+  }
+
+  // Summary
+  console.log(`\n  \x1b[32m${parentName ? "🧬 Bud" : "🌱 Root bud"} complete!\x1b[0m ${parentName ? `${parentName} → ${name}` : name}`);
+  console.log(`  \x1b[90m  repo: ${budRepoSlug}`);
+  console.log(`  \x1b[90m  fleet: ${fleetFile}`);
+  console.log(`  \x1b[90m  sync_peers: [${parentName || ""}]`);
+  if (!opts.fast) {
+    console.log(`  \x1b[90m  run /awaken in the new oracle for full identity setup\x1b[0m`);
+  }
+  console.log();
+}
+
+// cmdBudTiny removed — --tiny deprecated, code preserved in deprecated/tiny-bud-209/
+// Full buds with --blank default (alpha.38) are now as lightweight.
+// Issue #209 closed. Nothing is Deleted — the code lives in deprecated/.

--- a/plugins/bud/index.ts
+++ b/plugins/bud/index.ts
@@ -1,0 +1,125 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdBud } from "./impl";
+import { cmdBudFromRepo, looksLikeUrl } from "./from-repo";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "bud",
+  description: "Create a new oracle (bud from parent)",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, {
+        "--from": String,
+        "--from-repo": String,
+        "--stem": String,
+        "--org": String,
+        "--repo": String,
+        "--issue": Number,
+        "--note": String,
+        "--nickname": String,
+        "--fast": Boolean,
+        "--root": Boolean,
+        "--dry-run": Boolean,
+        "--pr": Boolean,
+        "--split": Boolean,
+        "--seed": Boolean,
+        "--blank": Boolean,
+        "--signal-on-birth": Boolean,
+        "--force": Boolean,
+        "--track-vault": Boolean,
+        "--sync-peers": Boolean,
+      }, 0);
+
+      // --from-repo branches early: inject scaffolding into an existing repo (#588).
+      // Scaffold-only this PR — see docs/bud/from-repo-design.md.
+      if (flags["--from-repo"]) {
+        const target = flags["--from-repo"];
+        const stem = flags["--stem"];
+        if (!stem) {
+          return { ok: false, error: "--from-repo requires --stem <stem> (oracle stem, no -oracle suffix)" };
+        }
+        if (stem.endsWith("-oracle")) {
+          return { ok: false, error: `--stem must NOT end with '-oracle' — got '${stem}'. Try: --stem ${stem.replace(/-oracle$/, "")}` };
+        }
+        await cmdBudFromRepo({
+          target,
+          stem,
+          isUrl: looksLikeUrl(target),
+          pr: !!flags["--pr"],
+          dryRun: !!flags["--dry-run"],
+          force: !!flags["--force"],
+          from: flags["--from"],
+          trackVault: !!flags["--track-vault"],
+          seed: !!flags["--seed"],
+          syncPeers: !!flags["--sync-peers"],
+        });
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const name = flags._[0];
+      if (!name || name === "--help" || name === "-h") {
+        return { ok: false, error: "usage: maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path|url> --stem <stem> [--pr] [--from <parent>] [--seed] [--sync-peers] [--force] [--track-vault] [--dry-run]  (#588)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from" };
+      }
+      if (name.startsWith("-")) {
+        return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  usage: maw bud <name> ${args.join(" ")}` };
+      }
+
+      await cmdBud(name, {
+        from: flags["--from"],
+        repo: flags["--repo"],
+        org: flags["--org"],
+        issue: flags["--issue"],
+        note: flags["--note"],
+        nickname: flags["--nickname"],
+        fast: flags["--fast"],
+        root: flags["--root"],
+        dryRun: flags["--dry-run"],
+        split: flags["--split"],
+        seed: flags["--seed"],
+        blank: flags["--blank"],
+        signalOnBirth: flags["--signal-on-birth"],
+      });
+    } else if (ctx.source === "api") {
+      const body = ctx.args as Record<string, unknown>;
+      const name = body.name as string;
+      if (!name) return { ok: false, error: "name required" };
+      await cmdBud(name, {
+        from: body.from as string | undefined,
+        repo: body.repo as string | undefined,
+        org: body.org as string | undefined,
+        issue: body.issue as number | undefined,
+        note: body.note as string | undefined,
+        nickname: body.nickname as string | undefined,
+        fast: body.fast as boolean | undefined,
+        root: body.root as boolean | undefined,
+        dryRun: body.dryRun as boolean | undefined,
+        split: body.split as boolean | undefined,
+        seed: body.seed as boolean | undefined,
+        blank: body.blank as boolean | undefined,
+        signalOnBirth: body.signalOnBirth as boolean | undefined,
+      });
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/bud/internal/lock.ts
+++ b/plugins/bud/internal/lock.ts
@@ -1,0 +1,78 @@
+/**
+ * maw peers — file lock for concurrent writers (#572 nit 3).
+ *
+ * Mirrors the pattern in src/cli/update-lock.ts: O_EXCL create on a
+ * sibling `.lock` file, write our pid, retry on EEXIST. If the holder
+ * pid is gone (kill -0 → ESRCH) we steal the lock immediately rather
+ * than waiting out the timeout. Synchronous (no await) so it composes
+ * with the existing sync savePeers signature without a contract change.
+ *
+ * Sized for CLI use: 5s deadline, 50ms poll. peers.json writes are
+ * sub-millisecond, so racing CLIs almost always succeed on first try.
+ */
+import { openSync, closeSync, unlinkSync, writeSync, readSync, existsSync } from "fs";
+
+const DEADLINE_MS = 5_000;
+const POLL_MS = 50;
+
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin — short waits only */ }
+}
+
+/** Run fn() while holding an exclusive lock on `<path>.lock`. Synchronous. */
+export function withPeersLock<T>(path: string, fn: () => T): T {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + DEADLINE_MS;
+  let fd: number | null = null;
+
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx"); // O_CREAT | O_EXCL
+      // fd-based write — prevents path-TOCTOU symlink swap between open and write.
+      // See #562 / #581 (exemplar fix in src/cli/update-lock.ts).
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      // fd-based read for the same TOCTOU reason as the write above.
+      // Fixed 64-byte buffer — PIDs are ≤20 digits on every supported OS, so
+      // no fstatSync needed (also avoids the CodeQL "stat-then-read" pattern).
+      let holderPid = NaN;
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(lockPath, "r");
+        const buf = Buffer.alloc(64);
+        const n = readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
+      } catch { /* empty/racy — treat as stale */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      if (!isAlive(holderPid)) {
+        try { unlinkSync(lockPath); } catch { /* race with another stealer is fine */ }
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`peers lock timeout: pid ${holderPid} still holds ${lockPath}`);
+      }
+      sleepSync(POLL_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
+    try { if (existsSync(lockPath)) unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+}

--- a/plugins/bud/internal/peers-store.ts
+++ b/plugins/bud/internal/peers-store.ts
@@ -1,0 +1,190 @@
+/**
+ * maw peers — storage layer (#568, #572).
+ *
+ * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
+ * and rename(2) so a crash mid-write leaves either the old file intact
+ * or the new file fully in place — never a truncated file. A stale tmp
+ * file from a crashed previous write is cleaned on load (the live file
+ * is still valid; the tmp is leftover from a crashed writer).
+ *
+ * Schema v1:
+ *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen,
+ *                                     [lastError, nickname, pubkey, pubkeyFirstSeen,
+ *                                      identity] } } }
+ *   — fields in brackets are optional. `pubkey` / `pubkeyFirstSeen` were
+ *   added in #804 Step 2 for TOFU peer-identity pinning. `identity` was
+ *   added in #804 Step 3 to capture the peer's self-reported `<oracle>:<node>`
+ *   pair for duplicate-detection (doctor + boot-time warn).
+ *
+ * Path resolution is a function (not a const) so tests can override
+ * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ *
+ * Concurrency: savePeers takes a short-lived file lock around the
+ * read-modify-write critical section so concurrent `maw peers add`
+ * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
+ *
+ * Corruption: if the live file fails to parse, OR if it parses but
+ * the shape is wrong (e.g. `{"peers":[]}` — array instead of object),
+ * we rename it aside to `peers.json.corrupt-<ISO>` and start fresh —
+ * non-destructive, with an audit trail (#572 nit 1, follow-up to #579).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { withPeersLock } from "./lock";
+
+/**
+ * Structured last-probe failure — opt-in field on Peer (#565).
+ *
+ * Absent (undefined) means either the peer has never been probed, or
+ * the most recent probe succeeded. Readers that don't know about this
+ * field continue to work — schema v1 is unchanged.
+ */
+export interface LastError {
+  /** Classified code — see probe.ts classifyProbeError(). */
+  code: "DNS" | "REFUSED" | "TIMEOUT" | "TLS" | "HTTP_4XX" | "HTTP_5XX" | "BAD_BODY" | "UNKNOWN";
+  /** Raw error message (from err.message or synthesized for HTTP cases). */
+  message: string;
+  /** ISO timestamp when the failure was recorded. */
+  at: string;
+}
+
+export interface Peer {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+  /** Optional — set by probePeer() when handshake fails; cleared on success. */
+  lastError?: LastError;
+  /** Optional human-friendly nickname, propagated from peer's /info (#643 Phase 2). */
+  nickname?: string | null;
+  /**
+   * TOFU-cached pubkey from the peer's /api/identity response (#804 Step 2).
+   *
+   * Absent until the first successful identity fetch that returned a `pubkey`
+   * field. Once cached, every subsequent identity check validates the response
+   * against this value — mismatch is treated as either rotation or
+   * impersonation and is refused (see ADR docs/federation/0001-peer-identity.md
+   * O6 table). Operator clears via `maw peers forget <alias>` to re-TOFU.
+   */
+  pubkey?: string;
+  /** ISO timestamp when the pubkey was first cached (TOFU). */
+  pubkeyFirstSeen?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` pair from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` during TOFU bootstrap and on
+   * every subsequent successful probe. Drives the duplicate-detection check
+   * in `maw doctor` and the boot-time warning in `maw serve` — two peers
+   * claiming the same `<oracle>:<node>` is operator confusion that crypto
+   * (Step 2) cannot solve, and operator must investigate.
+   *
+   * Absent for legacy peers (pre-Step-1 nodes that don't expose /api/identity)
+   * and for peers whose /api/identity response omitted both `node` and `oracle`.
+   * Doctor + boot-warn skip undefined identity (no false-positive collision).
+   */
+  identity?: { oracle: string; node: string };
+}
+
+export interface PeersFile {
+  version: 1;
+  peers: Record<string, Peer>;
+}
+
+export function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function emptyStore(): PeersFile {
+  return { version: 1, peers: {} };
+}
+
+export function loadPeers(): PeersFile {
+  clearStaleTmp();
+  const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return emptyStore();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) throw new Error("invalid store shape (expected { peers: { ... } } object)");
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch (e: any) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const aside = `${path}.corrupt-${stamp}`;
+    try { renameSync(path, aside); } catch { /* ignore — caller still gets empty store */ }
+    console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
+    return emptyStore();
+  }
+}
+
+/**
+ * Validate the parsed JSON matches the expected store shape:
+ * a non-null object whose `peers` field is itself a non-null,
+ * non-array object. Guards against `{"peers":[]}` (array) and
+ * other junk that would silently no-op every write (follow-up
+ * to #579).
+ */
+function isValidStoreShape(parsed: unknown): parsed is PeersFile {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const peers = (parsed as { peers?: unknown }).peers;
+  if (peers === undefined) return true; // missing peers is ok — we default to {}
+  return typeof peers === "object" && peers !== null && !Array.isArray(peers);
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  withPeersLock(path, () => writeAtomic(path, data));
+}
+
+/**
+ * Atomic read-modify-write under the peers lock. Use this whenever a
+ * mutation depends on current contents (add/remove) — it re-reads
+ * inside the lock so concurrent writers don't lose each other's
+ * updates. The mutator runs synchronously inside the critical section.
+ */
+export function mutatePeers(mutate: (data: PeersFile) => void): PeersFile {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  return withPeersLock(path, () => {
+    const fresh = readUnlocked(path);
+    mutate(fresh);
+    writeAtomic(path, fresh);
+    return fresh;
+  });
+}
+
+/** Read + parse without taking the lock or doing corruption-handling rename. */
+function readUnlocked(path: string): PeersFile {
+  if (!existsSync(path)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) return emptyStore();
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function writeAtomic(path: string, data: PeersFile): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Best-effort cleanup of a stale tmp file (ignore errors). */
+export function clearStaleTmp(): void {
+  const tmp = `${peersPath()}.tmp`;
+  try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+}

--- a/plugins/bud/internal/resolve.ts
+++ b/plugins/bud/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/plugins/bud/internal/soul-sync-impl.ts
+++ b/plugins/bud/internal/soul-sync-impl.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "fs";
+import { join, basename } from "path";
+import { hostExec } from "../../../../sdk";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
+import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+export { syncDir, findPeers, findProjectsForOracle, syncProjectVault } from "./sync-helpers";
+export type { SoulSyncResult, ProjectSyncResult } from "./sync-helpers";
+export { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+/**
+ * maw soul-sync [peer] [--from <peer>] — push ψ/ to peers; --from reverses direction.
+ * maw ss <peer>       push to specific peer
+ * maw ss --from <p>   pull from specific peer
+ */
+export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?: string }): Promise<SoulSyncResult[]> {
+  const results: SoulSyncResult[] = [];
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  const cwdParts = cwd.split("/");
+  const repoName = cwdParts.pop() || "";
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
+
+  let oraclePath = cwd;
+  try {
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (commonDir && commonDir !== ".git") {
+      const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+      oraclePath = join(mainGit, "..");
+    }
+  } catch { /* use cwd */ }
+
+  const peers = target ? [target] : findPeers(oracleName);
+  if (peers.length === 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m soul-sync: no sync_peers configured for '${oracleName}'`);
+    console.log(`  \x1b[90mAdd "sync_peers": ["name"] to fleet config, or run: maw ss <peer>\x1b[0m`);
+    return results;
+  }
+
+  const direction = opts?.from ? "pull" : "push";
+  const label = direction === "pull"
+    ? `pulling ${peers[0]} → ${oracleName}`
+    : `pushing ${oracleName} → ${peers.join(", ")}`;
+  console.log(`\n  \x1b[36m⚡ Soul Sync\x1b[0m — ${label}\n`);
+
+  for (const peer of peers) {
+    const peerPath = await resolveOraclePath(peer);
+    if (!peerPath) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${peer}: repo not found, skipping`);
+      continue;
+    }
+
+    const [from, to, fromName, toName] = direction === "pull"
+      ? [peerPath, oraclePath, peer, oracleName]
+      : [oraclePath, peerPath, oracleName, peer];
+
+    const result = syncOracleVaults(from, to, fromName, toName);
+    results.push(result);
+
+    if (result.total === 0) {
+      console.log(`  \x1b[90m○\x1b[0m ${fromName} → ${toName}: nothing new`);
+    } else {
+      const parts = Object.entries(result.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+      console.log(`  \x1b[32m✓\x1b[0m ${fromName} → ${toName}: ${parts.join(", ")}`);
+    }
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) synced.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+
+  return results;
+}
+
+/**
+ * maw soul-sync --project — absorb project ψ/ into oracle ψ/ (inward only).
+ * Oracle cwd: absorbs from each project_repos entry.
+ * Project cwd: pushes ψ/ to the oracle that owns this repo.
+ */
+export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<ProjectSyncResult[]> {
+  const results: ProjectSyncResult[] = [];
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  let repoRoot = cwd;
+  try {
+    const top = (await hostExec(`git -C '${cwd}' rev-parse --show-toplevel`)).trim();
+    if (top) repoRoot = top;
+  } catch { /* not a git repo */ }
+
+  const repoSlug = resolveProjectSlug(repoRoot, reposRoot);
+  const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
+  const isOracle = repoBase.endsWith("-oracle");
+
+  console.log(`\n  \x1b[36m⚡ Soul Sync (project)\x1b[0m — ${isOracle ? "absorbing into" : "exporting from"} ${repoBase}\n`);
+
+  if (isOracle) {
+    const oracleName = repoBase.replace(/-oracle$/, "");
+    const projects = findProjectsForOracle(oracleName);
+    if (projects.length === 0) {
+      console.log(`  \x1b[33m⚠\x1b[0m no project_repos configured for '${oracleName}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["org/repo"] to fleet config for ${oracleName}.\x1b[0m\n`);
+      return results;
+    }
+    for (const projectRepo of projects) {
+      const projectPath = join(reposRoot, projectRepo);
+      if (!existsSync(projectPath)) {
+        console.log(`  \x1b[33m⚠\x1b[0m ${projectRepo}: not found at ${projectPath}, skipping`);
+        continue;
+      }
+      const result = syncProjectVault(projectPath, repoRoot, projectRepo, oracleName);
+      results.push(result);
+      reportProjectResult(result);
+    }
+  } else {
+    if (!repoSlug) {
+      console.log(`  \x1b[33m⚠\x1b[0m cannot resolve project slug from ${repoRoot} (not under repos root ${reposRoot})\n`);
+      return results;
+    }
+    const oracleName = findOracleForProject(repoSlug);
+    if (!oracleName) {
+      console.log(`  \x1b[33m⚠\x1b[0m no oracle owns project '${repoSlug}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["${repoSlug}"] to an oracle's fleet config.\x1b[0m\n`);
+      return results;
+    }
+    const oraclePath = await resolveOraclePath(oracleName);
+    if (!oraclePath) {
+      console.log(`  \x1b[33m⚠\x1b[0m oracle '${oracleName}' repo not found locally\n`);
+      return results;
+    }
+    const result = syncProjectVault(repoRoot, oraclePath, repoSlug, oracleName);
+    results.push(result);
+    reportProjectResult(result);
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) absorbed.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+  return results;
+}

--- a/plugins/bud/internal/split-impl.ts
+++ b/plugins/bud/internal/split-impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
+import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/plugins/bud/internal/sync-helpers.ts
+++ b/plugins/bud/internal/sync-helpers.ts
@@ -1,0 +1,150 @@
+import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadFleet } from "../../../shared/fleet-load";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+/**
+ * Find peer oracle names for a given oracle from fleet config.
+ * Flat lookup — each oracle declares its own sync_peers.
+ */
+export function findPeers(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName && sess.sync_peers) return sess.sync_peers;
+  }
+  return [];
+}
+
+/**
+ * Find project repos this oracle absorbs from.
+ */
+export function findProjectsForOracle(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName) return sess.project_repos || [];
+  }
+  return [];
+}
+
+export interface SoulSyncResult {
+  from: string;
+  to: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from one oracle repo to another (new files only).
+ */
+export function syncOracleVaults(fromPath: string, toPath: string, fromName: string, toName: string): SoulSyncResult {
+  const fromVault = join(fromPath, "ψ");
+  const toVault = join(toPath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(fromVault, subdir);
+    const dst = join(toVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(toVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | ${fromName} → ${toName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { from: fromName, to: toName, synced, total };
+}
+
+export interface ProjectSyncResult {
+  project: string;
+  oracle: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from a project repo into an oracle repo.
+ * Knowledge flows inward through the membrane — project → oracle, new files only.
+ */
+export function syncProjectVault(
+  projectPath: string,
+  oraclePath: string,
+  projectRepo: string,
+  oracleName: string,
+): ProjectSyncResult {
+  const projectVault = join(projectPath, "ψ");
+  const oracleVault = join(oraclePath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(projectVault, subdir);
+    const dst = join(oracleVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(oracleVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | project:${projectRepo} → ${oracleName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { project: projectRepo, oracle: oracleName, synced, total };
+}
+
+export function reportProjectResult(r: ProjectSyncResult) {
+  if (r.total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m project:${r.project} → ${r.oracle}: nothing new`);
+  } else {
+    const parts = Object.entries(r.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+    console.log(`  \x1b[32m✓\x1b[0m project:${r.project} → ${r.oracle}: ${parts.join(", ")}`);
+  }
+}

--- a/plugins/bud/plugin.json
+++ b/plugins/bud/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "bud",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Create a new oracle (bud from parent)",
+  "cli": {
+    "command": "bud",
+    "help": "maw bud <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--fast] [--split] [--dry-run]\n       Or:    maw bud --from-repo <path> --stem <stem> [--pr] [--dry-run]  (#588, scaffold-only)\n       Default: born blank. Use --seed to pre-load parent's ψ at birth.\n       Pull memory later: maw soul-sync <parent> --from\n       NOTE: <name> is the STEM. Repo created as <name>-oracle.\n       e.g. 'maw bud fusion' → 'fusion-oracle'. 'maw bud fusion-oracle' → 'fusion-oracle-oracle' ✗",
+    "flags": {
+      "--from": "string",
+      "--from-repo": "string",
+      "--stem": "string",
+      "--org": "string",
+      "--repo": "string",
+      "--issue": "number",
+      "--note": "string",
+      "--fast": "boolean",
+      "--root": "boolean",
+      "--blank": "boolean",
+      "--pr": "boolean",
+      "--split": "boolean",
+      "--seed": "boolean",
+      "--dry-run": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/bud",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/bud/types.ts
+++ b/plugins/bud/types.ts
@@ -1,0 +1,46 @@
+/**
+ * Bud plugin — shared types.
+ *
+ * `BudOpts` lives in impl.ts for historical reasons; new-feature types land here.
+ * See docs/bud/from-repo-design.md for the `--from-repo` design.
+ */
+
+/** Options for `maw bud --from-repo <target> --stem <stem>`. Issue #588. */
+export interface FromRepoOpts {
+  /** The target repo. Accepts a local absolute path, `org/repo` slug, or git URL. */
+  target: string;
+  /** Stem of the oracle name; `-oracle` MUST NOT be included (impl.ts rejects it). */
+  stem: string;
+  /** Heuristic — `target` parses as a URL / slug rather than a filesystem path. */
+  isUrl: boolean;
+  /** Open a PR on the target instead of committing to the default branch. */
+  pr: boolean;
+  /** Print the injection plan and exit without writing. */
+  dryRun: boolean;
+  /** Suppress the ψ/-collision blocker. Never destructive — mkdir is idempotent. */
+  force?: boolean;
+  /** Parent oracle stem — embedded as lineage in CLAUDE.md (and fleet entry). */
+  from?: string;
+  /** Keep ψ/ tracked in git. Default: append `ψ/` to target .gitignore. */
+  trackVault?: boolean;
+  /** Pre-load parent's ψ/memory/ into target at bud time. Requires `from`. */
+  seed?: boolean;
+  /** Snapshot host peers.json into target's ψ/peers.json as a portable seed. */
+  syncPeers?: boolean;
+}
+
+/** One file in the injection plan — what would be added or appended. */
+export interface InjectionAction {
+  kind: "mkdir" | "write" | "append" | "skip";
+  path: string;
+  reason?: string;
+}
+
+/** Result of `planFromRepoInjection` — a read-only preview. */
+export interface InjectionPlan {
+  target: string;
+  stem: string;
+  actions: InjectionAction[];
+  /** If non-empty, the plan cannot proceed — `cmdBudFromRepo` must refuse. */
+  blockers: string[];
+}

--- a/plugins/capture/impl.ts
+++ b/plugins/capture/impl.ts
@@ -1,0 +1,83 @@
+import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+
+export interface CaptureOpts {
+  /** Pane index within the resolved window. Default: current/first. */
+  pane?: number;
+  /** Number of tail lines. Default: 50. Ignored if --full. */
+  lines?: number;
+  /** Capture the full scrollback history (-S -). */
+  full?: boolean;
+}
+
+/**
+ * maw capture <target> [--pane N] [--lines N] [--full]
+ *
+ * Capture tmux pane content. Wraps `tmux capture-pane -p` with sane
+ * defaults so skills don't shell out directly.
+ *
+ *   --pane N    pick a specific pane of the resolved window (default 0)
+ *   --lines N   tail the last N lines (default 50)
+ *   --full      capture full scrollback — overrides --lines
+ */
+export async function cmdCapture(target: string, opts: CaptureOpts = {}) {
+  if (!target) {
+    throw new Error("usage: maw capture <target> [--pane N] [--lines N] [--full]\n  e.g. maw capture mawjs\n       maw capture neo:0 --pane 1 --lines 100\n       maw capture mawjs --full");
+  }
+
+  let resolved: string;
+  if (target.includes(":")) {
+    const [rawSession, rest] = target.split(":", 2);
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(rawSession, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${rawSession}' is ambiguous — matches ${r.candidates.length} sessions`);
+    }
+    if (r.kind === "none") {
+      if (r.hints && r.hints.length > 0) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      throw new Error(`session '${rawSession}' not found`);
+    }
+    resolved = `${r.match.name}:${rest}`;
+  } else {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous — matches ${r.candidates.length} sessions`);
+    }
+    if (r.kind === "none") {
+      if (r.hints && r.hints.length > 0) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      } else {
+        console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      }
+      throw new Error(`session '${target}' not found`);
+    }
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  const paneSuffix = opts.pane !== undefined ? `.${opts.pane}` : "";
+  const full = resolved + paneSuffix;
+  const tmux = tmuxCmd();
+
+  try {
+    let raw: string;
+    if (opts.full) {
+      // -S - means "from the beginning of history"
+      raw = await hostExec(`${tmux} capture-pane -t '${full}' -p -S -`);
+    } else {
+      const lines = opts.lines ?? 50;
+      raw = await hostExec(`${tmux} capture-pane -t '${full}' -p -S -${lines}`);
+    }
+    if (raw) console.log(raw);
+  } catch (e: any) {
+    throw new Error(`capture failed: ${e.message || e}`);
+  }
+}

--- a/plugins/capture/index.ts
+++ b/plugins/capture/index.ts
@@ -1,0 +1,65 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdCapture } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "capture",
+  description: "Capture tmux pane content.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pane?: number; lines?: number; full?: boolean } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, {
+        "--pane": Number,
+        "--lines": Number,
+        "--full": Boolean,
+      }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw capture <target> [--pane N] [--lines N] [--full]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw capture <target>` };
+      }
+      opts = {
+        pane: flags["--pane"],
+        lines: flags["--lines"],
+        full: flags["--full"],
+      };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) return { ok: false, error: "target is required" };
+      target = body.target as string;
+      opts = {
+        pane: body.pane as number | undefined,
+        lines: body.lines as number | undefined,
+        full: body.full as boolean | undefined,
+      };
+    }
+
+    await cmdCapture(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/capture/plugin.json
+++ b/plugins/capture/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "capture",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Capture tmux pane content — visible history or full scrollback.",
+  "cli": {
+    "command": "capture",
+    "help": "maw capture <target> [--pane N] [--lines N] [--full]",
+    "flags": {
+      "--pane": "number",
+      "--lines": "number",
+      "--full": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/capture",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/check/impl.ts
+++ b/plugins/check/impl.ts
@@ -1,0 +1,107 @@
+import { spawnSync } from "child_process";
+import { tlink } from "../../../core/util/terminal";
+
+export interface ToolStatus {
+  name: string;
+  present: boolean;
+  version?: string;
+  required: boolean;
+  category: "required" | "optional";
+  installUrl: string;
+  notes?: string;
+}
+
+/** Alphabetical within each category. */
+export const TOOLS: Omit<ToolStatus, "present" | "version">[] = [
+  { name: "bun",  required: true,  category: "required", installUrl: "https://bun.sh" },
+  { name: "gh",   required: true,  category: "required", installUrl: "https://cli.github.com" },
+  { name: "ghq",  required: true,  category: "required", installUrl: "https://github.com/x-motemen/ghq#install" },
+  { name: "git",  required: true,  category: "required", installUrl: "https://git-scm.com/downloads" },
+  { name: "tmux", required: true,  category: "required", installUrl: "https://github.com/tmux/tmux/wiki/Installing" },
+  { name: "uv",   required: false, category: "optional", installUrl: "https://docs.astral.sh/uv/getting-started/installation/" },
+  { name: "uvx",  required: false, category: "optional", installUrl: "https://docs.astral.sh/uv/", notes: "provided by uv" },
+];
+
+/**
+ * Check whether a tool binary is present and extract its version string.
+ * - tmux uses `-V` (e.g. "tmux 3.4")
+ * - uvx is detected via `which` (it's a wrapper; no useful --version)
+ * - all others use `--version`
+ */
+export function checkTool(name: string): { present: boolean; version?: string } {
+  // uvx: detect presence via `which`, inherit version from uv
+  if (name === "uvx") {
+    const w = spawnSync("which", ["uvx"], { encoding: "utf-8" });
+    if (w.error || w.status !== 0) return { present: false };
+    const uv = spawnSync("uv", ["--version"], { encoding: "utf-8" });
+    const output = (uv.stdout || "") + (uv.stderr || "");
+    const match = output.match(/(\d+\.\d+(?:\.\d+)?)/);
+    return { present: true, version: match?.[1] };
+  }
+
+  const flag = name === "tmux" ? "-V" : "--version";
+  const r = spawnSync(name, [flag], { encoding: "utf-8" });
+
+  if (r.error) return { present: false };
+
+  const output = (r.stdout || "") + (r.stderr || "");
+  const match = output.match(/(\d+\.\d+(?:\.\d+)?)/);
+  return { present: true, version: match?.[1] };
+}
+
+export function cmdCheck(sub: string, _args: string[]): void {
+  if (sub !== "tools") {
+    console.log(`unknown subcommand: ${sub}`);
+    console.log("usage: maw check [tools]");
+    return;
+  }
+
+  const GREEN  = "\x1b[32m";
+  const RED    = "\x1b[31m";
+  const DIM    = "\x1b[90m";
+  const RESET  = "\x1b[0m";
+
+  const results: ToolStatus[] = TOOLS.map(t => ({ ...t, ...checkTool(t.name) }));
+  const reqResults  = results.filter(t => t.category === "required");
+  const optResults  = results.filter(t => t.category === "optional");
+  const missing     = results.filter(t => !t.present);
+
+  console.log("\nmaw check tools\n");
+
+  console.log("Required:");
+  for (const t of reqResults) {
+    if (t.present) {
+      const ver = t.version ? `  ${t.version}` : "";
+      console.log(`  ${GREEN}✓${RESET} ${t.name.padEnd(8)}${ver}`);
+    } else {
+      console.log(`  ${RED}✗${RESET} ${t.name.padEnd(8)}  ${DIM}not installed${RESET}`);
+    }
+  }
+
+  console.log("\nOptional (Python plugins):");
+  for (const t of optResults) {
+    if (t.present) {
+      const ver   = t.version ? `  ${t.version}` : "";
+      const notes = t.notes ? `  ${DIM}(${t.notes})${RESET}` : "";
+      console.log(`  ${GREEN}✓${RESET} ${t.name.padEnd(8)}${ver}${notes}`);
+    } else {
+      console.log(`  ${RED}✗${RESET} ${t.name.padEnd(8)}  ${DIM}not installed${RESET}`);
+    }
+  }
+
+  if (missing.length > 0) {
+    console.log("\nMissing:");
+    for (const t of missing) {
+      console.log(`  ${RED}✗${RESET} ${t.name.padEnd(16)}  ${tlink(t.installUrl)}`);
+    }
+  }
+
+  const reqOk  = reqResults.filter(t => t.present).length;
+  const optOk  = optResults.filter(t => t.present).length;
+  const misStr = missing.length > 0
+    ? `${RED}${missing.length} missing${RESET}`
+    : "0 missing";
+
+  console.log(`\n${reqOk} required ✓  ·  ${optOk} optional ✓  ·  ${misStr}`);
+  console.log();
+}

--- a/plugins/check/index.ts
+++ b/plugins/check/index.ts
@@ -1,0 +1,32 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdCheck } from "./impl";
+
+export const command = {
+  name: "check",
+  description: "Audit installed prep tools (ghq, gh, git, tmux, bun, uv, uvx)",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0] ?? "tools";
+    cmdCheck(sub, args.slice(1));
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/check/plugin.json
+++ b/plugins/check/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "check",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Audit installed prep tools (ghq, gh, git, tmux, bun, uv, uvx)",
+  "cli": {
+    "command": "check",
+    "help": "maw check [tools]   — audit installed prep tools",
+    "flags": {}
+  },
+  "weight": 30
+}

--- a/plugins/cleanup/index.ts
+++ b/plugins/cleanup/index.ts
@@ -1,0 +1,40 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdCleanupZombies } from "./internal/team-cleanup-zombies";
+
+export const command = {
+  name: "cleanup",
+  description: "Cleanup zombie agent panes.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    if (args.includes("--zombie-agents") || args.includes("--zombies")) {
+      await cmdCleanupZombies({ yes: args.includes("--yes") || args.includes("-y") });
+    } else {
+      logs.push("\x1b[36mmaw cleanup\x1b[0m \u2014 Cleanup utilities\n");
+      logs.push("  maw cleanup --zombie-agents [--yes]  Find and kill orphan zombie panes");
+      logs.push("  maw cleanup --zombies [--yes]        Alias for --zombie-agents\n");
+      logs.push("\x1b[90mWithout --yes, only lists zombies without killing them.\x1b[0m");
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -1,0 +1,116 @@
+import { readdirSync, existsSync } from "fs";
+import { join } from "path";
+import { tmux } from "../../../../sdk";
+import type { TmuxPane } from "../../../../sdk";
+import { loadFleetEntries } from "../../../shared/fleet-load";
+import { TEAMS_DIR, loadTeam } from "./team-helpers";
+
+// ─── maw cleanup --zombie-agents ───
+
+export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
+  console.log("\x1b[36mScanning tmux panes...\x1b[0m");
+
+  const allPanes = await tmux.listPanes();
+  const zombies = findZombiePanes(allPanes);
+
+  if (!zombies.length) {
+    console.log("\x1b[32m✓\x1b[0m No zombie agent panes found.");
+    return;
+  }
+
+  console.log(`\nFound \x1b[33m${zombies.length}\x1b[0m orphan claude pane(s):\n`);
+  for (const z of zombies) {
+    console.log(`  \x1b[33m${z.paneId}\x1b[0m  ${z.info}  \x1b[90m(team: ${z.teamName} — DELETED)\x1b[0m`);
+  }
+
+  if (!opts.yes) {
+    console.log(`\nRun with \x1b[36m--yes\x1b[0m to kill them.`);
+    return;
+  }
+
+  for (const z of zombies) {
+    await tmux.killPane(z.paneId);
+    console.log(`\x1b[32m✓\x1b[0m killed ${z.paneId}`);
+  }
+}
+
+interface ZombiePane {
+  paneId: string;
+  info: string;
+  teamName: string;
+}
+
+/**
+ * Find zombie panes: tmux panes running `claude` that are NOT part of any
+ * live team config AND NOT part of the fleet. Fleet-exclusion is critical
+ * — without it, every live fleet oracle would be flagged as a zombie.
+ */
+export function findZombiePanes(allPanes: TmuxPane[]): ZombiePane[] {
+  // Get all known team pane IDs from existing team configs
+  const knownTeamPaneIds = new Set<string>();
+  let teamDirs: string[] = [];
+  try {
+    teamDirs = readdirSync(TEAMS_DIR).filter(d =>
+      existsSync(join(TEAMS_DIR, d, "config.json"))
+    );
+  } catch { /* no teams dir */ }
+
+  for (const dir of teamDirs) {
+    const team = loadTeam(dir);
+    if (!team) continue;
+    for (const m of team.members) {
+      if (m.tmuxPaneId && m.tmuxPaneId !== "in-process" && m.tmuxPaneId !== "") {
+        knownTeamPaneIds.add(m.tmuxPaneId);
+      }
+    }
+  }
+
+  // Compute the set of fleet session names (e.g. "01-pulse", "08-mawjs").
+  // Any pane whose target starts with "<fleet-session>:" is a live fleet
+  // oracle and must NEVER be flagged as a zombie.
+  const fleetSessions = new Set<string>();
+  try {
+    for (const entry of loadFleetEntries()) {
+      fleetSessions.add(entry.file.replace(/\.json$/, ""));
+    }
+  } catch { /* no fleet dir */ }
+
+  // Also allow meta-view sessions (maw-view + any *-view) which mirror fleet
+  // panes. Each oracle creates its meta-view as `<stem>-view` (e.g.
+  // mawjs-view, mawui-view). #393 Bug F — zombie-auditor iter3 caught this:
+  // hardcoding only "maw-view" left every oracle's live pane one keystroke
+  // away from being killed by `maw cleanup --zombie-agents --yes`.
+  const isViewSession = (s: string) => s === "maw-view" || /-view$/.test(s);
+
+  // Defense-in-depth: also compute the set of pane ids that have ANY fleet
+  // (or view) listing. If the same pane id appears across multiple sessions
+  // (tmux-linked windows), a single safe target is enough to mark it safe.
+  // This protects against tmux reporting the non-fleet session as canonical.
+  const safePaneIds = new Set<string>();
+  for (const p of allPanes) {
+    const session = p.target.split(":")[0];
+    if (fleetSessions.has(session) || isViewSession(session)) {
+      safePaneIds.add(p.id);
+    }
+  }
+
+  const isFleetPane = (target: string): boolean => {
+    const session = target.split(":")[0];
+    return fleetSessions.has(session) || isViewSession(session);
+  };
+
+  // Find claude panes that are (a) not in any team config AND
+  // (b) not in the fleet/view (by either target OR any other listing of the same pane)
+  return allPanes
+    .filter(p =>
+      p.command?.includes("claude") &&
+      !knownTeamPaneIds.has(p.id) &&
+      !isFleetPane(p.target) &&
+      !safePaneIds.has(p.id)
+    )
+    .map(p => ({
+      paneId: p.id,
+      info: `${p.target}  "${(p.title || "").slice(0, 50)}"`,
+      teamName: "unknown",
+    }));
+}

--- a/plugins/cleanup/internal/team-helpers.ts
+++ b/plugins/cleanup/internal/team-helpers.ts
@@ -1,0 +1,108 @@
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+// Exported for testing — override with _setDirs
+export let TEAMS_DIR = join(homedir(), ".claude/teams");
+export let TASKS_DIR = join(homedir(), ".claude/tasks");
+
+/** @internal — for tests only */
+export function _setDirs(teams: string, tasks: string) {
+  TEAMS_DIR = teams;
+  TASKS_DIR = tasks;
+}
+
+export interface TeamMember {
+  name: string;
+  agentId?: string;
+  agentType?: string;
+  tmuxPaneId?: string;
+  color?: string;
+  model?: string;
+  backendType?: string;
+}
+
+export interface TeamConfig {
+  name: string;
+  description?: string;
+  members: TeamMember[];
+  createdAt?: number;
+}
+
+export function loadTeam(name: string): TeamConfig | null {
+  const configPath = join(TEAMS_DIR, name, "config.json");
+  if (!existsSync(configPath)) return null;
+  try { return JSON.parse(readFileSync(configPath, "utf-8")); }
+  catch { return null; }
+}
+
+/**
+ * Resolve ψ/ directory by walking UP from cwd looking for an oracle root
+ * (marked by CLAUDE.md + ψ/). Falls back to cwd/ψ for backward compat when
+ * no marker is found. Prevents rogue nested vaults when the CLI is run from
+ * a sub-directory (#393 — Bug A).
+ */
+export function resolvePsi(): string {
+  let dir = process.cwd();
+  // Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
+  while (true) {
+    const psi = join(dir, "ψ");
+    if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  // Fallback: legacy behavior — cwd/ψ, callers mkdir as needed
+  return join(process.cwd(), "ψ");
+}
+
+/**
+ * Write a shutdown_request message to a teammate's inbox file.
+ * This is the same protocol Claude Code uses internally via SendMessage.
+ */
+export function writeShutdownRequest(teamName: string, memberName: string, reason: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  const requestId = `shutdown-${Date.now()}@${memberName}`;
+  messages.push({
+    from: "maw-team-shutdown",
+    text: JSON.stringify({ type: "shutdown_request", reason, request_id: requestId }),
+    summary: `Shutdown request: ${reason}`,
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+/**
+ * Write a generic message to a teammate's inbox file.
+ * Same protocol as writeShutdownRequest but with type: "message".
+ */
+export function writeMessage(teamName: string, memberName: string, from: string, text: string): void {
+  const inboxPath = join(TEAMS_DIR, teamName, "inboxes", `${memberName}.json`);
+  let messages: any[] = [];
+  if (existsSync(inboxPath)) {
+    try { messages = JSON.parse(readFileSync(inboxPath, "utf-8")); } catch { messages = []; }
+  }
+  messages.push({
+    from,
+    text: JSON.stringify({ type: "message", content: text }),
+    summary: text.slice(0, 80),
+    timestamp: new Date().toISOString(),
+    read: false,
+  });
+  mkdirSync(join(TEAMS_DIR, teamName, "inboxes"), { recursive: true });
+  // lgtm[js/file-system-race] — PRIVATE-PATH: inbox under ~/.maw/teams/<team>/inboxes/, see docs/security/file-system-race-stance.md
+  writeFileSync(inboxPath, JSON.stringify(messages, null, 2));
+}
+
+export function cleanupTeamDir(name: string) {
+  const teamDir = join(TEAMS_DIR, name);
+  const tasksDir = join(TASKS_DIR, name);
+  if (existsSync(teamDir)) { try { rmSync(teamDir, { recursive: true }); } catch {} }
+  if (existsSync(tasksDir)) { try { rmSync(tasksDir, { recursive: true }); } catch {} }
+}

--- a/plugins/cleanup/plugin.json
+++ b/plugins/cleanup/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "cleanup",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Cleanup zombie agent panes.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "cleanup",
+    "aliases": [],
+    "help": "maw cleanup --zombie-agents [--yes] — Kill orphan zombie panes"
+  },
+  "weight": 50
+}

--- a/plugins/consent/index.ts
+++ b/plugins/consent/index.ts
@@ -1,0 +1,127 @@
+/**
+ * maw consent — CLI dispatcher (#644 Phase 1).
+ *
+ *   maw consent                          alias for `list`
+ *   maw consent list                     pending requests
+ *   maw consent approve <id> <pin>       approve + write trust
+ *   maw consent reject <id>              reject without trust
+ *   maw consent trust <peer> [action]    pre-approve (default action=hey)
+ *   maw consent untrust <peer> [action]  revoke trust entry
+ *   maw consent list-trust               show all trust entries
+ */
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import {
+  listPending, listTrust, recordTrust, removeTrust,
+  approveConsent, rejectConsent, type ConsentAction,
+} from "../../../core/consent";
+import { loadConfig } from "../../../config";
+
+const VALID_ACTIONS: ConsentAction[] = ["hey", "team-invite", "plugin-install"];
+
+function help(): string {
+  return [
+    "usage:",
+    "  maw consent                            list pending requests (alias for `list`)",
+    "  maw consent list                       list pending requests",
+    "  maw consent list-trust                 list approved trust entries",
+    "  maw consent approve <id> <pin>         approve a pending request",
+    "  maw consent reject <id>                reject a pending request",
+    "  maw consent trust <peer> [action]      pre-approve trust (default action=hey)",
+    "  maw consent untrust <peer> [action]    revoke trust entry",
+    "",
+    "actions: hey | team-invite | plugin-install",
+    "consent gating is opt-in via MAW_CONSENT=1 (Phase 1).",
+  ].join("\n");
+}
+
+function fmtPending(rows: ReturnType<typeof listPending>): string {
+  if (!rows.length) return "no pending consent requests";
+  const lines = ["id                        from → to             action            status   summary"];
+  for (const r of rows) {
+    const id = r.id.padEnd(24);
+    const fromTo = `${r.from} → ${r.to}`.padEnd(20);
+    const act = r.action.padEnd(16);
+    const st = r.status.padEnd(8);
+    const sum = r.summary.length > 50 ? r.summary.slice(0, 47) + "…" : r.summary;
+    lines.push(`${id}  ${fromTo}  ${act}  ${st}  ${sum}`);
+  }
+  return lines.join("\n");
+}
+
+function fmtTrust(rows: ReturnType<typeof listTrust>): string {
+  if (!rows.length) return "no trust entries";
+  const lines = ["from → to                action            approvedAt"];
+  for (const r of rows) {
+    const fromTo = `${r.from} → ${r.to}`.padEnd(22);
+    const act = r.action.padEnd(16);
+    lines.push(`${fromTo}  ${act}  ${r.approvedAt}`);
+  }
+  return lines.join("\n");
+}
+
+export const command = { name: "consent", description: "PIN-consent for cross-oracle actions (#644)." };
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+  const positional = args.filter(a => !a.startsWith("--"));
+
+  const sub = positional[0] ?? "list";
+
+  try {
+    if (sub === "list") {
+      return { ok: true, output: fmtPending(listPending()) };
+    }
+
+    if (sub === "list-trust") {
+      return { ok: true, output: fmtTrust(listTrust()) };
+    }
+
+    if (sub === "approve") {
+      const id = positional[1];
+      const pin = positional[2];
+      if (!id || !pin) return { ok: false, error: "usage: maw consent approve <id> <pin>" };
+      const r = await approveConsent(id, pin);
+      if (!r.ok) return { ok: false, error: r.error };
+      return { ok: true, output: `✅ approved ${id} — trust written for ${r.entry?.from} → ${r.entry?.to}:${r.entry?.action}` };
+    }
+
+    if (sub === "reject") {
+      const id = positional[1];
+      if (!id) return { ok: false, error: "usage: maw consent reject <id>" };
+      const r = rejectConsent(id);
+      if (!r.ok) return { ok: false, error: r.error };
+      return { ok: true, output: `✗ rejected ${id}` };
+    }
+
+    if (sub === "trust") {
+      const peer = positional[1];
+      const action = (positional[2] ?? "hey") as ConsentAction;
+      if (!peer) return { ok: false, error: "usage: maw consent trust <peer> [action]" };
+      if (!VALID_ACTIONS.includes(action)) return { ok: false, error: `unknown action '${action}' — expected: ${VALID_ACTIONS.join(", ")}` };
+      const myNode = loadConfig().node ?? "local";
+      recordTrust({
+        from: myNode, to: peer, action,
+        approvedAt: new Date().toISOString(), approvedBy: "human", requestId: null,
+      });
+      return { ok: true, output: `✅ trust written: ${myNode} → ${peer}:${action}` };
+    }
+
+    if (sub === "untrust") {
+      const peer = positional[1];
+      const action = (positional[2] ?? "hey") as ConsentAction;
+      if (!peer) return { ok: false, error: "usage: maw consent untrust <peer> [action]" };
+      if (!VALID_ACTIONS.includes(action)) return { ok: false, error: `unknown action '${action}'` };
+      const myNode = loadConfig().node ?? "local";
+      const removed = removeTrust(myNode, peer, action);
+      return { ok: true, output: removed ? `✗ removed: ${myNode} → ${peer}:${action}` : `(no trust entry for ${myNode} → ${peer}:${action})` };
+    }
+
+    if (sub === "help" || sub === "--help" || sub === "-h") {
+      return { ok: true, output: help() };
+    }
+
+    return { ok: false, error: `unknown subcommand: ${sub}\n\n${help()}` };
+  } catch (e: any) {
+    return { ok: false, error: e?.message ?? String(e) };
+  }
+}

--- a/plugins/consent/plugin.json
+++ b/plugins/consent/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "consent",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "PIN-consent for cross-oracle actions (#644 Phase 1 — gates `maw hey` when MAW_CONSENT=1).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "consent",
+    "aliases": [],
+    "help": "maw consent | list | approve <id> <pin> | reject <id> | trust <peer> [action] | untrust <peer> [action]"
+  },
+  "weight": 50
+}

--- a/plugins/contacts/contacts.test.ts
+++ b/plugins/contacts/contacts.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+import type { InvokeContext } from "../../../plugin/types";
+
+// Mock the contacts commands
+mock.module("./impl", () => ({
+  cmdContactsLs: async () => {
+    console.log("CONTACTS (2):");
+    console.log("  neo           maw: neo@white");
+  },
+  cmdContactsAdd: async (name: string, args: string[]) => {
+    console.log(`✓ contact ${name} saved`);
+  },
+  cmdContactsRm: async (name: string) => {
+    console.log(`✓ contact ${name} retired`);
+  },
+}));
+
+describe("contacts plugin", () => {
+  let handler: (ctx: InvokeContext) => Promise<any>;
+
+  beforeEach(async () => {
+    const mod = await import("./index");
+    handler = mod.default;
+  });
+
+  it("cli: ls subcommand lists contacts", async () => {
+    const result = await handler({ source: "cli", args: ["ls"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("CONTACTS");
+  });
+
+  it("cli: add subcommand adds a contact", async () => {
+    const result = await handler({ source: "cli", args: ["add", "neo", "--maw", "neo@white"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("neo saved");
+  });
+
+  it("cli: rm subcommand removes a contact", async () => {
+    const result = await handler({ source: "cli", args: ["rm", "neo"] });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("neo retired");
+  });
+
+  it("api GET: list contacts", async () => {
+    const result = await handler({ source: "api", args: { method: "GET" } });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("CONTACTS");
+  });
+
+  it("api POST: add contact", async () => {
+    const result = await handler({
+      source: "api",
+      args: { method: "POST", action: "add", name: "neo", transport: "neo@white" },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("neo saved");
+  });
+});

--- a/plugins/contacts/impl.ts
+++ b/plugins/contacts/impl.ts
@@ -1,0 +1,86 @@
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { loadConfig } from "../../../config";
+import { parseFlags } from "../../../cli/parse-args";
+
+interface Contact {
+  maw?: string;
+  thread?: string;
+  inbox?: string | null;
+  repo?: string | null;
+  notes?: string;
+  retired?: boolean;
+}
+
+interface ContactsFile {
+  contacts: Record<string, Contact>;
+  updated: string;
+}
+
+function resolvePsiPath(): string {
+  const config = loadConfig();
+  if (config.psiPath) return config.psiPath;
+  const cwd = process.cwd();
+  if (existsSync(join(cwd, "ψ"))) return join(cwd, "ψ");
+  return join(cwd, "psi");
+}
+
+function loadContacts(): ContactsFile {
+  const path = join(resolvePsiPath(), "contacts.json");
+  if (!existsSync(path)) return { contacts: {}, updated: new Date().toISOString() };
+  return JSON.parse(readFileSync(path, "utf-8"));
+}
+
+function saveContacts(data: ContactsFile) {
+  const psi = resolvePsiPath();
+  mkdirSync(psi, { recursive: true });
+  data.updated = new Date().toISOString();
+  writeFileSync(join(psi, "contacts.json"), JSON.stringify(data, null, 2) + "\n");
+}
+
+export async function cmdContactsLs() {
+  const { contacts } = loadContacts();
+  const active = Object.entries(contacts).filter(([, c]) => !c.retired);
+  if (!active.length) { console.log("\x1b[90mno contacts\x1b[0m"); return; }
+  console.log(`\n\x1b[36mCONTACTS\x1b[0m (${active.length}):\n`);
+  for (const [name, c] of active) {
+    const maw = c.maw ? `maw: \x1b[33m${c.maw}\x1b[0m` : "";
+    const thread = c.thread ? `thread: \x1b[90m${c.thread}\x1b[0m` : "";
+    const inbox = c.inbox ? `inbox: \x1b[90m${c.inbox}\x1b[0m` : "";
+    const repo = c.repo ? `repo: \x1b[90m${c.repo}\x1b[0m` : "";
+    const notes = c.notes ? `\x1b[90m"${c.notes}"\x1b[0m` : "";
+    const parts = [maw, thread, inbox, repo, notes].filter(Boolean).join("    ");
+    console.log(`  \x1b[32m${name.padEnd(12)}\x1b[0m  ${parts}`);
+  }
+  console.log();
+}
+
+export async function cmdContactsAdd(name: string, args: string[]) {
+  const data = loadContacts();
+  const c: Contact = data.contacts[name] || {};
+  const flags = parseFlags(args, {
+    "--maw": String,
+    "--thread": String,
+    "--inbox": String,
+    "--repo": String,
+    "--notes": String,
+  }, 0);
+  if (flags["--maw"]) c.maw = flags["--maw"];
+  if (flags["--thread"]) c.thread = flags["--thread"];
+  if (flags["--inbox"]) c.inbox = flags["--inbox"];
+  if (flags["--repo"]) c.repo = flags["--repo"];
+  if (flags["--notes"]) c.notes = flags["--notes"];
+  if (c.retired) delete c.retired;
+  data.contacts[name] = c;
+  saveContacts(data);
+  console.log(`\x1b[32m✓\x1b[0m contact \x1b[33m${name}\x1b[0m saved`);
+}
+
+export async function cmdContactsRm(name: string) {
+  const data = loadContacts();
+  if (!data.contacts[name]) { console.error(`\x1b[31merror\x1b[0m: contact '${name}' not found`); return; }
+  data.contacts[name].retired = true;
+  saveContacts(data);
+  console.log(`\x1b[32m✓\x1b[0m contact \x1b[33m${name}\x1b[0m retired`);
+}

--- a/plugins/contacts/index.ts
+++ b/plugins/contacts/index.ts
@@ -1,0 +1,62 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdContactsLs, cmdContactsAdd, cmdContactsRm } from "./impl";
+
+export const command = {
+  name: ["contacts", "contact"],
+  description: "Manage oracle contacts — add, remove, list",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const sub = args[0]?.toLowerCase();
+      if (sub === "add" && args[1]) {
+        await cmdContactsAdd(args[1], args.slice(2));
+      } else if (sub === "rm" || sub === "remove") {
+        if (!args[1]) { logs.push("usage: maw contacts rm <name>"); return { ok: false, error: "name required" }; }
+        await cmdContactsRm(args[1]);
+      } else {
+        await cmdContactsLs();
+      }
+    } else if (ctx.source === "api") {
+      const body = ctx.args as Record<string, unknown>;
+      const method = body.method as string | undefined;
+      if (!method || method === "GET") {
+        await cmdContactsLs();
+      } else if (method === "POST") {
+        const action = body.action as string;
+        const name = body.name as string;
+        if (!name) return { ok: false, error: "name required" };
+        if (action === "add") {
+          const transport = body.transport as string | undefined;
+          await cmdContactsAdd(name, transport ? ["--maw", transport] : []);
+        } else if (action === "rm") {
+          await cmdContactsRm(name);
+        } else {
+          return { ok: false, error: `unknown action: ${action}` };
+        }
+      }
+    } else {
+      await cmdContactsLs();
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/contacts/plugin.json
+++ b/plugins/contacts/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "contacts",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Manage oracle contacts — add, remove, list",
+  "cli": {
+    "command": "contacts",
+    "aliases": [
+      "contact"
+    ],
+    "help": "maw contacts [ls|add|rm] [name] [transport]"
+  },
+  "api": {
+    "path": "/api/contacts",
+    "methods": [
+      "GET",
+      "POST"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/doctor/cross-source-detect.ts
+++ b/plugins/doctor/cross-source-detect.ts
@@ -1,0 +1,200 @@
+/**
+ * doctor/cross-source-detect.ts — Sub-PR 2 of #841.
+ *
+ * Cross-source consistency analysis over `OracleManifest` (#838). Unlike
+ * `peers/duplicate-detect.ts` (#810) which scans the peer cache for
+ * `<oracle>:<node>` collisions, this layer asks a different question:
+ *
+ *   "For each oracle the manifest knows about, do the 5 registries AGREE
+ *    enough that runtime paths (federation routing, awake state, fleet
+ *    bring-up) will work?"
+ *
+ * Underlying fact: `loadConfig()` already auto-merges fleet windows into
+ * `config.agents` at load time (src/config/fleet-merge.ts). So a fleet
+ * window without an `agent` source label is rare on a healthy box — but
+ * an `agent` entry without a backing fleet window IS common when
+ * operators hand-edit `maw.config.json` ahead of registering the fleet,
+ * or after deleting a fleet json without cleaning the agent map.
+ *
+ * Pure: takes a manifest snapshot, returns a list of warnings. No fs, no
+ * network. The doctor surface adapts findings into the existing
+ * `DoctorResult["checks"]` shape; tests can drive `findGaps()` directly.
+ *
+ * Severity philosophy
+ * ───────────────────
+ * Every gap is a WARNING, not a hard failure — operators legitimately keep
+ * registries partly aligned during migrations (e.g. budding a new oracle
+ * into `config.sessions` before its filesystem checkout exists). The
+ * doctor entry returns `ok:true` in all cases; the message body counts
+ * the gaps. Gating on `ok:false` here would force operators into
+ * `--allow-drift` for normal mid-migration states, defeating the purpose.
+ */
+
+import type { OracleManifestEntry } from "../../../lib/oracle-manifest";
+
+/** One inconsistency flagged across the 5 registries for a single oracle. */
+export interface CrossSourceGap {
+  /** Oracle short name. */
+  oracle: string;
+  /** Stable category — drives test assertions and message templating. */
+  kind:
+    | "agent-without-fleet"
+    | "session-without-fleet"
+    | "fleet-without-oracles-json"
+    | "oracles-json-without-runtime"
+    | "agent-mismatch-fleet-local";
+  /** Human-readable hint (one sentence). */
+  detail: string;
+}
+
+/**
+ * Walk the manifest and surface each gap pattern. Pure — feed it the
+ * output of `loadManifestCached()` (or a hand-built fixture in tests).
+ *
+ * Patterns flagged:
+ *
+ *   1. agent-without-fleet
+ *      `agent` source present, `fleet` absent, AND node === "local".
+ *      An operator-added entry pointing to local with no fleet window
+ *      backing it; `maw hey <name>` will think it's local but find no
+ *      tmux session to wake.
+ *
+ *   2. session-without-fleet
+ *      `session` source present, `fleet` absent, no `agent` either —
+ *      a budded oracle whose Claude session UUID was recorded but no
+ *      fleet window was ever registered. This is the "just-budded but
+ *      not yet wired" state; usually transient but worth surfacing.
+ *
+ *   3. fleet-without-oracles-json
+ *      `fleet` source present, `oracles-json` absent, AND no
+ *      `localPath`. Indicates the registry cache (`oracles.json`) is
+ *      stale relative to fleet; `maw oracle scan` will reconcile.
+ *
+ *   4. oracles-json-without-runtime
+ *      Only `oracles-json` source. Filesystem-discovered oracle that
+ *      no fleet/session/agent registry references. Either an orphan
+ *      checkout (clone exists, never wired up) or a stale cache entry
+ *      pointing at a deleted directory.
+ *
+ *   5. agent-mismatch-fleet-local
+ *      `fleet` AND `agent` both present, but `agent` says a remote
+ *      node while fleet implies "local". Federation routing will
+ *      prefer the agent value (#736 precedence), so a `maw hey` will
+ *      go remote even though there's a local fleet window — almost
+ *      certainly a misconfigured agents map after a node migration.
+ */
+export function findGaps(manifest: OracleManifestEntry[]): CrossSourceGap[] {
+  const gaps: CrossSourceGap[] = [];
+  for (const e of manifest) {
+    const has = (s: string) => e.sources.includes(s as OracleManifestEntry["sources"][number]);
+    const hasFleet = has("fleet");
+    const hasSession = has("session");
+    const hasAgent = has("agent");
+    const hasOraclesJson = has("oracles-json");
+
+    // 1. agent-without-fleet — operator-added agent map entry pointing
+    //    "local" but no fleet window to back it. Pure agent entries that
+    //    point to a remote node are a normal federation routing setup
+    //    (no fleet expected on the local box), so we only flag the
+    //    `local`-typed ones to avoid false positives.
+    if (hasAgent && !hasFleet && e.node === "local") {
+      gaps.push({
+        oracle: e.name,
+        kind: "agent-without-fleet",
+        detail:
+          `config.agents has '${e.name}' → 'local' but no fleet window registered — ` +
+          `'maw hey ${e.name}' will fail to wake. Run 'maw fleet --init-agents' or remove the entry.`,
+      });
+    }
+
+    // 2. session-without-fleet — Claude session UUID without fleet/agent
+    //    registration. Budded-but-not-wired state.
+    if (hasSession && !hasFleet && !hasAgent) {
+      gaps.push({
+        oracle: e.name,
+        kind: "session-without-fleet",
+        detail:
+          `config.sessions has '${e.name}' but no fleet window or agent route — ` +
+          `oracle is unreachable. Register a fleet window or remove the session.`,
+      });
+    }
+
+    // 3. fleet-without-oracles-json — fleet registered but registry
+    //    cache hasn't seen it (no oracles-json source AND no localPath).
+    //    Pure-fleet entries with localPath happen via routed-only setups
+    //    where the operator legitimately has no checkout — only flag
+    //    when there's no cache record AND the manifest didn't surface
+    //    a path from anywhere.
+    if (hasFleet && !hasOraclesJson && !e.localPath) {
+      gaps.push({
+        oracle: e.name,
+        kind: "fleet-without-oracles-json",
+        detail:
+          `fleet has '${e.name}' but oracles.json has no record and no local checkout known — ` +
+          `run 'maw oracle scan' to refresh.`,
+      });
+    }
+
+    // 4. oracles-json-without-runtime — filesystem-only oracle, no
+    //    fleet/session/agent. Orphan checkout or stale cache.
+    if (hasOraclesJson && !hasFleet && !hasSession && !hasAgent) {
+      gaps.push({
+        oracle: e.name,
+        kind: "oracles-json-without-runtime",
+        detail:
+          `oracles.json lists '${e.name}' but no fleet window, session, or agent route — ` +
+          `orphan checkout or stale cache. Wake it once or remove the directory.`,
+      });
+    }
+
+    // 5. agent-mismatch-fleet-local — both fleet and agent contributed,
+    //    but the resolved node is NOT "local". Federation will route
+    //    away from the local fleet window. We detect this by looking
+    //    for entries that have fleet AND a non-local node — fleet's
+    //    own contribution would have left node === "local".
+    if (hasFleet && hasAgent && e.node && e.node !== "local") {
+      gaps.push({
+        oracle: e.name,
+        kind: "agent-mismatch-fleet-local",
+        detail:
+          `fleet window for '${e.name}' is local but config.agents points at '${e.node}' — ` +
+          `federation will route away from local. Reconcile with 'maw fleet --init-agents' or fix the agent map.`,
+      });
+    }
+  }
+  // Stable order: by oracle name, then kind — keeps test assertions
+  // and human-readable diff output deterministic.
+  gaps.sort((a, b) =>
+    a.oracle === b.oracle ? a.kind.localeCompare(b.kind) : a.oracle.localeCompare(b.oracle),
+  );
+  return gaps;
+}
+
+/**
+ * Format one gap as a single-line warning suitable for `maw doctor` output.
+ * Caller wraps with color codes per its own log surface.
+ */
+export function formatGap(g: CrossSourceGap): string {
+  return `[${g.kind}] ${g.detail}`;
+}
+
+/**
+ * Aggregate all gaps into a single doctor message body. Returns a tuple of
+ * `(headline, lines)` so the doctor renderer can do one-line-per-gap output
+ * while still surfacing a compact `message` field on the check result.
+ */
+export function summarizeGaps(gaps: CrossSourceGap[]): { headline: string; lines: string[] } {
+  if (gaps.length === 0) {
+    return { headline: "no cross-source inconsistencies", lines: [] };
+  }
+  const byKind = new Map<string, number>();
+  for (const g of gaps) byKind.set(g.kind, (byKind.get(g.kind) ?? 0) + 1);
+  const breakdown = [...byKind.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, n]) => `${k}×${n}`)
+    .join(", ");
+  return {
+    headline: `${gaps.length} cross-source ${gaps.length === 1 ? "gap" : "gaps"} (${breakdown})`,
+    lines: gaps.map(formatGap),
+  };
+}

--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -1,0 +1,288 @@
+import { existsSync, readFileSync, readlinkSync } from "fs";
+import { execSync } from "child_process";
+import { homedir } from "os";
+import { join, dirname, resolve } from "path";
+import { loadPeers } from "./internal/peers-store";
+import { findDuplicateIdentities, formatDuplicate } from "./internal/duplicate-detect";
+import { loadConfig } from "../../../config";
+import { C } from "../../shared/fleet-doctor-fixer";
+import { loadManifestCached, invalidateManifest } from "../../../lib/oracle-manifest";
+import { findGaps, summarizeGaps } from "./cross-source-detect";
+
+export interface DoctorResult {
+  ok: boolean;
+  checks: Array<{ name: string; ok: boolean; message: string }>;
+}
+
+export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
+  const flags = new Set(args.filter(a => a.startsWith("--")));
+  const positional = args.filter(a => !a.startsWith("--"));
+  const only = positional[0];
+  const allowDrift = flags.has("--allow-drift");
+  const checks: DoctorResult["checks"] = [];
+
+  if (!only || only === "install" || only === "all") {
+    checks.push(await checkInstall());
+  }
+  if (!only || only === "version" || only === "all") {
+    const vChecks = await checkVersionDrift();
+    for (const c of vChecks) checks.push(c);
+  }
+  if (!only || only === "peers" || only === "all") {
+    checks.push(checkPeerDuplicates());
+  }
+  if (!only || only === "manifest" || only === "all") {
+    checks.push(checkCrossSourceConsistency());
+  }
+
+  const hardOk = checks.every(c => c.ok);
+  const onlyDriftFails = !hardOk && checks.every(c => c.ok || c.name.startsWith("version:"));
+  const ok = hardOk || (allowDrift && onlyDriftFails);
+  renderResults(checks, ok);
+  return { ok, checks };
+}
+
+async function checkInstall(): Promise<{ name: string; ok: boolean; message: string }> {
+  const binPath = join(homedir(), ".bun/bin/maw");
+  const exists = existsSync(binPath);
+  if (!exists) {
+    console.log(`  ${C.yellow}⚠${C.reset} maw binary missing at ${binPath}`);
+    console.log(`  ${C.gray}attempting reinstall…${C.reset}`);
+    try {
+      execSync("bun add -g github:Soul-Brews-Studio/maw-js", { stdio: "inherit" });
+      const nowExists = existsSync(binPath);
+      return {
+        name: "install",
+        ok: nowExists,
+        message: nowExists
+          ? "reinstalled from github:Soul-Brews-Studio/maw-js"
+          : "reinstall did not produce the binary — manual intervention needed",
+      };
+    } catch (e: any) {
+      return { name: "install", ok: false, message: `reinstall failed: ${e.message || e}` };
+    }
+  }
+  try {
+    const link = readlinkSync(binPath);
+    const abs = link.startsWith("/") ? link : resolve(dirname(binPath), link);
+    if (!existsSync(abs)) {
+      return { name: "install", ok: false, message: `binary is a broken symlink → ${abs}` };
+    }
+  } catch { /* not a symlink — that's fine */ }
+  return { name: "install", ok: true, message: "maw binary present and resolvable" };
+}
+
+/**
+ * Version drift: compare source package.json version to each running maw
+ * process's `/info` endpoint version (#638). MVP covers pm2 only.
+ *
+ * Returns a list (one per running maw, or a single synthetic entry when
+ * pm2/source lookup fails). Drift → ok:false; exit code gating lives in
+ * cmdDoctor via the --allow-drift flag.
+ */
+async function checkVersionDrift(): Promise<DoctorResult["checks"]> {
+  const source = readSourceVersion();
+  if (!source) {
+    return [{ name: "version:source", ok: false, message: "could not read package.json version" }];
+  }
+
+  const procs = listPm2MawProcs();
+  if (procs === null) {
+    return [{ name: "version:pm2", ok: true, message: `pm2 unavailable — source ${source} (no running maw to compare)` }];
+  }
+  if (procs.length === 0) {
+    return [{ name: "version:pm2", ok: true, message: `no running maw — source ${source}` }];
+  }
+
+  const results: DoctorResult["checks"] = [];
+  for (const p of procs) {
+    const port = p.port ?? defaultPort();
+    const label = `version:${p.name}${p.pmId != null ? `#${p.pmId}` : ""}`;
+    try {
+      const running = await fetchInfoVersion(port);
+      if (running === null) {
+        results.push({ name: label, ok: false, message: `unreachable at :${port} — source ${source}` });
+      } else if (running === source) {
+        results.push({ name: label, ok: true, message: `aligned (${source}) :${port}` });
+      } else {
+        results.push({ name: label, ok: false, message: `drift — running ${running}, source ${source} :${port}` });
+      }
+    } catch (e: any) {
+      results.push({ name: label, ok: false, message: `probe failed: ${e?.message || e} :${port}` });
+    }
+  }
+  return results;
+}
+
+function readSourceVersion(): string | null {
+  try {
+    const pkgPath = join(import.meta.dir, "..", "..", "..", "..", "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultPort(): number {
+  const envPort = Number(process.env.MAW_PORT);
+  return Number.isFinite(envPort) && envPort > 0 ? envPort : 3456;
+}
+
+interface Pm2Proc {
+  name: string;
+  pmId?: number;
+  port?: number;
+}
+
+function listPm2MawProcs(): Pm2Proc[] | null {
+  let raw: string;
+  try {
+    raw = execSync("pm2 jlist 2>/dev/null", { encoding: "utf-8" });
+  } catch {
+    return null;
+  }
+  let procs: any[];
+  try {
+    procs = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(procs)) return [];
+  const out: Pm2Proc[] = [];
+  for (const p of procs) {
+    if (!p || typeof p.name !== "string") continue;
+    if (p.name !== "maw" && !p.name.startsWith("maw-")) continue;
+    const env = p.pm2_env?.env || p.pm2_env || {};
+    const envPort = Number(env?.MAW_PORT ?? env?.PORT);
+    out.push({
+      name: p.name,
+      pmId: typeof p.pm_id === "number" ? p.pm_id : undefined,
+      port: Number.isFinite(envPort) && envPort > 0 ? envPort : undefined,
+    });
+  }
+  return out;
+}
+
+/**
+ * Peer cache duplicate `<oracle>:<node>` check (#804 Step 3).
+ *
+ * Loads `~/.maw/peers.json` (or `$PEERS_FILE` in tests) plus the local
+ * `(oracle, node)` from config and reports any collisions. This is a
+ * read-only check — duplicates surface as a `peers:duplicates` line with
+ * `ok:false` so the doctor exits non-zero, but we never auto-prune.
+ *
+ * Empty cache, missing-identity peers, and zero-collisions all return
+ * `ok:true`. Any peer without an `identity` field is silently skipped (legacy
+ * peers from pre-Step-3 captures — re-probing them via `maw peers probe`
+ * will populate identity and bring them under the dedup umbrella).
+ */
+function checkPeerDuplicates(): DoctorResult["checks"][number] {
+  let peers: Record<string, import("./internal/peers-store").Peer> = {};
+  try {
+    peers = loadPeers().peers;
+  } catch (e: any) {
+    return {
+      name: "peers:duplicates",
+      ok: true,
+      message: `peer cache unreadable (${e?.message || e}) — skipping dedup check`,
+    };
+  }
+
+  let local: { oracle: string; node: string } | undefined;
+  try {
+    const cfg = loadConfig();
+    if (cfg.node) {
+      local = { oracle: cfg.oracle ?? "mawjs", node: cfg.node };
+    }
+  } catch {
+    // Config unreadable in this environment — skip the local-vs-cache check
+    // but still scan peer-vs-peer collisions below.
+  }
+
+  const dups = findDuplicateIdentities(peers, local);
+  if (dups.length === 0) {
+    const n = Object.keys(peers).length;
+    return {
+      name: "peers:duplicates",
+      ok: true,
+      message: n === 0
+        ? "no peers cached"
+        : `no <oracle>:<node> collisions across ${n} peer${n === 1 ? "" : "s"}`,
+    };
+  }
+  return {
+    name: "peers:duplicates",
+    ok: false,
+    message: dups.map(formatDuplicate).join("; "),
+  };
+}
+
+/**
+ * Cross-source consistency via OracleManifest (Sub-PR 2 of #841).
+ *
+ * Loads the unified manifest (#838 — fleet, sessions, agents, oracles.json)
+ * and runs `findGaps()` over it to surface inconsistencies between the
+ * registries. All gaps are warnings, never hard failures: operators
+ * legitimately keep registries partly aligned during migrations, so
+ * gating exit codes on these would force `--allow-drift` for normal
+ * mid-flight states. Surface as `ok:true` with a message body that
+ * counts the gaps and breaks them down by kind; the per-gap detail
+ * lines are written to console for human inspection.
+ *
+ * Uses `loadManifestCached()` so this check shares the in-process
+ * manifest with any other consumer running in the same `maw doctor`
+ * invocation. We invalidate first to avoid serving a stale view if
+ * `loadConfig`-touching work happened earlier in the same process.
+ */
+function checkCrossSourceConsistency(): DoctorResult["checks"][number] {
+  let gaps: ReturnType<typeof findGaps>;
+  try {
+    invalidateManifest();
+    const manifest = loadManifestCached();
+    gaps = findGaps(manifest);
+  } catch (e: any) {
+    return {
+      name: "manifest:cross-source",
+      ok: true,
+      message: `manifest unreadable (${e?.message || e}) — skipping cross-source check`,
+    };
+  }
+
+  const { headline, lines } = summarizeGaps(gaps);
+  for (const line of lines) {
+    console.log(`    ${C.yellow}⚠${C.reset} ${line}`);
+  }
+  return {
+    name: "manifest:cross-source",
+    ok: true,
+    message: headline,
+  };
+}
+
+async function fetchInfoVersion(port: number): Promise<string | null> {
+  try {
+    const res = await fetch(`http://localhost:${port}/info`, { signal: AbortSignal.timeout(2000) });
+    if (!res.ok) return null;
+    const body: any = await res.json();
+    return typeof body?.version === "string" ? body.version : null;
+  } catch {
+    return null;
+  }
+}
+
+function renderResults(checks: DoctorResult["checks"], ok: boolean): void {
+  console.log("");
+  console.log(`  ${ok ? C.green + "✓" : C.red + "✗"} maw doctor${C.reset}`);
+  for (const c of checks) {
+    const icon = iconFor(c);
+    console.log(`    ${icon} ${c.name}${C.reset}: ${c.message}`);
+  }
+  console.log("");
+}
+
+function iconFor(c: { name: string; ok: boolean; message: string }): string {
+  if (c.ok) return C.green + "✓";
+  if (c.name.startsWith("version:") && c.message.startsWith("drift")) return C.yellow + "⚠";
+  return C.red + "✗";
+}

--- a/plugins/doctor/index.ts
+++ b/plugins/doctor/index.ts
@@ -1,0 +1,41 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdDoctor } from "./impl";
+
+export const command = {
+  name: "doctor",
+  description: "Diagnostic checks — verifies maw install health and auto-heals when possible.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let args: string[] = [];
+    if (ctx.source === "cli") {
+      args = ctx.args as string[];
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      if (typeof a.check === "string") args = [a.check];
+    }
+    const result = await cmdDoctor(args);
+    return {
+      ok: result.ok,
+      output: logs.join("\n") || undefined,
+      error: result.ok ? undefined : "one or more checks failed",
+    };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/doctor/internal/duplicate-detect.ts
+++ b/plugins/doctor/internal/duplicate-detect.ts
@@ -1,0 +1,104 @@
+/**
+ * peers/duplicate-detect.ts — #804 Step 3.
+ *
+ * Pure logic that scans the peer cache for duplicate `<oracle>:<node>` claims.
+ * Two peers in `peers.json` advertising the same `(oracle, node)` pair is
+ * almost certainly operator confusion — typically a copy-pasted alias setup,
+ * a forgotten `maw peers remove` after a node migration, or a fleet split-
+ * brain where the same identity got TOFU'd from two different URLs.
+ *
+ * Per ADR docs/federation/0001-peer-identity.md ("Crypto solves can't-fake;
+ * doctor + boot-time check solves operator confusion") — this layer does NOT
+ * refuse anything. It surfaces collisions; the operator decides whether to
+ * `maw peers remove` the loser, rename a node, or accept (multi-oracle on a
+ * single node, where the *oracle* names differ even though the *node* is one
+ * physical machine, is fine and won't trigger this — the key is the full
+ * `<oracle>:<node>` pair).
+ *
+ * Pure: no fs, no network. Caller passes in the peer set + optional local
+ * identity. That makes the module trivial to test and lets both the doctor
+ * subsystem and the `maw serve` startup hook reuse the same code path.
+ */
+import type { Peer } from "./peers-store";
+
+/** A single collision: two-or-more peers (or local + peers) sharing one key. */
+export interface DuplicateClaim {
+  /** Canonical `<oracle>:<node>` key the peers collide on. */
+  key: string;
+  /** All claimants — alias `"<local>"` is the running maw process itself. */
+  claimants: Array<{ alias: string; url?: string }>;
+}
+
+/**
+ * Build the map of `<oracle>:<node>` → claimants.
+ *
+ * Peers without an `identity` field are skipped (legacy peers; their oracle
+ * may differ from "mawjs" silently — surfacing them as collisions would be
+ * a false-positive against pre-Step-1 nodes that simply haven't been probed
+ * since the upgrade).
+ *
+ * The local identity is included as alias `"<local>"` so the boot-time check
+ * can spot "this maw IS something I'm also calling a peer" (often happens
+ * when an operator copy-pastes a federation snippet on the wrong machine).
+ */
+export function findDuplicateIdentities(
+  peers: Record<string, Peer>,
+  local?: { oracle: string; node: string },
+): DuplicateClaim[] {
+  const groups = new Map<string, Array<{ alias: string; url?: string }>>();
+
+  if (local) {
+    const localKey = `${local.oracle}:${local.node}`;
+    groups.set(localKey, [{ alias: "<local>" }]);
+  }
+
+  for (const [alias, peer] of Object.entries(peers)) {
+    if (!peer?.identity) continue;
+    const { oracle, node } = peer.identity;
+    if (!oracle || !node) continue;
+    const key = `${oracle}:${node}`;
+    const arr = groups.get(key) ?? [];
+    arr.push({ alias, url: peer.url });
+    groups.set(key, arr);
+  }
+
+  const dups: DuplicateClaim[] = [];
+  for (const [key, claimants] of groups) {
+    if (claimants.length >= 2) dups.push({ key, claimants });
+  }
+  // Stable order: by key, alphabetically.
+  dups.sort((a, b) => a.key.localeCompare(b.key));
+  return dups;
+}
+
+/**
+ * Format a one-line warning suitable for `maw doctor` output OR a `maw serve`
+ * startup log. Caller wraps in colors per its own log surface.
+ */
+export function formatDuplicate(d: DuplicateClaim): string {
+  const tail = d.claimants
+    .map(c => (c.url ? `${c.alias} (${c.url})` : c.alias))
+    .join(", ");
+  return `duplicate <oracle>:<node> claim "${d.key}" — ${tail}`;
+}
+
+/**
+ * Boot-time hook used by `startServer()`. Loads the peer cache + the
+ * caller-supplied local identity, then writes a YELLOW warning per
+ * collision via `console.warn`. Never throws — boot must continue per ADR.
+ *
+ * Returns the duplicates list so tests / callers can assert on it.
+ */
+export function warnDuplicatesAtBoot(args: {
+  peers: Record<string, Peer>;
+  local?: { oracle: string; node: string };
+  log?: (msg: string) => void;
+}): DuplicateClaim[] {
+  const log = args.log ?? ((m: string) => console.warn(m));
+  const dups = findDuplicateIdentities(args.peers, args.local);
+  for (const d of dups) {
+    log(`\x1b[33m⚠ ${formatDuplicate(d)}\x1b[0m`);
+    log(`\x1b[33m  investigate with \`maw peers list\` and \`maw peers remove <alias>\` if stale.\x1b[0m`);
+  }
+  return dups;
+}

--- a/plugins/doctor/internal/lock.ts
+++ b/plugins/doctor/internal/lock.ts
@@ -1,0 +1,78 @@
+/**
+ * maw peers — file lock for concurrent writers (#572 nit 3).
+ *
+ * Mirrors the pattern in src/cli/update-lock.ts: O_EXCL create on a
+ * sibling `.lock` file, write our pid, retry on EEXIST. If the holder
+ * pid is gone (kill -0 → ESRCH) we steal the lock immediately rather
+ * than waiting out the timeout. Synchronous (no await) so it composes
+ * with the existing sync savePeers signature without a contract change.
+ *
+ * Sized for CLI use: 5s deadline, 50ms poll. peers.json writes are
+ * sub-millisecond, so racing CLIs almost always succeed on first try.
+ */
+import { openSync, closeSync, unlinkSync, writeSync, readSync, existsSync } from "fs";
+
+const DEADLINE_MS = 5_000;
+const POLL_MS = 50;
+
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin — short waits only */ }
+}
+
+/** Run fn() while holding an exclusive lock on `<path>.lock`. Synchronous. */
+export function withPeersLock<T>(path: string, fn: () => T): T {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + DEADLINE_MS;
+  let fd: number | null = null;
+
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx"); // O_CREAT | O_EXCL
+      // fd-based write — prevents path-TOCTOU symlink swap between open and write.
+      // See #562 / #581 (exemplar fix in src/cli/update-lock.ts).
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      // fd-based read for the same TOCTOU reason as the write above.
+      // Fixed 64-byte buffer — PIDs are ≤20 digits on every supported OS, so
+      // no fstatSync needed (also avoids the CodeQL "stat-then-read" pattern).
+      let holderPid = NaN;
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(lockPath, "r");
+        const buf = Buffer.alloc(64);
+        const n = readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
+      } catch { /* empty/racy — treat as stale */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      if (!isAlive(holderPid)) {
+        try { unlinkSync(lockPath); } catch { /* race with another stealer is fine */ }
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`peers lock timeout: pid ${holderPid} still holds ${lockPath}`);
+      }
+      sleepSync(POLL_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
+    try { if (existsSync(lockPath)) unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+}

--- a/plugins/doctor/internal/peers-store.ts
+++ b/plugins/doctor/internal/peers-store.ts
@@ -1,0 +1,190 @@
+/**
+ * maw peers — storage layer (#568, #572).
+ *
+ * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
+ * and rename(2) so a crash mid-write leaves either the old file intact
+ * or the new file fully in place — never a truncated file. A stale tmp
+ * file from a crashed previous write is cleaned on load (the live file
+ * is still valid; the tmp is leftover from a crashed writer).
+ *
+ * Schema v1:
+ *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen,
+ *                                     [lastError, nickname, pubkey, pubkeyFirstSeen,
+ *                                      identity] } } }
+ *   — fields in brackets are optional. `pubkey` / `pubkeyFirstSeen` were
+ *   added in #804 Step 2 for TOFU peer-identity pinning. `identity` was
+ *   added in #804 Step 3 to capture the peer's self-reported `<oracle>:<node>`
+ *   pair for duplicate-detection (doctor + boot-time warn).
+ *
+ * Path resolution is a function (not a const) so tests can override
+ * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ *
+ * Concurrency: savePeers takes a short-lived file lock around the
+ * read-modify-write critical section so concurrent `maw peers add`
+ * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
+ *
+ * Corruption: if the live file fails to parse, OR if it parses but
+ * the shape is wrong (e.g. `{"peers":[]}` — array instead of object),
+ * we rename it aside to `peers.json.corrupt-<ISO>` and start fresh —
+ * non-destructive, with an audit trail (#572 nit 1, follow-up to #579).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { withPeersLock } from "./lock";
+
+/**
+ * Structured last-probe failure — opt-in field on Peer (#565).
+ *
+ * Absent (undefined) means either the peer has never been probed, or
+ * the most recent probe succeeded. Readers that don't know about this
+ * field continue to work — schema v1 is unchanged.
+ */
+export interface LastError {
+  /** Classified code — see probe.ts classifyProbeError(). */
+  code: "DNS" | "REFUSED" | "TIMEOUT" | "TLS" | "HTTP_4XX" | "HTTP_5XX" | "BAD_BODY" | "UNKNOWN";
+  /** Raw error message (from err.message or synthesized for HTTP cases). */
+  message: string;
+  /** ISO timestamp when the failure was recorded. */
+  at: string;
+}
+
+export interface Peer {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+  /** Optional — set by probePeer() when handshake fails; cleared on success. */
+  lastError?: LastError;
+  /** Optional human-friendly nickname, propagated from peer's /info (#643 Phase 2). */
+  nickname?: string | null;
+  /**
+   * TOFU-cached pubkey from the peer's /api/identity response (#804 Step 2).
+   *
+   * Absent until the first successful identity fetch that returned a `pubkey`
+   * field. Once cached, every subsequent identity check validates the response
+   * against this value — mismatch is treated as either rotation or
+   * impersonation and is refused (see ADR docs/federation/0001-peer-identity.md
+   * O6 table). Operator clears via `maw peers forget <alias>` to re-TOFU.
+   */
+  pubkey?: string;
+  /** ISO timestamp when the pubkey was first cached (TOFU). */
+  pubkeyFirstSeen?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` pair from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` during TOFU bootstrap and on
+   * every subsequent successful probe. Drives the duplicate-detection check
+   * in `maw doctor` and the boot-time warning in `maw serve` — two peers
+   * claiming the same `<oracle>:<node>` is operator confusion that crypto
+   * (Step 2) cannot solve, and operator must investigate.
+   *
+   * Absent for legacy peers (pre-Step-1 nodes that don't expose /api/identity)
+   * and for peers whose /api/identity response omitted both `node` and `oracle`.
+   * Doctor + boot-warn skip undefined identity (no false-positive collision).
+   */
+  identity?: { oracle: string; node: string };
+}
+
+export interface PeersFile {
+  version: 1;
+  peers: Record<string, Peer>;
+}
+
+export function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function emptyStore(): PeersFile {
+  return { version: 1, peers: {} };
+}
+
+export function loadPeers(): PeersFile {
+  clearStaleTmp();
+  const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return emptyStore();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) throw new Error("invalid store shape (expected { peers: { ... } } object)");
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch (e: any) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const aside = `${path}.corrupt-${stamp}`;
+    try { renameSync(path, aside); } catch { /* ignore — caller still gets empty store */ }
+    console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
+    return emptyStore();
+  }
+}
+
+/**
+ * Validate the parsed JSON matches the expected store shape:
+ * a non-null object whose `peers` field is itself a non-null,
+ * non-array object. Guards against `{"peers":[]}` (array) and
+ * other junk that would silently no-op every write (follow-up
+ * to #579).
+ */
+function isValidStoreShape(parsed: unknown): parsed is PeersFile {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const peers = (parsed as { peers?: unknown }).peers;
+  if (peers === undefined) return true; // missing peers is ok — we default to {}
+  return typeof peers === "object" && peers !== null && !Array.isArray(peers);
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  withPeersLock(path, () => writeAtomic(path, data));
+}
+
+/**
+ * Atomic read-modify-write under the peers lock. Use this whenever a
+ * mutation depends on current contents (add/remove) — it re-reads
+ * inside the lock so concurrent writers don't lose each other's
+ * updates. The mutator runs synchronously inside the critical section.
+ */
+export function mutatePeers(mutate: (data: PeersFile) => void): PeersFile {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  return withPeersLock(path, () => {
+    const fresh = readUnlocked(path);
+    mutate(fresh);
+    writeAtomic(path, fresh);
+    return fresh;
+  });
+}
+
+/** Read + parse without taking the lock or doing corruption-handling rename. */
+function readUnlocked(path: string): PeersFile {
+  if (!existsSync(path)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) return emptyStore();
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function writeAtomic(path: string, data: PeersFile): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Best-effort cleanup of a stale tmp file (ignore errors). */
+export function clearStaleTmp(): void {
+  const tmp = `${peersPath()}.tmp`;
+  try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+}

--- a/plugins/doctor/plugin.json
+++ b/plugins/doctor/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "doctor",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Diagnostic checks — verifies maw install health and auto-heals when possible (#531).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "doctor",
+    "help": "maw doctor [install] — run install-check (and future: config-check, peer-check)"
+  },
+  "weight": 80
+}

--- a/plugins/done/done-autosave.ts
+++ b/plugins/done/done-autosave.ts
@@ -1,0 +1,92 @@
+import { hostExec } from "../../../sdk";
+import { tmux } from "../../../sdk";
+import { appendFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { cmdReunion } from "./internal/reunion-impl";
+import { cmdSoulSync } from "./internal/soul-sync-impl";
+import type { DoneOpts } from "./impl";
+
+type SessionInfo = { name: string; windows: { index: number; name: string; active: boolean }[] };
+
+/** Signal parent oracle inbox that a worktree window is done (#81). */
+export async function signalParentInbox(
+  windowName: string,
+  sessionName: string,
+  sessions: SessionInfo[],
+): Promise<void> {
+  const from = process.env.CLAUDE_AGENT_NAME || windowName;
+  const parentWindow = sessions.find(s => s.name === sessionName)?.windows[0]?.name;
+  if (!parentWindow) return;
+  const parentTarget = parentWindow.replace(/[^a-zA-Z0-9_-]/g, "");
+  const inboxDir = join(homedir(), ".oracle", "inbox");
+  const signal =
+    JSON.stringify({ ts: new Date().toISOString(), from, type: "done", msg: `worktree ${windowName} completed`, thread: null }) + "\n";
+  try {
+    mkdirSync(inboxDir, { recursive: true });
+    appendFileSync(join(inboxDir, `${parentTarget}.jsonl`), signal);
+  } catch (e) {
+    console.error(`  \x1b[33m⚠\x1b[0m inbox signal failed: ${e}`);
+  }
+}
+
+/** Auto-save: send /rrr, git commit+push, reunion + soul-sync (unless --force or dry-run). */
+export async function autoSave(
+  windowName: string,
+  sessionName: string,
+  opts: DoneOpts,
+): Promise<void> {
+  const target = `${sessionName}:${windowName}`;
+
+  let paneCwd = "";
+  try {
+    paneCwd = (await hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
+  } catch { /* expected: pane may not exist */ }
+
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send /rrr to ${target} and wait 10s`);
+    if (paneCwd) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would git add + commit + push in ${paneCwd}`);
+    }
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would kill window ${target}`);
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would remove worktree + fleet config`);
+    console.log();
+    return;
+  }
+
+  // Send /rrr to the agent for a session retrospective
+  console.log(`  \x1b[36m⏳\x1b[0m sending /rrr to ${target}...`);
+  try {
+    await tmux.sendText(target, "/rrr");
+    await new Promise(r => setTimeout(r, 10_000));
+    console.log(`  \x1b[32m✓\x1b[0m /rrr sent (waited 10s)`);
+  } catch {
+    console.log(`  \x1b[33m⚠\x1b[0m could not send /rrr (agent may not be running)`);
+  }
+
+  // Git auto-save in pane's cwd
+  if (paneCwd) {
+    console.log(`  \x1b[36m⏳\x1b[0m git auto-save in ${paneCwd}...`);
+    try {
+      await hostExec(`git -C '${paneCwd}' add -A`);
+      try {
+        await hostExec(`git -C '${paneCwd}' commit -m 'chore: auto-save before done'`);
+        console.log(`  \x1b[32m✓\x1b[0m committed changes`);
+      } catch {
+        console.log(`  \x1b[90m○\x1b[0m nothing to commit`);
+      }
+      try {
+        await hostExec(`git -C '${paneCwd}' push`);
+        console.log(`  \x1b[32m✓\x1b[0m pushed to remote`);
+      } catch {
+        console.log(`  \x1b[33m⚠\x1b[0m push failed (no remote or auth issue)`);
+      }
+    } catch (e: any) {
+      console.log(`  \x1b[33m⚠\x1b[0m git auto-save failed: ${e.message || e}`);
+    }
+  }
+
+  // Reunion + soul-sync
+  await cmdReunion(windowName);
+  try { await cmdSoulSync(undefined, { cwd: paneCwd }); } catch { /* no peers configured */ }
+}

--- a/plugins/done/done-worktree.ts
+++ b/plugins/done/done-worktree.ts
@@ -1,0 +1,104 @@
+import { hostExec } from "../../../sdk";
+import { FLEET_DIR } from "../../../sdk";
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Remove a git worktree via fleet config lookup.
+ * Returns true if a worktree was removed.
+ */
+export async function removeWorktreeViaConfig(
+  windowNameLower: string,
+  reposRoot: string,
+): Promise<boolean> {
+  try {
+    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
+      const config = JSON.parse(readFileSync(join(FLEET_DIR, file), "utf-8"));
+      const win = (config.windows || []).find((w: any) => w.name.toLowerCase() === windowNameLower);
+      if (!win?.repo) continue;
+
+      const fullPath = join(reposRoot, win.repo);
+      if (!win.repo.includes(".wt-")) break;
+
+      const parts = win.repo.split("/");
+      const wtDir = parts.pop()!;
+      const org = parts.join("/");
+      const mainRepo = wtDir.split(".wt-")[0];
+      const mainPath = join(reposRoot, org, mainRepo);
+
+      try {
+        let branch = "";
+        try { branch = (await hostExec(`git -C '${fullPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        await hostExec(`git -C '${mainPath}' worktree remove '${fullPath}' --force`);
+        await hostExec(`git -C '${mainPath}' worktree prune`);
+        console.log(`  \x1b[32m✓\x1b[0m removed worktree ${win.repo}`);
+        if (branch && branch !== "main" && branch !== "HEAD") {
+          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+        }
+        return true;
+      } catch (e: any) {
+        console.log(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e.message || e}`);
+      }
+      break;
+    }
+  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m fleet scan failed: ${e}`); }
+  return false;
+}
+
+/**
+ * Fallback: scan ghq for .wt- dirs matching the window name suffix.
+ * EXACT match only — substring matching killed unrelated worktrees (#60).
+ * Returns true if any worktrees were removed.
+ */
+export async function removeWorktreeByGhqScan(
+  windowName: string,
+  reposRoot: string,
+): Promise<boolean> {
+  let removed = false;
+  try {
+    const suffix = windowName.replace(/^[^-]+-/, ""); // e.g. "mother-schedule" → "schedule"
+    const ghqOut = await hostExec(`find ${reposRoot} -maxdepth 3 -name '*.wt-*' -type d 2>/dev/null`);
+    const allWtPaths = ghqOut.trim().split("\n").filter(Boolean);
+    const exactMatch = allWtPaths.filter(p => {
+      const base = p.split("/").pop()!;
+      const wtSuffix = base.replace(/^.*\.wt-(?:\d+-)?/, "");
+      return wtSuffix.toLowerCase() === suffix.toLowerCase();
+    });
+    for (const wtPath of exactMatch) {
+      const base = wtPath.split("/").pop()!;
+      const mainRepo = base.split(".wt-")[0];
+      const mainPath = wtPath.replace(base, mainRepo);
+      try {
+        let branch = "";
+        try { branch = (await hostExec(`git -C '${wtPath}' rev-parse --abbrev-ref HEAD`)).trim(); } catch { /* expected */ }
+        await hostExec(`git -C '${mainPath}' worktree remove '${wtPath}' --force`);
+        await hostExec(`git -C '${mainPath}' worktree prune`);
+        console.log(`  \x1b[32m✓\x1b[0m removed worktree ${base}`);
+        removed = true;
+        if (branch && branch !== "main" && branch !== "HEAD") {
+          try { await hostExec(`git -C '${mainPath}' branch -d '${branch}'`); console.log(`  \x1b[32m✓\x1b[0m deleted branch ${branch}`); } catch { /* expected */ }
+        }
+      } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree remove failed: ${e}`); }
+    }
+  } catch (e) { console.error(`  \x1b[33m⚠\x1b[0m worktree scan failed: ${e}`); }
+  return removed;
+}
+
+/** Remove a window entry from all fleet config JSON files. Returns true if any file was updated. */
+export function removeFromFleetConfig(windowNameLower: string): boolean {
+  let removed = false;
+  try {
+    for (const file of readdirSync(FLEET_DIR).filter(f => f.endsWith(".json"))) {
+      const filePath = join(FLEET_DIR, file);
+      const config = JSON.parse(readFileSync(filePath, "utf-8"));
+      const before = config.windows?.length || 0;
+      config.windows = (config.windows || []).filter((w: any) => w.name.toLowerCase() !== windowNameLower);
+      if (config.windows.length < before) {
+        writeFileSync(filePath, JSON.stringify(config, null, 2) + "\n");
+        console.log(`  \x1b[32m✓\x1b[0m removed from ${file}`);
+        removed = true;
+      }
+    }
+  } catch { /* fleet dir may not exist */ }
+  return removed;
+}

--- a/plugins/done/done.test.ts
+++ b/plugins/done/done.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+const root = join(import.meta.dir, "../../..");
+
+mock.module(join(root, "commands/plugins/done/impl"), () => ({
+  cmdDone: async (name: string, opts: { force?: boolean; dryRun?: boolean }) => {
+    console.log(`done ${name} force=${!!opts.force} dryRun=${!!opts.dryRun}`);
+  },
+}));
+
+const { default: handler } = await import("./index");
+
+describe("done plugin", () => {
+  it("CLI — valid window name completes ok", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo-freelance"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("done neo-freelance");
+  });
+
+  it("CLI — --force flag passes through", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo-freelance", "--force"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("force=true");
+  });
+
+  it("CLI — --dry-run flag passes through", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo-freelance", "--dry-run"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("dryRun=true");
+  });
+
+  it("CLI — missing name returns error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage");
+  });
+
+  it("API — name completes ok", async () => {
+    const ctx: InvokeContext = { source: "api", args: { name: "neo-freelance" } };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("done neo-freelance");
+  });
+
+  it("API — missing name returns error", async () => {
+    const ctx: InvokeContext = { source: "api", args: {} };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("name is required");
+  });
+});

--- a/plugins/done/impl.ts
+++ b/plugins/done/impl.ts
@@ -1,0 +1,83 @@
+import { join } from "path";
+import { listSessions } from "../../../sdk";
+import { getGhqRoot } from "../../../config/ghq-root";
+import { FLEET_DIR } from "../../../sdk";
+import { takeSnapshot } from "../../../sdk";
+import { tmux } from "../../../sdk";
+import { normalizeTarget } from "../../../core/matcher/normalize-target";
+import { signalParentInbox, autoSave } from "./done-autosave";
+import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig } from "./done-worktree";
+
+export interface DoneOpts {
+  force?: boolean;
+  dryRun?: boolean;
+}
+
+/**
+ * maw done <window-name> [--force] [--dry-run]
+ *
+ * Clean up a finished worktree window:
+ * 0. Send /rrr to agent + git auto-save (unless --force)
+ * 1. Kill the tmux window
+ * 2. Remove git worktree (if it is one)
+ * 3. Remove from fleet config JSON
+ */
+export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
+  let windowName = normalizeTarget(windowName_);
+  const sessions = await listSessions();
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  const windowNameLower = windowName.toLowerCase();
+  let sessionName: string | null = null;
+  let windowIndex: number | null = null;
+  for (const s of sessions) {
+    const w = s.windows.find(w => w.name.toLowerCase() === windowNameLower);
+    if (w) { sessionName = s.name; windowIndex = w.index; windowName = w.name; break; }
+  }
+
+  // 0. Signal parent inbox (#81) — write before kill so parent knows
+  if (sessionName) {
+    await signalParentInbox(windowName, sessionName, sessions as any);
+  }
+
+  // 0.5. Auto-save: send /rrr + git commit + push (unless --force)
+  if (sessionName !== null && windowIndex !== null && !opts.force) {
+    const exited = await autoSave(windowName, sessionName, opts);
+    // autoSave returns void; dryRun path returns early inside
+    if (opts.dryRun) return;
+  } else if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] window '${windowName}' not running — nothing to auto-save`);
+  }
+
+  // 1. Kill tmux window
+  if (sessionName !== null && windowIndex !== null) {
+    try {
+      await tmux.killWindow(`${sessionName}:${windowName}`);
+      console.log(`  \x1b[32m✓\x1b[0m killed window ${sessionName}:${windowName}`);
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m could not kill window (may already be closed)`);
+    }
+  } else {
+    console.log(`  \x1b[90m○\x1b[0m window '${windowName}' not running`);
+  }
+
+  // 2. Remove git worktree
+  let removedWorktree = await removeWorktreeViaConfig(windowNameLower, reposRoot);
+  if (!removedWorktree) {
+    removedWorktree = await removeWorktreeByGhqScan(windowName, reposRoot);
+  }
+  if (!removedWorktree) {
+    console.log(`  \x1b[90m○\x1b[0m no worktree to remove (may be a main window)`);
+  }
+
+  // 3. Remove from fleet config
+  const removedFromConfig = removeFromFleetConfig(windowNameLower);
+  if (!removedFromConfig) {
+    console.log(`  \x1b[90m○\x1b[0m not in any fleet config`);
+  }
+
+  // Snapshot after done
+  takeSnapshot("done").catch(() => {});
+
+  console.log();
+}

--- a/plugins/done/index.ts
+++ b/plugins/done/index.ts
@@ -1,0 +1,54 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdDone } from "./impl";
+
+export const command = {
+  name: ["done", "finish"],
+  description: "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let name: string;
+    let force: boolean | undefined;
+    let dryRun: boolean | undefined;
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      // Find first non-flag arg
+      const positional = args.filter(a => !a.startsWith("--"));
+      if (!positional[0]) {
+        return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run]" };
+      }
+      name = positional[0];
+      force = args.includes("--force");
+      dryRun = args.includes("--dry-run");
+    } else {
+      const args = ctx.args as Record<string, unknown>;
+      if (!args.name) {
+        return { ok: false, error: "name is required" };
+      }
+      name = args.name as string;
+      force = args.force as boolean | undefined;
+      dryRun = args.dryRun as boolean | undefined;
+    }
+
+    await cmdDone(name, { force, dryRun });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/done/internal/resolve.ts
+++ b/plugins/done/internal/resolve.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../../core/ghq";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { loadFleet } from "../../../shared/fleet-load";
+
+/**
+ * Resolve ghq path for an oracle name.
+ * Tries: ghqFind(`/<stem>-oracle$`) — case-insensitive ghq lookup.
+ *
+ * Defensive — accepts both bare oracle name ("neo") and full repo name
+ * ("neo-oracle"). Strips trailing "-oracle" before re-appending so callers
+ * passing either form land on the same lookup. (#372)
+ */
+export async function resolveOraclePath(name: string): Promise<string | null> {
+  // Strip trailing -oracle so "neo" and "neo-oracle" both resolve identically.
+  const stem = name.replace(/-oracle$/, "");
+  const out = await ghqFind(`/${stem}-oracle$`);
+  if (out) return out;
+
+  // Fallback: check fleet config for repo path
+  const reposRoot = join(getGhqRoot(), "github.com");
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const oracleName = sess.name.replace(/^\d+-/, "");
+    if (oracleName === stem && sess.windows.length > 0) {
+      const repoPath = join(reposRoot, sess.windows[0].repo);
+      if (existsSync(repoPath)) return repoPath;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Resolve a git repo path to its canonical "org/repo" slug for `project_repos`
+ * lookup. Handles both shapes of `ghqRoot`:
+ *
+ *   A. github.com-rooted: `/home/neo/Code/github.com`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ *   B. bare ghq root:     `/home/neo/Code`
+ *      repoRoot = `/home/neo/Code/github.com/Soul-Brews-Studio/maw-js`
+ *      → rel = `github.com/Soul-Brews-Studio/maw-js` → (strip host) →
+ *        `Soul-Brews-Studio/maw-js` → slug = `Soul-Brews-Studio/maw-js`
+ *
+ * Before this normalization, shape B produced the org-only slug
+ * `github.com/Soul-Brews-Studio` because `.split("/").slice(0, 2)` grabbed
+ * the host + org instead of org + repo. See #193.
+ *
+ * Worktree suffix (`.wt-*`) is stripped from the repo segment so worktrees
+ * match their parent repo's `project_repos` entry.
+ *
+ * Returns null if `repoRoot` is not under `ghqRoot` or doesn't have the
+ * expected depth (e.g. sitting directly under ghqRoot with no org segment).
+ */
+export function resolveProjectSlug(repoRoot: string, ghqRoot: string): string | null {
+  if (!repoRoot.startsWith(ghqRoot)) return null;
+  let rel = repoRoot.slice(ghqRoot.length).replace(/^\/+/, "");
+  // If ghqRoot is the bare ghq root (not github.com-rooted), rel starts with
+  // a host segment — strip known forges so we always land at "<org>/<repo>".
+  rel = rel.replace(/^(github\.com|gitlab\.com|bitbucket\.org)\//, "");
+  const parts = rel.split("/").slice(0, 2);
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return null;
+  parts[1] = parts[1].replace(/\.wt-.*$/, "");
+  return parts.join("/");
+}
+
+/**
+ * Find the oracle that owns a given project repo (org/repo slug).
+ */
+export function findOracleForProject(projectRepo: string): string | null {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    if (sess.project_repos?.includes(projectRepo)) {
+      return sess.name.replace(/^\d+-/, "");
+    }
+  }
+  return null;
+}

--- a/plugins/done/internal/reunion-impl.ts
+++ b/plugins/done/internal/reunion-impl.ts
@@ -1,0 +1,141 @@
+import { listSessions, hostExec } from "../../../../sdk";
+import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Resolve the main oracle repo root from a worktree cwd.
+ * Uses git --git-common-dir which points to the shared .git in the main repo.
+ */
+async function resolveMainRepoRoot(cwd: string): Promise<string | null> {
+  try {
+    // git rev-parse --git-common-dir returns path to shared .git
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (!commonDir || commonDir === ".git") return null; // already main repo
+
+    // commonDir is something like /path/to/main-repo/.git
+    // strip trailing /.git to get main repo root
+    const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+    return dirname(mainGit);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+export interface ReunionResult {
+  mainRoot: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * maw reunion [window]
+ *
+ * Sync ψ/memory/ from a worktree back to the main oracle repo.
+ * Subdirs synced: memory/learnings, memory/retrospectives, memory/traces
+ * Skip existing files (never overwrite main).
+ */
+export async function cmdReunion(windowName?: string): Promise<ReunionResult | null> {
+  // 1. Resolve cwd
+  let cwd = "";
+  if (windowName) {
+    const sessions = await listSessions();
+    const wl = windowName.toLowerCase();
+    let target = "";
+    for (const s of sessions) {
+      const w = s.windows.find(w => w.name.toLowerCase() === wl);
+      if (w) { target = `${s.name}:${w.name}`; break; }
+    }
+    if (!target) {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: window '${windowName}' not found, skipping`);
+      return null;
+    }
+    try {
+      cwd = (await hostExec(`tmux display-message -t '${target}' -p '#{pane_current_path}'`)).trim();
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: could not get cwd for ${target}`);
+      return null;
+    }
+  } else {
+    // Use current pane's cwd
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      console.log(`  \x1b[33m⚠\x1b[0m reunion: not in tmux, cannot determine cwd`);
+      return null;
+    }
+  }
+
+  // 2. Find ψ/ in cwd
+  const wtVault = join(cwd, "ψ");
+  if (!existsSync(wtVault)) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: no ψ/ in ${cwd}, skipping`);
+    return null;
+  }
+
+  // 3. Find main oracle repo
+  const mainRoot = await resolveMainRepoRoot(cwd);
+  if (!mainRoot) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: not a worktree (already main), skipping`);
+    return null;
+  }
+
+  const mainVault = join(mainRoot, "ψ");
+
+  // 4. Sync subdirs
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(wtVault, subdir);
+    const dst = join(mainVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  // 5. Report
+  if (total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m reunion: nothing new to sync to main (${mainRoot.split("/").pop()})`);
+  } else {
+    const parts = Object.entries(synced).map(([dir, n]) => {
+      const label = dir.split("/").pop()!;
+      return `${n} ${label}`;
+    });
+    console.log(`  \x1b[32m✓\x1b[0m reunion: synced ${parts.join(", ")} → ${mainRoot.split("/").pop()}/ψ/`);
+  }
+
+  return { mainRoot, synced, total };
+}

--- a/plugins/done/internal/soul-sync-impl.ts
+++ b/plugins/done/internal/soul-sync-impl.ts
@@ -1,0 +1,166 @@
+import { existsSync } from "fs";
+import { join, basename } from "path";
+import { hostExec } from "../../../../sdk";
+import { getGhqRoot } from "../../../../config/ghq-root";
+import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
+import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+export { syncDir, findPeers, findProjectsForOracle, syncProjectVault } from "./sync-helpers";
+export type { SoulSyncResult, ProjectSyncResult } from "./sync-helpers";
+export { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
+
+/**
+ * maw soul-sync [peer] [--from <peer>] — push ψ/ to peers; --from reverses direction.
+ * maw ss <peer>       push to specific peer
+ * maw ss --from <p>   pull from specific peer
+ */
+export async function cmdSoulSync(target?: string, opts?: { from?: boolean; cwd?: string }): Promise<SoulSyncResult[]> {
+  const results: SoulSyncResult[] = [];
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  const cwdParts = cwd.split("/");
+  const repoName = cwdParts.pop() || "";
+  // Strip `.wt-…` worktree suffix via indexOf — non-regex to avoid CodeQL polynomial-redos flag.
+  const wtIdx = repoName.indexOf(".wt-");
+  const baseRepo = wtIdx >= 0 ? repoName.slice(0, wtIdx) : repoName;
+  const oracleName = baseRepo.replace(/-oracle$/, "");
+
+  let oraclePath = cwd;
+  try {
+    const commonDir = (await hostExec(`git -C '${cwd}' rev-parse --git-common-dir`)).trim();
+    if (commonDir && commonDir !== ".git") {
+      const mainGit = commonDir.startsWith("/") ? commonDir : join(cwd, commonDir);
+      oraclePath = join(mainGit, "..");
+    }
+  } catch { /* use cwd */ }
+
+  const peers = target ? [target] : findPeers(oracleName);
+  if (peers.length === 0) {
+    console.log(`  \x1b[33m⚠\x1b[0m soul-sync: no sync_peers configured for '${oracleName}'`);
+    console.log(`  \x1b[90mAdd "sync_peers": ["name"] to fleet config, or run: maw ss <peer>\x1b[0m`);
+    return results;
+  }
+
+  const direction = opts?.from ? "pull" : "push";
+  const label = direction === "pull"
+    ? `pulling ${peers[0]} → ${oracleName}`
+    : `pushing ${oracleName} → ${peers.join(", ")}`;
+  console.log(`\n  \x1b[36m⚡ Soul Sync\x1b[0m — ${label}\n`);
+
+  for (const peer of peers) {
+    const peerPath = await resolveOraclePath(peer);
+    if (!peerPath) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${peer}: repo not found, skipping`);
+      continue;
+    }
+
+    const [from, to, fromName, toName] = direction === "pull"
+      ? [peerPath, oraclePath, peer, oracleName]
+      : [oraclePath, peerPath, oracleName, peer];
+
+    const result = syncOracleVaults(from, to, fromName, toName);
+    results.push(result);
+
+    if (result.total === 0) {
+      console.log(`  \x1b[90m○\x1b[0m ${fromName} → ${toName}: nothing new`);
+    } else {
+      const parts = Object.entries(result.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+      console.log(`  \x1b[32m✓\x1b[0m ${fromName} → ${toName}: ${parts.join(", ")}`);
+    }
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) synced.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+
+  return results;
+}
+
+/**
+ * maw soul-sync --project — absorb project ψ/ into oracle ψ/ (inward only).
+ * Oracle cwd: absorbs from each project_repos entry.
+ * Project cwd: pushes ψ/ to the oracle that owns this repo.
+ */
+export async function cmdSoulSyncProject(opts?: { cwd?: string }): Promise<ProjectSyncResult[]> {
+  const results: ProjectSyncResult[] = [];
+  const reposRoot = join(getGhqRoot(), "github.com");
+
+  let cwd = opts?.cwd || "";
+  if (!cwd) {
+    try {
+      cwd = (await hostExec("tmux display-message -p '#{pane_current_path}'")).trim();
+    } catch {
+      cwd = process.cwd();
+    }
+  }
+
+  let repoRoot = cwd;
+  try {
+    const top = (await hostExec(`git -C '${cwd}' rev-parse --show-toplevel`)).trim();
+    if (top) repoRoot = top;
+  } catch { /* not a git repo */ }
+
+  const repoSlug = resolveProjectSlug(repoRoot, reposRoot);
+  const repoBase = basename(repoRoot).replace(/\.wt-.*$/, "");
+  const isOracle = repoBase.endsWith("-oracle");
+
+  console.log(`\n  \x1b[36m⚡ Soul Sync (project)\x1b[0m — ${isOracle ? "absorbing into" : "exporting from"} ${repoBase}\n`);
+
+  if (isOracle) {
+    const oracleName = repoBase.replace(/-oracle$/, "");
+    const projects = findProjectsForOracle(oracleName);
+    if (projects.length === 0) {
+      console.log(`  \x1b[33m⚠\x1b[0m no project_repos configured for '${oracleName}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["org/repo"] to fleet config for ${oracleName}.\x1b[0m\n`);
+      return results;
+    }
+    for (const projectRepo of projects) {
+      const projectPath = join(reposRoot, projectRepo);
+      if (!existsSync(projectPath)) {
+        console.log(`  \x1b[33m⚠\x1b[0m ${projectRepo}: not found at ${projectPath}, skipping`);
+        continue;
+      }
+      const result = syncProjectVault(projectPath, repoRoot, projectRepo, oracleName);
+      results.push(result);
+      reportProjectResult(result);
+    }
+  } else {
+    if (!repoSlug) {
+      console.log(`  \x1b[33m⚠\x1b[0m cannot resolve project slug from ${repoRoot} (not under repos root ${reposRoot})\n`);
+      return results;
+    }
+    const oracleName = findOracleForProject(repoSlug);
+    if (!oracleName) {
+      console.log(`  \x1b[33m⚠\x1b[0m no oracle owns project '${repoSlug}'`);
+      console.log(`  \x1b[90mAdd "project_repos": ["${repoSlug}"] to an oracle's fleet config.\x1b[0m\n`);
+      return results;
+    }
+    const oraclePath = await resolveOraclePath(oracleName);
+    if (!oraclePath) {
+      console.log(`  \x1b[33m⚠\x1b[0m oracle '${oracleName}' repo not found locally\n`);
+      return results;
+    }
+    const result = syncProjectVault(repoRoot, oraclePath, repoSlug, oracleName);
+    results.push(result);
+    reportProjectResult(result);
+  }
+
+  const totalAll = results.reduce((a, r) => a + r.total, 0);
+  if (totalAll > 0) {
+    console.log(`\n  \x1b[32m${totalAll} file(s) absorbed.\x1b[0m\n`);
+  } else {
+    console.log();
+  }
+  return results;
+}

--- a/plugins/done/internal/sync-helpers.ts
+++ b/plugins/done/internal/sync-helpers.ts
@@ -1,0 +1,150 @@
+import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
+import { join } from "path";
+import { loadFleet } from "../../../shared/fleet-load";
+
+const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
+
+/**
+ * Sync new files from src dir to dst dir (skip existing).
+ * Returns count of files copied.
+ */
+export function syncDir(srcDir: string, dstDir: string): number {
+  if (!existsSync(srcDir)) return 0;
+  let count = 0;
+
+  function walk(src: string, dst: string) {
+    let entries: string[];
+    try { entries = readdirSync(src, { withFileTypes: true } as any) as any; }
+    catch { return; }
+
+    for (const entry of entries as any[]) {
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      if (entry.isDirectory()) {
+        walk(srcPath, dstPath);
+      } else if (!existsSync(dstPath)) {
+        try {
+          mkdirSync(dst, { recursive: true });
+          copyFileSync(srcPath, dstPath);
+          count++;
+        } catch { /* skip unreadable files */ }
+      }
+    }
+  }
+
+  walk(srcDir, dstDir);
+  return count;
+}
+
+/**
+ * Find peer oracle names for a given oracle from fleet config.
+ * Flat lookup — each oracle declares its own sync_peers.
+ */
+export function findPeers(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName && sess.sync_peers) return sess.sync_peers;
+  }
+  return [];
+}
+
+/**
+ * Find project repos this oracle absorbs from.
+ */
+export function findProjectsForOracle(oracleName: string): string[] {
+  const fleet = loadFleet();
+  for (const sess of fleet) {
+    const name = sess.name.replace(/^\d+-/, "");
+    if (name === oracleName) return sess.project_repos || [];
+  }
+  return [];
+}
+
+export interface SoulSyncResult {
+  from: string;
+  to: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from one oracle repo to another (new files only).
+ */
+export function syncOracleVaults(fromPath: string, toPath: string, fromName: string, toName: string): SoulSyncResult {
+  const fromVault = join(fromPath, "ψ");
+  const toVault = join(toPath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(fromVault, subdir);
+    const dst = join(toVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(toVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | ${fromName} → ${toName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { from: fromName, to: toName, synced, total };
+}
+
+export interface ProjectSyncResult {
+  project: string;
+  oracle: string;
+  synced: Record<string, number>;
+  total: number;
+}
+
+/**
+ * Sync ψ/memory/ from a project repo into an oracle repo.
+ * Knowledge flows inward through the membrane — project → oracle, new files only.
+ */
+export function syncProjectVault(
+  projectPath: string,
+  oraclePath: string,
+  projectRepo: string,
+  oracleName: string,
+): ProjectSyncResult {
+  const projectVault = join(projectPath, "ψ");
+  const oracleVault = join(oraclePath, "ψ");
+
+  const synced: Record<string, number> = {};
+  for (const subdir of SYNC_DIRS) {
+    const src = join(projectVault, subdir);
+    const dst = join(oracleVault, subdir);
+    const count = syncDir(src, dst);
+    if (count > 0) synced[subdir] = count;
+  }
+  const total = Object.values(synced).reduce((a, b) => a + b, 0);
+
+  if (total > 0) {
+    const logDir = join(oracleVault, ".soul-sync");
+    try {
+      mkdirSync(logDir, { recursive: true });
+      const ts = new Date().toISOString();
+      const logLine = `${ts} | project:${projectRepo} → ${oracleName} | ${total} files | ${Object.entries(synced).map(([k, v]) => `${v} ${k.split("/").pop()}`).join(", ")}\n`;
+      appendFileSync(join(logDir, "sync.log"), logLine);
+    } catch { /* non-critical */ }
+  }
+
+  return { project: projectRepo, oracle: oracleName, synced, total };
+}
+
+export function reportProjectResult(r: ProjectSyncResult) {
+  if (r.total === 0) {
+    console.log(`  \x1b[90m○\x1b[0m project:${r.project} → ${r.oracle}: nothing new`);
+  } else {
+    const parts = Object.entries(r.synced).map(([dir, n]) => `${n} ${dir.split("/").pop()}`);
+    console.log(`  \x1b[32m✓\x1b[0m project:${r.project} → ${r.oracle}: ${parts.join(", ")}`);
+  }
+}

--- a/plugins/done/plugin.json
+++ b/plugins/done/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "done",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "done",
+    "aliases": [
+      "finish"
+    ],
+    "help": "maw done <window-name> [--force] [--dry-run] — clean up a finished worktree"
+  },
+  "api": {
+    "path": "/api/done",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/health/health.test.ts
+++ b/plugins/health/health.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+const root = join(import.meta.dir, "../../..");
+
+// Use the shared mock helper to provide ALL config exports (Bun 1.3 mock leaks globally)
+const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
+mock.module(join(root, "config"), () => mockConfigModule(() => ({ host: "localhost", port: 3456, peers: [] })));
+
+// Mock the health impl directly — do NOT mock child_process (leaks globally in Bun 1.3)
+mock.module("./impl", () => ({
+  cmdHealth: async () => {
+    console.log("maw health — localhost:3456");
+    console.log("tmux server: running (2 sessions)");
+    console.log("pm2: maw online (pid 1234)");
+  },
+}));
+
+const { default: handler } = await import("./index");
+
+describe("health plugin", () => {
+  it("CLI surface — returns ok with health output", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("maw health");
+  });
+
+  it("API surface — returns ok with health output", async () => {
+    const ctx: InvokeContext = { source: "api", args: {} };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("maw health");
+  });
+
+  it("reports tmux server in output", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("tmux server");
+  });
+
+  it("accepts extra args gracefully (no-op)", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--verbose"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/plugins/health/impl.ts
+++ b/plugins/health/impl.ts
@@ -1,0 +1,104 @@
+import { execSync } from "child_process";
+import { loadConfig, cfgTimeout } from "../../../config";
+import { curlFetch } from "../../../sdk";
+import { tmux } from "../../../sdk";
+
+export async function cmdHealth() {
+  const checks: { name: string; status: string; detail: string }[] = [];
+
+  // 1. tmux
+  try {
+    const sessions = await tmux.listSessions();
+    checks.push({ name: "tmux server", status: "ok", detail: `running (${sessions.length} sessions)` });
+  } catch {
+    checks.push({ name: "tmux server", status: "fail", detail: "not running" });
+  }
+
+  // 2. maw server — POST /api/probe (#804 Step 5)
+  // We POST /api/probe (not GET /api/sessions or /api/identity) because the
+  // probe walks the same code path as /api/send. If probe is green, /send
+  // is green; a green /sessions or /identity could coexist with broken /send
+  // (the #795 schema-drift incident). No body → bare healthcheck mode.
+  try {
+    const port = loadConfig().port;
+    const res = await fetch(`http://localhost:${port}/api/probe`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+      signal: AbortSignal.timeout(cfgTimeout("health")),
+    });
+    if (res.ok) {
+      const data: any = await res.json().catch(() => ({}));
+      const count = typeof data?.sessions === "number" ? data.sessions : "?";
+      checks.push({ name: "maw server", status: "ok", detail: `online (:${port}, ${count} sessions, probe ok)` });
+    } else {
+      checks.push({ name: "maw server", status: "warn", detail: `HTTP ${res.status} (probe)` });
+    }
+  } catch {
+    checks.push({ name: "maw server", status: "fail", detail: "offline" });
+  }
+
+  // 3. disk
+  try {
+    const df = execSync("df -h /tmp | tail -1", { encoding: "utf-8" }).trim();
+    const parts = df.split(/\s+/);
+    const avail = parts[3] || "?";
+    const pct = parseInt(parts[4] || "0");
+    checks.push({ name: "disk /tmp", status: pct > 90 ? "warn" : "ok", detail: `${avail} free` });
+  } catch {
+    checks.push({ name: "disk /tmp", status: "warn", detail: "unknown" });
+  }
+
+  // 4. memory
+  try {
+    const mem = execSync("free -m | grep Mem", { encoding: "utf-8" }).trim();
+    const parts = mem.split(/\s+/);
+    const avail = parseInt(parts[6] || "0");
+    checks.push({ name: "memory", status: avail < 500 ? "warn" : "ok", detail: `${avail}MB available` });
+  } catch {
+    checks.push({ name: "memory", status: "warn", detail: "unknown" });
+  }
+
+  // 5. pm2
+  try {
+    const pm2 = execSync("pm2 jlist 2>/dev/null", { encoding: "utf-8" });
+    const procs = JSON.parse(pm2);
+    const maw = procs.find((p: any) => p.name === "maw");
+    if (maw) {
+      checks.push({ name: "pm2 maw", status: maw.pm2_env?.status === "online" ? "ok" : "warn", detail: `${maw.pm2_env?.status} (pid ${maw.pid})` });
+    } else {
+      checks.push({ name: "pm2 maw", status: "fail", detail: "not found" });
+    }
+  } catch {
+    checks.push({ name: "pm2 maw", status: "warn", detail: "pm2 not available" });
+  }
+
+  // 6. peers — reconcile both config.peers (string[]) and config.namedPeers ({name,url}[])
+  const config = loadConfig();
+  const rawPeers: string[] = config.peers || [];
+  const namedPeers: { name: string; url: string }[] = config.namedPeers || [];
+  const allPeers: { label: string; url: string }[] = [
+    ...rawPeers.map(url => ({ label: url, url })),
+    ...namedPeers.map(p => ({ label: `${p.name} (${p.url})`, url: p.url })),
+  ];
+  if (allPeers.length === 0) {
+    checks.push({ name: "peers", status: "none", detail: "none configured" });
+  } else {
+    for (const peer of allPeers) {
+      try {
+        const r = await curlFetch(`${peer.url}/api/federation/status`, { timeout: cfgTimeout("health") });
+        checks.push({ name: `peer ${peer.label}`, status: r.ok ? "ok" : "warn", detail: r.ok ? "online" : `HTTP ${r.status}` });
+      } catch {
+        checks.push({ name: `peer ${peer.label}`, status: "fail", detail: "unreachable" });
+      }
+    }
+  }
+
+  // Output
+  console.log("\nmaw health\n");
+  for (const c of checks) {
+    const icon = c.status === "ok" ? "\x1b[32m●\x1b[0m" : c.status === "warn" ? "\x1b[33m●\x1b[0m" : c.status === "fail" ? "\x1b[31m●\x1b[0m" : "\x1b[90m○\x1b[0m";
+    console.log(`  ${icon} ${c.name.padEnd(18)} ${c.detail}`);
+  }
+  console.log();
+}

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -1,0 +1,30 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdHealth } from "./impl";
+
+export const command = {
+  name: "health",
+  description: "System health check — tmux, maw server, disk, memory, pm2, peers.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    await cmdHealth();
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/health/plugin.json
+++ b/plugins/health/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "health",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "System health check — tmux, maw server, disk, memory, pm2, peers.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "health",
+    "help": "maw health — check system health (tmux, server, disk, memory, pm2, peers)"
+  },
+  "api": {
+    "path": "/api/health",
+    "methods": [
+      "GET"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/hey-test/hey-plugin.test.ts
+++ b/plugins/hey-test/hey-plugin.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for maw hey plugin:<name> routing in cmdSend.
+ *
+ * Stubs plugin/registry and config to avoid filesystem + tmux dependencies.
+ */
+
+import { describe, test, expect, mock, beforeEach, afterEach } from "bun:test";
+
+// --- Stub types (mirrors src/plugin/types.ts) ---
+interface LoadedPlugin {
+  manifest: { name: string; version: string; wasm: string; sdk: string };
+  dir: string;
+  wasmPath: string;
+}
+
+// --- Mutable stubs ---
+let fakePlugins: LoadedPlugin[] = [
+  {
+    manifest: { name: "hello-package", version: "1.0.0", wasm: "hello.wasm", sdk: "^1.0.0" },
+    dir: "/tmp/hello-package",
+    wasmPath: "/tmp/hello-package/hello.wasm",
+  },
+];
+let fakeInvokeResult: { ok: boolean; output?: string; error?: string } = {
+  ok: true,
+  output: "federation context: source=peer from=local-node",
+};
+
+mock.module("../../../plugin/registry", () => ({
+  discoverPackages: () => fakePlugins,
+  invokePlugin: async (_plugin: LoadedPlugin, _ctx: unknown) => fakeInvokeResult,
+}));
+
+const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
+mock.module("../../../config", () => mockConfigModule(() => ({ node: "local-node", port: 3456 })));
+
+mock.module("../../../core/transport/ssh", () => ({
+  listSessions: async () => [],
+  capture: async () => "",
+  sendKeys: async () => {},
+  getPaneCommand: async () => "",
+  getPaneCommands: async () => [],
+  getPaneInfos: async () => ({}),
+}));
+
+mock.module("../../../core/routing", () => ({
+  resolveTarget: () => ({ type: "error", detail: "not found", hint: "" }),
+}));
+
+mock.module("../../../core/runtime/hooks", () => ({ runHook: async () => {} }));
+mock.module("../../../core/transport/peers", () => ({ findPeerForTarget: async () => undefined }));
+mock.module("../../../core/fleet/worktrees", () => ({ scanWorktrees: async () => [] }));
+// NOTE: do NOT mock find-window here — it leaks globally and breaks routing tests (#198)
+mock.module("../../../core/transport/curl-fetch", () => ({ curlFetch: async () => ({ ok: false, data: {} }) }));
+mock.module("../../../commands/shared/wake", () => ({ resolveFleetSession: () => undefined }));
+
+import { cmdSend } from "../../../commands/shared/comm";
+
+describe("maw hey plugin:<name> routing", () => {
+  let exitCode: number | undefined;
+  let consoleOut: string[] = [];
+  let consoleErr: string[] = [];
+  let originalExit: typeof process.exit;
+  let originalLog: typeof console.log;
+  let originalError: typeof console.error;
+
+  beforeEach(() => {
+    exitCode = undefined;
+    consoleOut = [];
+    consoleErr = [];
+
+    originalExit = process.exit;
+    originalLog = console.log;
+    originalError = console.error;
+
+    process.exit = ((code?: number) => {
+      exitCode = code ?? 0;
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+    console.log = (...args: unknown[]) => { consoleOut.push(args.join(" ")); };
+    console.error = (...args: unknown[]) => { consoleErr.push(args.join(" ")); };
+
+    // Reset stubs to defaults
+    fakePlugins = [
+      {
+        manifest: { name: "hello-package", version: "1.0.0", wasm: "hello.wasm", sdk: "^1.0.0" },
+        dir: "/tmp/hello-package",
+        wasmPath: "/tmp/hello-package/hello.wasm",
+      },
+    ];
+    fakeInvokeResult = { ok: true, output: "federation context: source=peer from=local-node" };
+  });
+
+  afterEach(() => {
+    process.exit = originalExit;
+    console.log = originalLog;
+    console.error = originalError;
+  });
+
+  test("plugin:<name> invokes registry and prints output", async () => {
+    await cmdSend("plugin:hello-package", "test from peer");
+
+    expect(exitCode).toBeUndefined();
+    expect(consoleOut.some(l => l.includes("federation context"))).toBe(true);
+  });
+
+  test("plugin:<name> with no output prints (no output)", async () => {
+    fakeInvokeResult = { ok: true };
+    await cmdSend("plugin:hello-package", "test");
+
+    expect(exitCode).toBeUndefined();
+    expect(consoleOut.some(l => l.includes("(no output)"))).toBe(true);
+  });
+
+  test("unknown plugin name exits with error", async () => {
+    await expect(
+      cmdSend("plugin:does-not-exist", "test"),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitCode).toBe(1);
+    expect(consoleErr.some(l => l.includes("plugin not found: does-not-exist"))).toBe(true);
+  });
+
+  test("non-plugin: prefix still routes normally (no regression)", async () => {
+    // "mawjs" has no plugin: prefix — falls through to normal routing
+    // resolveTarget returns error type → cmdSend exits with error (not a plugin error)
+    await expect(
+      cmdSend("mawjs", "hello"),
+    ).rejects.toThrow("process.exit");
+
+    expect(exitCode).toBe(1);
+    // Must NOT print "plugin not found"
+    expect(consoleErr.some(l => l.includes("plugin not found"))).toBe(false);
+  });
+});

--- a/plugins/init/bootstrap-plugins-lock.ts
+++ b/plugins/init/bootstrap-plugins-lock.ts
@@ -1,0 +1,24 @@
+import { existsSync, mkdirSync } from "fs";
+import { dirname } from "path";
+import { LOCK_SCHEMA, lockPath, writeLock } from "./internal/plugin-lock";
+
+export interface BootstrapPluginsLockResult {
+  created: boolean;
+  path: string;
+}
+
+/**
+ * First-run bootstrap for ~/.maw/plugins.lock (#680 ask 4).
+ *
+ * If the lockfile is absent, create it with an empty-but-valid shape so every
+ * subsequent `maw plugin install` has a truth file to write into. If present,
+ * leave it alone — never overwrite, never merge.
+ */
+export function bootstrapPluginsLock(): BootstrapPluginsLockResult {
+  const path = lockPath();
+  if (existsSync(path)) return { created: false, path };
+
+  mkdirSync(dirname(path), { recursive: true });
+  writeLock({ schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} });
+  return { created: true, path };
+}

--- a/plugins/init/federation.ts
+++ b/plugins/init/federation.ts
@@ -1,0 +1,9 @@
+import { randomBytes } from "crypto";
+
+export function generateFederationToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export function isValidFederationToken(t: string): boolean {
+  return typeof t === "string" && t.length >= 16;
+}

--- a/plugins/init/impl.ts
+++ b/plugins/init/impl.ts
@@ -1,0 +1,170 @@
+import { homedir, hostname } from "os";
+import { existsSync, readdirSync } from "fs";
+import { CONFIG_FILE, FLEET_DIR } from "../../../core/paths";
+import { runPromptLoop, ttyAsk, type AskFn } from "./prompts";
+import { parseNonInteractive } from "./non-interactive";
+import {
+  buildConfig,
+  configExists,
+  backupConfig,
+  writeConfigAtomic,
+} from "./write-config";
+import { generateFederationToken } from "./federation";
+import { bootstrapPluginsLock } from "./bootstrap-plugins-lock";
+
+const CYAN = "\x1b[36m";
+const GREEN = "\x1b[32m";
+const GRAY = "\x1b[90m";
+const RED = "\x1b[31m";
+const BOLD = "\x1b[1m";
+const RESET = "\x1b[0m";
+
+function defaults() {
+  // #680 — ghqRoot is no longer captured at init; `getGhqRoot()` resolves on demand.
+  return { node: hostname() };
+}
+
+export type ExistingChoice = "overwrite" | "backup" | "abort";
+
+export async function chooseExistingAction(ask: AskFn, defaultChoice: ExistingChoice = "abort"): Promise<ExistingChoice> {
+  const ans = (await ask("Existing config found — [o]verwrite, [b]ackup+overwrite, [A]bort", "")).toLowerCase();
+  if (ans === "o" || ans === "overwrite") return "overwrite";
+  if (ans === "b" || ans === "backup") return "backup";
+  if (ans === "a" || ans === "abort" || ans === "") return defaultChoice;
+  return defaultChoice;
+}
+
+export interface CmdInitOpts {
+  args: string[];
+  /** Override prompt for tests */
+  ask?: AskFn;
+  /** Override writer (default console.log) */
+  writer?: (msg: string) => void;
+}
+
+export interface CmdInitResult {
+  ok: boolean;
+  error?: string;
+  configPath?: string;
+  config?: Record<string, unknown>;
+}
+
+export async function cmdInit(opts: CmdInitOpts): Promise<CmdInitResult> {
+  const ask = opts.ask ?? ttyAsk;
+  const write = opts.writer ?? ((m: string) => console.log(m));
+  const isNonInteractive = opts.args.includes("--non-interactive");
+  const home = homedir();
+  const def = defaults();
+
+  if (isNonInteractive) {
+    const parsed = parseNonInteractive(opts.args, home, def);
+    if (!parsed.ok) return { ok: false, error: parsed.error };
+
+    // #510 (spec § 4a): --backup implies --force + preserve existing as .bak.<timestamp>.
+    // Without --force or --backup, refuse to overwrite.
+    if (configExists(CONFIG_FILE) && !parsed.opts.force && !parsed.opts.backup) {
+      return { ok: false, error: `Config exists at ${CONFIG_FILE}. Use --force to overwrite or --backup to preserve + overwrite.` };
+    }
+    if (configExists(CONFIG_FILE) && parsed.opts.backup) {
+      const bak = backupConfig(CONFIG_FILE);
+      write(`${GREEN}✓${RESET} backed up to ${bak}`);
+    }
+
+    // #510 (spec § 3 Q3): warn when no --token flag AND no CLAUDE_CODE_OAUTH_TOKEN env.
+    // Non-blocking — config still writes.
+    if (!parsed.opts.token && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+      process.stderr.write(`${GRAY}warning${RESET}: no --token and no CLAUDE_CODE_OAUTH_TOKEN env — Claude agents will need credentials before wake\n`);
+    }
+
+    const federationToken = parsed.opts.federate
+      ? (parsed.opts.federationToken ?? generateFederationToken())
+      : undefined;
+
+    const config = buildConfig({
+      node: parsed.opts.node,
+      ghqRoot: parsed.opts.ghqRoot,
+      token: parsed.opts.token,
+      federate: parsed.opts.federate,
+      peers: parsed.opts.peers,
+      federationToken,
+    });
+
+    writeConfigAtomic(CONFIG_FILE, config, /* overwrite */ true);
+    write(`${GREEN}✓${RESET} Wrote ${CONFIG_FILE}`);
+    try {
+      const boot = bootstrapPluginsLock();
+      if (boot.created) write(`${GREEN}✓${RESET} plugins.lock (bootstrap) ${GRAY}${boot.path}${RESET}`);
+    } catch (e: any) {
+      write(`${GRAY}warning: plugins.lock bootstrap skipped — ${e?.message ?? String(e)}${RESET}`);
+    }
+    if (federationToken && parsed.opts.federate) {
+      write(`${CYAN}federation token${RESET}: ${federationToken}`);
+      write(`${GRAY}  share with each peer in their maw.config.json${RESET}`);
+    }
+    return { ok: true, configPath: CONFIG_FILE, config };
+  }
+
+  // ─── interactive mode ──────────────────────────────────────────────
+  write(`${BOLD}maw init${RESET} — first-run setup`);
+  write("");
+
+  if (configExists(CONFIG_FILE)) {
+    write(`${GRAY}Found existing config at ${CONFIG_FILE}${RESET}`);
+    const choice = await chooseExistingAction(ask);
+    if (choice === "abort") {
+      write("Aborted. Existing config untouched.");
+      return { ok: true };
+    }
+    if (choice === "backup") {
+      const bak = backupConfig(CONFIG_FILE);
+      write(`${GREEN}✓${RESET} backed up to ${bak}`);
+    }
+  }
+
+  let answers;
+  try {
+    answers = await runPromptLoop(ask, def, home, write);
+  } catch (e: any) {
+    return { ok: false, error: e.message };
+  }
+
+  const federationToken = answers.federate ? generateFederationToken() : undefined;
+
+  const config = buildConfig({
+    node: answers.node,
+    token: answers.token,
+    federate: answers.federate,
+    peers: answers.peers,
+    federationToken,
+  });
+
+  writeConfigAtomic(CONFIG_FILE, config, /* overwrite */ true);
+
+  write("");
+  write(`${GREEN}✓${RESET} Wrote ${CONFIG_FILE}`);
+  try {
+    const boot = bootstrapPluginsLock();
+    if (boot.created) write(`${GREEN}✓${RESET} plugins.lock (bootstrap) ${GRAY}${boot.path}${RESET}`);
+  } catch (e: any) {
+    write(`${GRAY}warning: plugins.lock bootstrap skipped — ${e?.message ?? String(e)}${RESET}`);
+  }
+  if (existsSync(FLEET_DIR)) {
+    const fleetCount = readdirSync(FLEET_DIR).filter(f => f.endsWith(".json")).length;
+    write(`${GREEN}✓${RESET} Fleet dir ready: ${FLEET_DIR} ${GRAY}(${fleetCount} entr${fleetCount === 1 ? "y" : "ies"})${RESET}`);
+  }
+
+  if (federationToken) {
+    write("");
+    write(`${CYAN}Generated federation token${RESET} (share with all peers):`);
+    write(`  ${federationToken}`);
+    write(`${GRAY}  copy this verbatim into each peer's maw.config.json under "federationToken"${RESET}`);
+  }
+
+  write("");
+  write(`${BOLD}Next steps${RESET}:`);
+  write(`  maw serve              ${GRAY}# start the local daemon${RESET}`);
+  write(`  maw wake <repo>        ${GRAY}# spawn your first agent${RESET}`);
+  write(`  maw bud <name>         ${GRAY}# create a new oracle (writes fleet/<NN>-<name>.json)${RESET}`);
+
+  return { ok: true, configPath: CONFIG_FILE, config };
+}

--- a/plugins/init/index.ts
+++ b/plugins/init/index.ts
@@ -1,0 +1,62 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdInit } from "./impl";
+
+export const command = {
+  name: "init",
+  description: "First-run wizard — configure ~/.config/maw/maw.config.json",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const writer = (m: string) => {
+    if (ctx.writer) ctx.writer(m);
+    else logs.push(m);
+  };
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => writer(a.map(String).join(" "));
+  console.error = (...a: any[]) => writer(a.map(String).join(" "));
+
+  try {
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      if (args[0] === "--help" || args[0] === "-h") {
+        return {
+          ok: true,
+          output: "maw init [--non-interactive --node <name> --token <t> --federate --peer <url> --peer-name <name> --federation-token <hex> --force]\n\nInteractive 3-question wizard. Writes ~/.config/maw/maw.config.json.\nIn non-interactive mode, all required fields fall back to detected defaults\n(hostname). Existing config requires --force to overwrite. (#680: --ghq-root\nflag accepted but ignored — ghq root is resolved on demand via `ghq root`.)",
+        };
+      }
+      const result = await cmdInit({ args, writer });
+      if (!result.ok) return { ok: false, error: result.error ?? "init failed", output: logs.join("\n") || undefined };
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+    if (ctx.source === "api") {
+      // API-mode init: accept the same options as the non-interactive CLI.
+      // We translate the body into the equivalent flag array so we share
+      // the parser and validation paths with the CLI.
+      const body = (ctx.args ?? {}) as Record<string, unknown>;
+      const args: string[] = ["--non-interactive"];
+      if (body.node) args.push("--node", String(body.node));
+      // #680 — body.ghqRoot intentionally ignored; resolved on demand.
+      if (body.token) args.push("--token", String(body.token));
+      if (body.federate) args.push("--federate");
+      if (Array.isArray(body.peers)) {
+        for (const p of body.peers as Array<{ name: string; url: string }>) {
+          args.push("--peer", p.url);
+          args.push("--peer-name", p.name);
+        }
+      }
+      if (body.federationToken) args.push("--federation-token", String(body.federationToken));
+      if (body.force) args.push("--force");
+      const result = await cmdInit({ args, writer });
+      if (!result.ok) return { ok: false, error: result.error ?? "init failed", output: logs.join("\n") || undefined };
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+    return { ok: false, error: "unsupported source" };
+  } catch (e: any) {
+    return { ok: false, error: e?.message ?? String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/init/internal/install-extraction.ts
+++ b/plugins/init/internal/install-extraction.ts
@@ -1,0 +1,210 @@
+/**
+ * install-impl seam: tarball extraction, URL download, artifact hash verify.
+ */
+
+import type { PluginManifest } from "../../../../plugin/types";
+import { spawnSync } from "child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { hashFile } from "../../../../plugin/registry";
+
+const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+
+/**
+ * Run `tar -xzf <tarball> -C <destDir>` synchronously. Returns true on success.
+ * We shell out to GNU tar rather than adding a `tar` npm dep — Bun ships without
+ * streaming tar, and adding a dep for a single call is not worth it.
+ */
+export function extractTarball(tarballPath: string, destDir: string): { ok: true } | { ok: false; error: string } {
+  // Path-traversal guard: list entries first, reject any that escape the staging dir.
+  // GNU tar does not strip "../" by default; -C alone does not prevent traversal.
+  const list = spawnSync("tar", ["-tzf", tarballPath], { encoding: "utf8" });
+  if (list.status !== 0) {
+    return { ok: false, error: `tar list failed: ${list.stderr || list.stdout || `exit ${list.status}`}` };
+  }
+  for (const entry of list.stdout.split("\n").filter(Boolean)) {
+    if (entry.startsWith("/") || entry.split("/").includes("..")) {
+      return { ok: false, error: `tarball rejected: path traversal in entry "${entry}"` };
+    }
+  }
+
+  const r = spawnSync("tar", ["-xzf", tarballPath, "-C", destDir], {
+    encoding: "utf8",
+  });
+  if (r.status !== 0) {
+    return { ok: false, error: `tar extract failed: ${r.stderr || r.stdout || `exit ${r.status}`}` };
+  }
+  return { ok: true };
+}
+
+/**
+ * Download a URL to a temp file. Verifies the content type looks like gzip/tar
+ * before writing (per brief: "verify content-type is gzip/tar").
+ */
+export async function downloadTarball(url: string): Promise<{ ok: true; path: string } | { ok: false; error: string }> {
+  // Scheme gate — defense in depth; detectMode already filters callers from cmdPluginInstall
+  // but direct callers of this function would bypass that upstream check.
+  if (!/^https?:\/\//i.test(url)) {
+    return { ok: false, error: `download refused: only http/https URLs are allowed (got ${JSON.stringify(url.slice(0, 32))})` };
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (e: any) {
+    return { ok: false, error: `download failed: ${e.message}` };
+  }
+  if (!res.ok) {
+    return { ok: false, error: `download failed: HTTP ${res.status} ${res.statusText}` };
+  }
+
+  // Size cap: reject before buffering if Content-Length already exceeds limit.
+  const declared = Number(res.headers.get("content-length") ?? 0);
+  if (declared > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: Content-Length ${declared} exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
+  const ct = (res.headers.get("content-type") ?? "").toLowerCase();
+  const ctOk =
+    ct.includes("gzip") ||
+    ct.includes("x-gzip") ||
+    ct.includes("x-tar") ||
+    ct.includes("tar+gzip") ||
+    ct.includes("octet-stream"); // many CDNs return generic binary
+  if (!ctOk) {
+    return { ok: false, error: `unexpected content-type ${JSON.stringify(ct)} — expected gzip/tar` };
+  }
+
+  const buf = new Uint8Array(await res.arrayBuffer());
+  // Cap actual bytes too — Content-Length can be absent or spoofed.
+  if (buf.byteLength > MAX_DOWNLOAD_BYTES) {
+    return { ok: false, error: `download refused: response body (${buf.byteLength} bytes) exceeds ${MAX_DOWNLOAD_BYTES} byte limit` };
+  }
+
+  const tmp = mkdtempSync(join(tmpdir(), "maw-dl-"));
+  const filename = basename(new URL(url).pathname) || "plugin.tgz";
+  const outPath = join(tmp, filename);
+  writeFileSync(outPath, buf);
+  return { ok: true, path: outPath };
+}
+
+/**
+ * Source-plugin detector (#874 path A.3, hardened in #896).
+ *
+ * A "source plugin" is one that ships executable source rather than a
+ * pre-built bundle — typical of community repos with `src/index.ts` +
+ * `plugin.json` and no `dist/`. Bun runs `.ts`/`.js` source transparently,
+ * so the install path can accept them without an ahead-of-time build. We
+ * still hash the entry file's bytes for plugins.lock parity so
+ * `recordInstall` / `--pin` / hash-mismatch all work uniformly.
+ *
+ * #896 — hardened to accept EITHER of:
+ *   • no `artifact` + has `entry`         (canonical source shape, #874 A.3)
+ *   • has `artifact.sha256 === null` + has `entry`  (half-built — entry is
+ *     authoritative because the artifact has no committed bytes to verify)
+ *
+ * The second branch matters because parseManifest accepts `artifact.sha256
+ * = null` as valid (a manifest mid-build). Pre-#896 those tarballs hit the
+ * `manifest.artifact` truthy branch, fell through `verifyArtifactHash`'s
+ * sha256-null fencepost, and never tried the perfectly valid `entry`. The
+ * symptom looked like a stale-binary regression (#896): the user filed
+ * `tarball manifest has no 'artifact' field` even on tarballs whose
+ * plugin.json clearly had `entry: "./src/index.ts"` — the artifact branch
+ * was rejecting them before the entry branch could rescue.
+ */
+export function isSourcePluginManifest(manifest: PluginManifest): boolean {
+  const hasEntry = typeof manifest.entry === "string" && manifest.entry.length > 0;
+  if (!hasEntry) return false;
+  // Canonical source shape: no artifact at all.
+  if (!manifest.artifact) return true;
+  // Half-built: artifact declared but sha256 not yet computed. Entry is the
+  // authoritative byte source.
+  if (manifest.artifact.sha256 === null) return true;
+  return false;
+}
+
+/**
+ * Verify sha256 of `manifest.artifact.path` (relative to `dir`) matches
+ * `expected`. If `expected` is null/undefined, the manifest's embedded hash is
+ * used as the expected value — this is the legacy (circular) check kept as a
+ * defense-in-depth fencepost for transport corruption. See #487 / plugins.lock
+ * for the real adversarial check (registry-pinned hashes).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead.
+ *
+ * #896 — when `manifest.artifact.path` doesn't exist on disk but the
+ * manifest also declares `entry`, fall back to entry. Defensive against
+ * tarballs whose artifact path got out of sync with their actual contents
+ * (e.g. registry source republished with a stale dist reference).
+ */
+export function verifyArtifactHashAgainst(
+  dir: string,
+  manifest: PluginManifest,
+  expected: string,
+): { ok: true } | { ok: false; error: string } {
+  let relPath: string;
+  // #896: entry-first when source-shaped — covers no-artifact AND
+  // half-built (sha256:null) shapes uniformly.
+  if (isSourcePluginManifest(manifest)) {
+    relPath = manifest.entry!;
+  } else if (manifest.artifact) {
+    relPath = manifest.artifact.path;
+    // #896: artifact declared but missing on disk — try entry rescue.
+    if (!existsSync(join(dir, relPath)) && typeof manifest.entry === "string" && manifest.entry.length > 0) {
+      relPath = manifest.entry;
+    }
+  } else {
+    return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with `maw plugin build` or declare an entry path" };
+  }
+  const artifactPath = join(dir, relPath);
+  if (!existsSync(artifactPath)) {
+    return { ok: false, error: `artifact missing at ${relPath}` };
+  }
+  const observed = hashFile(artifactPath);
+  if (observed !== expected) {
+    return {
+      ok: false,
+      error:
+        `artifact hash mismatch — refusing to install.\n` +
+        `  expected: ${expected}\n` +
+        `  actual:   ${observed}`,
+    };
+  }
+  return { ok: true };
+}
+
+/**
+ * Legacy manifest-only hash check. Kept as defense-in-depth fencepost per
+ * #487 §8 Phase 1.
+ *
+ * #874 path A.3 — source plugins (no `artifact`, has `entry`) skip this
+ * fencepost: there is no embedded hash to check against, so the registry-
+ * pinned hash in plugins.lock is the only authoritative source. Tampering
+ * is still detected at the pinned-hash check in `installFromTarball`.
+ *
+ * #896 — `isSourcePluginManifest` now accepts both no-artifact and
+ * half-built (artifact.sha256===null) shapes when entry is present. Both
+ * fall through to entry-only existence verification.
+ */
+export function verifyArtifactHash(dir: string, manifest: PluginManifest): { ok: true } | { ok: false; error: string } {
+  if (isSourcePluginManifest(manifest)) {
+    // Source plugins have no embedded sha256 to fencepost against. Verify the
+    // entry file at least exists; the real adversarial check is plugins.lock.
+    const entryPath = join(dir, manifest.entry!);
+    if (!existsSync(entryPath)) {
+      return { ok: false, error: `source entry missing at ${manifest.entry}` };
+    }
+    return { ok: true };
+  }
+  if (!manifest.artifact) {
+    return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with `maw plugin build` or declare an entry path" };
+  }
+  if (manifest.artifact.sha256 === null) {
+    // Should be unreachable thanks to #896 isSourcePluginManifest covering
+    // half-built + entry. Kept as a fencepost for the no-entry case.
+    return { ok: false, error: "tarball manifest has artifact.sha256=null (unbuilt) and no entry fallback — rebuild with `maw plugin build`" };
+  }
+  return verifyArtifactHashAgainst(dir, manifest, manifest.artifact.sha256);
+}

--- a/plugins/init/internal/install-manifest-helpers.ts
+++ b/plugins/init/internal/install-manifest-helpers.ts
@@ -1,0 +1,122 @@
+/**
+ * install-impl seam: manifest reading + success printing helpers.
+ */
+
+import type { PluginManifest } from "../../../../plugin/types";
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { join } from "path";
+import { parseManifest } from "../../../../plugin/manifest";
+import { runtimeSdkVersion } from "../../../../plugin/registry";
+
+/**
+ * #864 — Resolve the plugin root inside an extracted staging dir.
+ *
+ * `maw plugin build` produces flat tarballs (plugin.json at root). But
+ * GitHub-archive tarballs (`github:OWNER/REPO#REF` registry sources, used by
+ * shellenv/bg/rename/park) extract with a wrapping `<repo>-<ref>/` directory,
+ * and npm tarballs likewise wrap in `package/`. Both leave plugin.json one
+ * level down, breaking root-only manifest discovery.
+ *
+ * Walks at most one level: if plugin.json exists at root, returns root; else
+ * if root contains exactly one entry — a directory — with plugin.json inside,
+ * returns that subdir; else returns null. The extractTarball() path-traversal
+ * guard ensures every entry lives under the staging dir, so walking one level
+ * is safe.
+ */
+export function findPluginRoot(stagingDir: string): string | null {
+  if (existsSync(join(stagingDir, "plugin.json"))) return stagingDir;
+  let entries: string[];
+  try { entries = readdirSync(stagingDir); } catch { return null; }
+  if (entries.length !== 1) return null;
+  const inner = join(stagingDir, entries[0]!);
+  try { if (!statSync(inner).isDirectory()) return null; } catch { return null; }
+  if (existsSync(join(inner, "plugin.json"))) return inner;
+  return null;
+}
+
+/**
+ * Resolve the plugin root inside an extracted monorepo staging dir
+ * (maw-plugin-registry#2). The registry repo's tarball, fetched via the
+ * `monorepo:plugins/<name>@<tag>` source format, is wrapped by github in
+ * `<repo>-<tag>/` and contains the FULL repo at that tag — so the plugin
+ * doesn't live at the root, it lives under a known subpath
+ * (typically `plugins/<name>/`).
+ *
+ * Walk: optional wrapper-dir descent (matching findPluginRoot's one-level
+ * walk), then descend into `subpath`. Returns null if no `plugin.json` is
+ * found at the resolved location.
+ *
+ * Path-traversal is gated upstream by `extractTarball`'s entry list check;
+ * we still refuse `..` segments in the parsed subpath (parseMonorepoRef).
+ */
+export function findMonorepoPluginRoot(stagingDir: string, subpath: string): string | null {
+  // First try: subpath relative to the staging dir directly. Local-tarball
+  // fixtures and any tarball whose entries weren't wrapped in a top-level
+  // dir hit this path.
+  const direct = join(stagingDir, subpath);
+  if (existsSync(join(direct, "plugin.json"))) return direct;
+
+  // Then: github-archive wrap style — `<repo>-<tag>/<subpath>/`. Walk one
+  // level into the lone top-level dir and retry. We don't gate on plugin.json
+  // at the staging root because the monorepo root NEVER has plugin.json — the
+  // root is the repo, plugins live under <subpath>.
+  let entries: string[];
+  try { entries = readdirSync(stagingDir); } catch { return null; }
+  if (entries.length !== 1) return null;
+  const inner = join(stagingDir, entries[0]!);
+  try {
+    if (!statSync(inner).isDirectory()) return null;
+  } catch { return null; }
+  const wrapped = join(inner, subpath);
+  if (existsSync(join(wrapped, "plugin.json"))) return wrapped;
+  return null;
+}
+
+/**
+ * Read + parse plugin.json from an unpacked dir. Returns null + logs if missing.
+ */
+export function readManifest(dir: string): PluginManifest | null {
+  const manifestPath = join(dir, "plugin.json");
+  if (!existsSync(manifestPath)) {
+    console.error(`\x1b[31m✗\x1b[0m no plugin.json at ${dir}`);
+    return null;
+  }
+  try {
+    return parseManifest(readFileSync(manifestPath, "utf8"), dir);
+  } catch (e: any) {
+    console.error(`\x1b[31m✗\x1b[0m invalid plugin.json: ${e.message}`);
+    return null;
+  }
+}
+
+/** Short sha256 prefix for the label, e.g. "abc1234" from "sha256:abc1234def…". */
+export function shortHash(sha256: string): string {
+  const idx = sha256.indexOf(":");
+  const hex = idx === -1 ? sha256 : sha256.slice(idx + 1);
+  return hex.slice(0, 7);
+}
+
+/** Print the Phase A success label block. */
+export function printInstallSuccess(
+  manifest: PluginManifest,
+  dest: string,
+  mode: "linked (dev)" | { sha256: string },
+  sourceNote?: string,
+): void {
+  const runtime = runtimeSdkVersion();
+  const caps =
+    manifest.capabilities && manifest.capabilities.length
+      ? manifest.capabilities.join(", ")
+      : "(none)";
+  const modeLabel =
+    typeof mode === "string" ? mode : `installed (sha256:${shortHash(mode.sha256)}…)`;
+  const lines = [
+    `\x1b[32m✓\x1b[0m ${manifest.name}@${manifest.version} installed${sourceNote ? " " + sourceNote : ""}`,
+    `  sdk: ${manifest.sdk} ✓ (maw ${runtime})`,
+    `  capabilities: ${caps}`,
+    `  mode: ${modeLabel}`,
+    `  dir: ${dest}`,
+    `try: maw ${manifest.cli?.command ?? manifest.name}`,
+  ];
+  console.log(lines.join("\n"));
+}

--- a/plugins/init/internal/plugin-lock.ts
+++ b/plugins/init/internal/plugin-lock.ts
@@ -1,0 +1,341 @@
+/**
+ * plugins.lock — registry-pinned plugin hashes (#487, Option A).
+ *
+ * A node-local JSON file (~/.maw/plugins.lock) that maps plugin names to
+ * approved {version, sha256, source} entries. `maw plugin install` derives
+ * the expected hash from here instead of from the tarball's own manifest,
+ * closing the circular-trust bug where an attacker who controls the tarball
+ * controls both the artifact AND its declared hash.
+ *
+ * See ψ/writing/2026-04-18/plugin-hash-supply-chain-spec.md for the spec.
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import { hashFile } from "../../../../plugin/registry";
+import { readManifest } from "./install-manifest-helpers";
+import { extractTarball } from "./install-extraction";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+export const LOCK_SCHEMA = 1;
+
+export interface LockEntry {
+  version: string;
+  sha256: string;
+  source: string;
+  added: string;
+  signers?: string[];
+  /** True iff entry was written by a `--link` (dev-clone) install. */
+  linked?: boolean;
+}
+
+export interface Lock {
+  schema: number;
+  updated: string;
+  plugins: Record<string, LockEntry>;
+}
+
+/** Default lock when none exists on disk. */
+function emptyLock(): Lock {
+  return { schema: LOCK_SCHEMA, updated: new Date().toISOString(), plugins: {} };
+}
+
+/** Resolve lock path. Honors MAW_PLUGINS_LOCK for tests. */
+export function lockPath(): string {
+  return process.env.MAW_PLUGINS_LOCK || join(homedir(), ".maw", "plugins.lock");
+}
+
+/** Validate sha256 is a canonical "sha256:" + 64 lowercase hex, or bare 64-hex. */
+export function validateSha256(value: string): { ok: true } | { ok: false; error: string } {
+  const s = typeof value === "string" ? value : "";
+  const hex = s.startsWith("sha256:") ? s.slice("sha256:".length) : s;
+  if (!/^[0-9a-f]{64}$/.test(hex)) {
+    return { ok: false, error: `invalid sha256 (want 64 lowercase hex chars, got ${JSON.stringify(s)})` };
+  }
+  return { ok: true };
+}
+
+/** Plugin names: segmented by '/', lowercase alnum + . _ - within segments. */
+export function validateName(name: string): { ok: true } | { ok: false; error: string } {
+  if (typeof name !== "string" || name.length === 0) {
+    return { ok: false, error: "plugin name required" };
+  }
+  if (!/^[a-z0-9][a-z0-9._\-\/]{0,127}$/.test(name)) {
+    return { ok: false, error: `invalid plugin name ${JSON.stringify(name)}` };
+  }
+  return { ok: true };
+}
+
+/** Schema check — refuse unknown schema versions with migration hint. */
+export function validateSchema(parsed: unknown): { ok: true; lock: Lock } | { ok: false; error: string } {
+  if (!parsed || typeof parsed !== "object") {
+    return { ok: false, error: "plugins.lock: not a JSON object" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const schema = obj.schema ?? obj["$schema"];
+  if (typeof schema !== "number") {
+    return { ok: false, error: "plugins.lock: missing numeric 'schema' field" };
+  }
+  if (schema !== LOCK_SCHEMA) {
+    return {
+      ok: false,
+      error:
+        `plugins.lock: unknown schema ${schema} (this build supports ${LOCK_SCHEMA}).\n` +
+        `  migration: upgrade maw-js or regenerate the lockfile with 'maw plugin pin' on each entry.`,
+    };
+  }
+  const plugins = obj.plugins;
+  if (plugins === undefined || typeof plugins !== "object" || plugins === null || Array.isArray(plugins)) {
+    return { ok: false, error: "plugins.lock: 'plugins' must be an object" };
+  }
+  const updated = typeof obj.updated === "string" ? obj.updated : new Date().toISOString();
+  // Per-entry validation.
+  const out: Record<string, LockEntry> = {};
+  for (const [name, entry] of Object.entries(plugins as Record<string, unknown>)) {
+    const nv = validateName(name);
+    if (!nv.ok) return { ok: false, error: `plugins.lock: ${nv.error}` };
+    if (!entry || typeof entry !== "object") {
+      return { ok: false, error: `plugins.lock: entry '${name}' is not an object` };
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.version !== "string" || !e.version) {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'version'` };
+    }
+    if (typeof e.sha256 !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'sha256'` };
+    }
+    const hv = validateSha256(e.sha256);
+    if (!hv.ok) return { ok: false, error: `plugins.lock: entry '${name}': ${hv.error}` };
+    if (typeof e.source !== "string") {
+      return { ok: false, error: `plugins.lock: entry '${name}' missing 'source'` };
+    }
+    out[name] = {
+      version: e.version,
+      sha256: e.sha256,
+      source: e.source,
+      added: typeof e.added === "string" ? e.added : updated,
+      signers: Array.isArray(e.signers) ? (e.signers as string[]).filter(s => typeof s === "string") : undefined,
+      ...(e.linked === true ? { linked: true } : {}),
+    };
+  }
+  return { ok: true, lock: { schema: LOCK_SCHEMA, updated, plugins: out } };
+}
+
+/** Warn to stderr if lockfile is world-writable. Per spec §8: warn but proceed. */
+function checkLockPermissions(path: string): void {
+  try {
+    const mode = statSync(path).mode & 0o777;
+    if ((mode & 0o022) !== 0) {
+      process.stderr.write(
+        `\x1b[33m!\x1b[0m plugins.lock is group/world-writable (mode ${mode.toString(8)}) — ` +
+        `recommend 'chmod 0644 ${path}'\n`
+      );
+    }
+  } catch { /* stat can fail on exotic filesystems — non-fatal */ }
+}
+
+/**
+ * Read + validate the lockfile. Returns an empty lock if the file does not
+ * exist (first-time use). Throws on malformed JSON or unknown schema so the
+ * caller never silently treats a broken lock as "no plugins pinned".
+ */
+export function readLock(): Lock {
+  const path = lockPath();
+  if (!existsSync(path)) return emptyLock();
+  checkLockPermissions(path);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf8"));
+  } catch (e: any) {
+    throw new Error(`plugins.lock: invalid JSON at ${path}: ${e.message}`);
+  }
+  const v = validateSchema(parsed);
+  if (!v.ok) throw new Error(v.error);
+  return v.lock;
+}
+
+/**
+ * Atomically write the lockfile. Writes to <path>.tmp then renames into place
+ * so a crashed write never leaves a half-written lock on disk.
+ */
+export function writeLock(lock: Lock): void {
+  const path = lockPath();
+  const tmp = `${path}.tmp`;
+  const content = JSON.stringify({ ...lock, updated: new Date().toISOString() }, null, 2) + "\n";
+  // Parent dir may not exist yet on fresh installs that haven't run `maw init`.
+  mkdirSync(dirname(path), { recursive: true });
+  // Exclusive create on the tmp path — if a prior write crashed and left
+  // <path>.tmp behind, we refuse to clobber without surfacing it.
+  try {
+    writeFileSync(tmp, content, { encoding: "utf8", flag: "w" });
+  } catch (e: any) {
+    throw new Error(`plugins.lock: failed to stage ${tmp}: ${e.message}`);
+  }
+  try {
+    chmodSync(tmp, 0o644);
+  } catch { /* not all filesystems support chmod — continue */ }
+  renameSync(tmp, path);
+}
+
+/**
+ * Compute sha256 of a tarball's declared artifact (matches manifest.artifact.path).
+ *
+ * #874 path A.3 — for source plugins (no `artifact`, has `entry`), the entry
+ * file's bytes ARE the artifact. Hash that instead so `maw plugin pin` works
+ * uniformly across source and built tarballs.
+ */
+function hashTarballArtifact(tarballPath: string): { ok: true; hash: string; version: string } | { ok: false; error: string } {
+  if (!existsSync(tarballPath)) {
+    return { ok: false, error: `source not found: ${tarballPath}` };
+  }
+  const staging = mkdtempSync(join(tmpdir(), "maw-pin-"));
+  try {
+    const ex = extractTarball(tarballPath, staging);
+    if (!ex.ok) return { ok: false, error: ex.error };
+    // findPluginRoot reused via the manifest helper if needed — but
+    // pinPlugin's tarballs are produced by `maw plugin build` (flat layout)
+    // OR community-source tarballs (also flat after extraction). Either way
+    // plugin.json sits at the staging root.
+    const manifest = readManifest(staging);
+    if (!manifest) return { ok: false, error: "failed to read plugin.json from tarball" };
+    // #896 — entry-first when source-shaped (covers no-artifact AND half-built
+    // artifact.sha256=null shapes). Mirrors `verifyArtifactHashAgainst` so
+    // `maw plugin pin` and `maw plugin install` both accept the same set of
+    // tarballs uniformly.
+    const hasEntry = typeof manifest.entry === "string" && manifest.entry.length > 0;
+    const isSourceShaped = hasEntry && (!manifest.artifact || manifest.artifact.sha256 === null);
+    let relPath: string;
+    if (isSourceShaped) {
+      relPath = manifest.entry!;
+    } else if (manifest.artifact) {
+      relPath = manifest.artifact.path;
+    } else if (hasEntry) {
+      relPath = manifest.entry!;
+    } else {
+      return { ok: false, error: "tarball manifest has no 'artifact' or 'entry' field — rebuild with 'maw plugin build' or declare an entry path" };
+    }
+    const artifactPath = join(staging, relPath);
+    if (!existsSync(artifactPath)) {
+      return { ok: false, error: `artifact missing at ${relPath}` };
+    }
+    const hash = hashFile(artifactPath);
+    return { ok: true, hash, version: manifest.version };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+export interface PinOptions {
+  version?: string;
+  signers?: string[];
+}
+
+export interface PinResult {
+  name: string;
+  entry: LockEntry;
+  previous?: LockEntry;
+}
+
+/**
+ * Pin a plugin: hash the tarball at `source`, stage a lockfile entry, write.
+ * Source must be a local tarball path for v1 (URL pinning needs download +
+ * cache; deferred to follow-up — document in pin command help).
+ */
+export function pinPlugin(name: string, source: string, opts: PinOptions = {}): PinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+
+  const h = hashTarballArtifact(source);
+  if (!h.ok) throw new Error(h.error);
+
+  if (opts.version !== undefined && opts.version !== h.version) {
+    throw new Error(
+      `version mismatch: --version=${opts.version} but tarball manifest.version=${h.version}`,
+    );
+  }
+
+  const lock = readLock();
+  const previous = lock.plugins[name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: h.version,
+    sha256: h.hash,
+    source,
+    added: previous?.added ?? now,
+    ...(opts.signers && opts.signers.length ? { signers: opts.signers } : {}),
+  };
+  lock.plugins[name] = entry;
+  writeLock(lock);
+  return { name, entry, previous };
+}
+
+/**
+ * #680 ask #1 — happy-path install writer.
+ *
+ * Called after a successful `maw plugin install`. Persists the artifact's
+ * sha256 into plugins.lock so subsequent installs have local truth to verify
+ * against. Idempotent: re-installing `<name>` updates the entry but preserves
+ * the original `added` timestamp.
+ *
+ * Separate from `pinPlugin` (which hashes a tarball on disk): this one trusts
+ * the caller's already-verified sha256 so we don't double-hash the artifact
+ * in the common install flow.
+ */
+export interface RecordInstallInput {
+  name: string;
+  version: string;
+  /** Canonical 64-hex sha256. For --link installs, hash of plugin.json content. */
+  sha256: string;
+  /** Tarball path, URL, or `link:<abs-path>` for --link. */
+  source: string;
+  /** True iff this was a --link (dev-clone) install. */
+  linked?: boolean;
+  signers?: string[];
+}
+
+export function recordInstall(input: RecordInstallInput): LockEntry {
+  const nv = validateName(input.name);
+  if (!nv.ok) throw new Error(nv.error);
+  const hv = validateSha256(input.sha256);
+  if (!hv.ok) throw new Error(`recordInstall(${input.name}): ${hv.error}`);
+  if (typeof input.version !== "string" || !input.version) {
+    throw new Error(`recordInstall(${input.name}): version required`);
+  }
+  if (typeof input.source !== "string" || !input.source) {
+    throw new Error(`recordInstall(${input.name}): source required`);
+  }
+  const lock = readLock();
+  const previous = lock.plugins[input.name];
+  const now = new Date().toISOString();
+  const entry: LockEntry = {
+    version: input.version,
+    sha256: input.sha256,
+    source: input.source,
+    added: previous?.added ?? now,
+    ...(input.linked === true ? { linked: true } : {}),
+    ...(input.signers && input.signers.length ? { signers: input.signers } : {}),
+  };
+  lock.plugins[input.name] = entry;
+  writeLock(lock);
+  return entry;
+}
+
+export interface UnpinResult {
+  name: string;
+  removed: LockEntry | null;
+}
+
+/** Remove a plugin from the lockfile. No-op if not present. */
+export function unpinPlugin(name: string): UnpinResult {
+  const nv = validateName(name);
+  if (!nv.ok) throw new Error(nv.error);
+  const lock = readLock();
+  const removed = lock.plugins[name] ?? null;
+  if (removed) {
+    delete lock.plugins[name];
+    writeLock(lock);
+  }
+  return { name, removed };
+}

--- a/plugins/init/non-interactive.ts
+++ b/plugins/init/non-interactive.ts
@@ -1,0 +1,77 @@
+import { parseFlags } from "../../../cli/parse-args";
+import { validateNodeName, validatePeerUrl, validatePeerName, validateGhqRoot } from "./prompts";
+
+export interface NonInteractiveOpts {
+  node: string;
+  ghqRoot?: string;
+  token?: string;
+  federate: boolean;
+  peers: { name: string; url: string }[];
+  federationToken?: string;
+  force: boolean;
+  backup: boolean;
+}
+
+export type NonInteractiveResult =
+  | { ok: true; opts: NonInteractiveOpts }
+  | { ok: false; error: string };
+
+export function parseNonInteractive(args: string[], homedir: string, defaults: { node: string }): NonInteractiveResult {
+  // arg's String type collapses repeated flags; use [String] for arrays.
+  const flags = parseFlags(args, {
+    "--non-interactive": Boolean,
+    "--node": String,
+    // #680 — --ghq-root honored as legacy override (validated + persisted); deprecation warn.
+    "--ghq-root": String,
+    "--token": String,
+    "--federate": Boolean,
+    "--peer": [String],
+    "--peer-name": [String],
+    "--federation-token": String,
+    "--force": Boolean,
+    "--backup": Boolean,
+  }, 0);
+
+  const node = flags["--node"] ?? defaults.node;
+  const nodeErr = validateNodeName(node);
+  if (nodeErr) return { ok: false, error: nodeErr };
+
+  let ghqRoot: string | undefined;
+  if (flags["--ghq-root"]) {
+    const ghqV = validateGhqRoot(flags["--ghq-root"], homedir);
+    if (!ghqV.ok) return { ok: false, error: ghqV.err };
+    ghqRoot = ghqV.path;
+    process.stderr.write(
+      `[maw init] warning: --ghq-root is deprecated (#680) — honored as legacy override; prefer removing it and letting \`ghq root\` resolve on demand.\n`,
+    );
+  }
+
+  const peerUrls = (flags["--peer"] ?? []) as string[];
+  const peerNames = (flags["--peer-name"] ?? []) as string[];
+  const peers: { name: string; url: string }[] = [];
+  for (let i = 0; i < peerUrls.length; i++) {
+    const url = peerUrls[i];
+    const urlErr = validatePeerUrl(url);
+    if (urlErr) return { ok: false, error: `--peer #${i + 1}: ${urlErr}` };
+    const name = peerNames[i] ?? `peer-${i + 1}`;
+    const nameErr = validatePeerName(name);
+    if (nameErr) return { ok: false, error: `--peer-name #${i + 1}: ${nameErr}` };
+    peers.push({ name, url });
+  }
+
+  const federate = !!flags["--federate"] || peers.length > 0;
+
+  return {
+    ok: true,
+    opts: {
+      node,
+      ghqRoot,
+      token: flags["--token"],
+      federate,
+      peers,
+      federationToken: flags["--federation-token"],
+      force: !!flags["--force"],
+      backup: !!flags["--backup"],
+    },
+  };
+}

--- a/plugins/init/plugin.json
+++ b/plugins/init/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "init",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "First-run wizard — configure ~/.config/maw/maw.config.json",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "init",
+    "help": "maw init — interactive first-run wizard. Flags: --non-interactive --node <name> --ghq-root <path> --token <t> --federate --peer <url> --peer-name <name> --federation-token <hex> --force"
+  },
+  "weight": 5
+}

--- a/plugins/init/prompts.ts
+++ b/plugins/init/prompts.ts
@@ -1,0 +1,146 @@
+import { createInterface } from "readline";
+import { createReadStream, openSync } from "fs";
+
+export type AskFn = (question: string, defaultVal?: string) => Promise<string>;
+
+export async function ttyAsk(question: string, defaultVal = ""): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const prompt = defaultVal ? `${question} [${defaultVal}]: ` : `${question}: `;
+    let fd: number;
+    try {
+      fd = openSync("/dev/tty", "r+");
+    } catch (e) {
+      reject(new Error("/dev/tty unavailable — use --non-interactive"));
+      return;
+    }
+    const rl = createInterface({
+      input: createReadStream("/dev/tty", { fd }),
+      output: process.stdout,
+      terminal: true,
+    });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultVal);
+    });
+  });
+}
+
+const NODE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}$/i;
+const PEER_NAME_RE = /^[a-z0-9][a-z0-9-]{0,30}$/i;
+
+export function validateNodeName(name: string): string | null {
+  if (!NODE_NAME_RE.test(name)) {
+    return "Node name must be 1-63 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+/**
+ * @deprecated (#680) — `ghqRoot` is no longer asked at init. Retained only so
+ * third-party callers that imported this validator keep compiling. The init
+ * flow resolves ghq root on demand via `getGhqRoot()`.
+ */
+export function validateGhqRoot(input: string, homedir: string): { ok: true; path: string } | { ok: false; err: string } {
+  if (!input) return { ok: false, err: "Path must be absolute" };
+  if (!input.startsWith("/") && !input.startsWith("~")) {
+    return { ok: false, err: "Path must be absolute (start with / or ~)" };
+  }
+  const expanded = input.startsWith("~") ? input.replace(/^~/, homedir) : input;
+  return { ok: true, path: expanded };
+}
+
+export function validatePeerUrl(url: string): string | null {
+  if (!url) return "URL required";
+  if (!/^https?:\/\//.test(url)) return "URL must start with http:// or https://";
+  try {
+    new URL(url);
+    return null;
+  } catch {
+    return `Invalid URL: ${url}`;
+  }
+}
+
+export function validatePeerName(name: string): string | null {
+  if (!PEER_NAME_RE.test(name)) {
+    return "Name must be 1-31 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+export interface PromptAnswers {
+  node: string;
+  token: string;
+  federate: boolean;
+  peers: { name: string; url: string }[];
+}
+
+const MAX_ATTEMPTS = 3;
+
+async function askUntilValid(
+  ask: AskFn,
+  question: string,
+  defaultVal: string,
+  validate: (v: string) => string | null,
+  writer: (msg: string) => void,
+): Promise<string> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const answer = await ask(question, defaultVal);
+    const err = validate(answer);
+    if (!err) return answer;
+    writer(`  \x1b[31m✗\x1b[0m ${err}`);
+    if (attempt === MAX_ATTEMPTS) {
+      throw new Error(`Aborted after ${MAX_ATTEMPTS} invalid attempts: ${question}`);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+export async function runPromptLoop(
+  ask: AskFn,
+  defaults: { node: string },
+  homedir: string,
+  writer: (msg: string) => void,
+): Promise<PromptAnswers> {
+  // #680 — ghq root is no longer prompted; it's resolved on demand via `ghq root`.
+  void homedir; // kept in signature for backward-compat (callers still pass it)
+  const node = await askUntilValid(
+    ask,
+    "Node name (this machine's identity in the federation)",
+    defaults.node,
+    validateNodeName,
+    writer,
+  );
+
+  const token = await ask("Claude token (blank = use $CLAUDE_CODE_OAUTH_TOKEN or ~/.claude/credentials)", "");
+  if (!token && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    writer(`  \x1b[33m!\x1b[0m no token provided and $CLAUDE_CODE_OAUTH_TOKEN not set — set it before running 'maw wake'`);
+  }
+
+  const federateAnswer = (await ask("Federate with other machines? (y/N)", "N")).toLowerCase();
+  const federate = federateAnswer === "y" || federateAnswer === "yes";
+
+  const peers: { name: string; url: string }[] = [];
+  if (federate) {
+    let idx = 1;
+    while (true) {
+      const url = await ask(`Peer ${idx} URL`, "done");
+      if (!url || url === "done") break;
+      const urlErr = validatePeerUrl(url);
+      if (urlErr) {
+        writer(`  \x1b[31m✗\x1b[0m ${urlErr}`);
+        continue;
+      }
+      const name = await askUntilValid(
+        ask,
+        `Peer ${idx} name (short label)`,
+        `peer-${idx}`,
+        validatePeerName,
+        writer,
+      );
+      peers.push({ name, url });
+      idx++;
+    }
+  }
+
+  return { node, token, federate, peers };
+}

--- a/plugins/init/write-config.ts
+++ b/plugins/init/write-config.ts
@@ -1,0 +1,75 @@
+import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
+import { dirname } from "path";
+import type { MawConfig } from "../../../config/types";
+
+/** Atomically write JSON config; throws EEXIST if `wx` flag and file exists. */
+export function writeConfigAtomic(filePath: string, config: Partial<MawConfig>, overwrite: boolean): void {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const body = JSON.stringify(config, null, 2) + "\n";
+  if (overwrite) {
+    writeFileSync(filePath, body, "utf-8");
+    return;
+  }
+  // wx mode: fail if exists
+  writeFileSync(filePath, body, { encoding: "utf-8", flag: "wx" });
+}
+
+export function backupConfig(filePath: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${filePath}.bak.${ts}`;
+  copyFileSync(filePath, backupPath);
+  return backupPath;
+}
+
+export function configExists(filePath: string): boolean {
+  return existsSync(filePath);
+}
+
+export interface BuildConfigInput {
+  node: string;
+  ghqRoot?: string;
+  token?: string;
+  federate?: boolean;
+  peers?: { name: string; url: string }[];
+  federationToken?: string;
+}
+
+const DEFAULT_PORT = 3456;
+const DEFAULT_ORACLE_URL = "http://localhost:47779";
+const DEFAULT_COMMAND = "claude --dangerously-skip-permissions --continue";
+
+export function buildConfig(input: BuildConfigInput): Partial<MawConfig> {
+  const env: Record<string, string> = {};
+  if (input.token) env.CLAUDE_CODE_OAUTH_TOKEN = input.token;
+
+  // #680 — ghqRoot is resolved on demand; only persist when caller explicitly
+  // passes it (legacy override path; logs deprecation in cmdInit).
+  //
+  // #906 — `host` is the SSH connection target for hostExec, NOT the node
+  // identity. Pre-#906 we wrote `host: input.node`, which made hostExec try
+  // to `ssh <node-name> <cmd>` for every fleet-pinned clone. Concrete blast
+  // radius: any user who ran `maw init --node mba` (or the prompt's default
+  // os.hostname()) had `config.host = "mba"` → wake-resolve-impl's
+  // `hostExec("ghq get …")` failed with `[ssh:mba] ssh: Could not resolve
+  // hostname mba`. The fix is small + surgical: `host` defaults to "local"
+  // (the same fallback DEFAULT_HOST uses when the field is absent), and
+  // `node` keeps the identity. Existing broken configs are healed at load
+  // time — see config/load.ts (#906 migration sibling).
+  const cfg: Partial<MawConfig> = {
+    host: "local",
+    node: input.node,
+    port: DEFAULT_PORT,
+    oracleUrl: DEFAULT_ORACLE_URL,
+    env,
+    commands: { default: DEFAULT_COMMAND },
+    sessions: {},
+  };
+  if (input.ghqRoot) cfg.ghqRoot = input.ghqRoot;
+
+  if (input.federate) {
+    cfg.federationToken = input.federationToken;
+    cfg.namedPeers = input.peers ?? [];
+  }
+
+  return cfg;
+}

--- a/plugins/kill/impl.ts
+++ b/plugins/kill/impl.ts
@@ -1,0 +1,92 @@
+import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+
+export interface KillOpts {
+  /** Pane index — narrows kill to a specific pane of the resolved window. */
+  pane?: number;
+}
+
+/**
+ * maw kill <target>[:window] [--pane N]
+ *
+ * Trust the user — if they typed it, they meant it. No --force gate.
+ *
+ *   maw kill <session>            → kill whole session
+ *   maw kill <session>:<window>   → kill that window
+ *   maw kill <target> --pane N    → kill pane N of target window
+ *
+ * Target resolution mirrors maw split: bare session names go through the
+ * canonical `resolveSessionTarget` matcher. Silent wrong-answer is worse
+ * than a loud failure.
+ */
+export async function cmdKill(target: string, opts: KillOpts = {}) {
+  if (!target) {
+    console.error("usage: maw kill <target>[:window] [--pane N]");
+    console.error("  e.g. maw kill mawjs");
+    console.error("       maw kill mawjs:0");
+    console.error("       maw kill mawjs --pane 1");
+    throw new Error("usage: maw kill <target>[:window] [--pane N]");
+  }
+
+  const [rawSession, rawWindow] = target.includes(":")
+    ? target.split(":", 2)
+    : [target, ""];
+
+  // Resolve bare session name against live fleet
+  const sessions = await listSessions();
+  const r = resolveSessionTarget(rawSession, sessions);
+
+  if (r.kind === "ambiguous") {
+    console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${r.candidates.length} sessions:`);
+    for (const s of r.candidates) {
+      console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+    }
+    console.error(`  \x1b[90m  use the full name: maw kill <exact-session>\x1b[0m`);
+    throw new Error(`'${rawSession}' is ambiguous`);
+  }
+  if (r.kind === "none") {
+    console.error(`  \x1b[31m✗\x1b[0m session '${rawSession}' not found`);
+    if (r.hints && r.hints.length > 0) {
+      console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+      for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+    } else {
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+    }
+    throw new Error(`session '${rawSession}' not found`);
+  }
+
+  const session = r.match.name;
+  const tmux = tmuxCmd();
+
+  // --pane requires a window, bare session kill does not
+  if (opts.pane !== undefined) {
+    // Default to window 0 if no window given
+    const win = rawWindow || String(r.match.windows[0]?.index ?? 0);
+    const pane = `${session}:${win}.${opts.pane}`;
+    try {
+      await hostExec(`${tmux} kill-pane -t '${pane}'`);
+      console.log(`  \x1b[32m✓\x1b[0m killed pane ${pane}`);
+    } catch (e: any) {
+      throw new Error(`kill-pane failed: ${e.message || e}`);
+    }
+    return;
+  }
+
+  if (rawWindow) {
+    const win = `${session}:${rawWindow}`;
+    try {
+      await hostExec(`${tmux} kill-window -t '${win}'`);
+      console.log(`  \x1b[32m✓\x1b[0m killed window ${win}`);
+    } catch (e: any) {
+      throw new Error(`kill-window failed: ${e.message || e}`);
+    }
+    return;
+  }
+
+  try {
+    await hostExec(`${tmux} kill-session -t '${session}'`);
+    console.log(`  \x1b[32m✓\x1b[0m killed session ${session}`);
+  } catch (e: any) {
+    throw new Error(`kill-session failed: ${e.message || e}`);
+  }
+}

--- a/plugins/kill/index.ts
+++ b/plugins/kill/index.ts
@@ -1,0 +1,53 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdKill } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "kill",
+  description: "Kill a tmux session, window, or pane.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pane?: number } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, { "--pane": Number }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw kill <target>` };
+      }
+      opts = { pane: flags["--pane"] };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) return { ok: false, error: "target is required" };
+      target = body.target as string;
+      opts = { pane: body.pane as number | undefined };
+    }
+
+    await cmdKill(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/kill/plugin.json
+++ b/plugins/kill/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "kill",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Kill a tmux session, window, or pane (trusts the user — no --force).",
+  "cli": {
+    "command": "kill",
+    "help": "maw kill <target>[:window] [--pane N]",
+    "flags": {
+      "--pane": "number"
+    }
+  },
+  "api": {
+    "path": "/api/kill",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/locate/impl.ts
+++ b/plugins/locate/impl.ts
@@ -1,0 +1,144 @@
+/**
+ * maw locate — diagnostic "where is this oracle?" command.
+ *
+ * Inspired by multi-agent-workflow-kit's `maw warp` (kit uses a bash
+ * function to cd the parent shell into a worktree). mawjs is a binary,
+ * so we can't cd the caller — instead we PRINT location info across
+ * the oracle's full information space: ghq repo, ψ/ presence, tmux
+ * session, fleet config, federation node.
+ *
+ * Use `cd $(maw locate mawjs --path)` if you want the kit's warp
+ * behavior — the shell eval does the cd.
+ */
+
+import { existsSync } from "fs";
+import { join } from "path";
+import { ghqFind } from "../../../core/ghq";
+import { listSessions, FLEET_DIR } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { UserError } from "../../../core/util/user-error";
+
+export interface LocateOpts {
+  path?: boolean;
+  json?: boolean;
+}
+
+interface LocateResult {
+  name: string;
+  repoPath: string | null;
+  hasPsi: boolean;
+  sessionName: string | null;
+  windowCount: number;
+  fleetConfigPath: string | null;
+  federationNode: string | null;
+  inAgentsConfig: boolean;
+}
+
+async function gatherInfo(oracle: string): Promise<LocateResult> {
+  // ghq repo path — try `<name>-oracle` suffix first (canonical), then bare name
+  const repoPath =
+    (await ghqFind(`/${oracle}-oracle`)) ?? (await ghqFind(`/${oracle}`));
+
+  // ψ/ presence
+  const hasPsi = repoPath ? existsSync(join(repoPath, "ψ")) : false;
+
+  // tmux session — use the alpha.77 suffix-preferred resolver so bare
+  // name resolves to the `NN-name` canonical session, not a `name-view`.
+  let sessionName: string | null = null;
+  let windowCount = 0;
+  try {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(oracle, sessions);
+    if (r.kind === "exact" || r.kind === "fuzzy") {
+      sessionName = r.match.name;
+      windowCount = r.match.windows?.length ?? 0;
+    }
+  } catch {
+    /* tmux not running — leave session null */
+  }
+
+  // Fleet config — check for a file matching this oracle
+  let fleetConfigPath: string | null = null;
+  if (sessionName) {
+    const candidate = join(FLEET_DIR, `${sessionName}.json`);
+    if (existsSync(candidate)) fleetConfigPath = candidate;
+  }
+  if (!fleetConfigPath) {
+    // Fallback: try `<oracle>-oracle.json` or `<oracle>.json`
+    for (const name of [`${oracle}-oracle`, oracle]) {
+      const candidate = join(FLEET_DIR, `${name}.json`);
+      if (existsSync(candidate)) {
+        fleetConfigPath = candidate;
+        break;
+      }
+    }
+  }
+
+  // Federation — config.agents map + node
+  const config = loadConfig();
+  const agents = config.agents ?? {};
+  const inAgentsConfig = oracle in agents;
+  const federationNode = inAgentsConfig ? agents[oracle]! : (config.node ?? null);
+
+  return {
+    name: oracle,
+    repoPath,
+    hasPsi,
+    sessionName,
+    windowCount,
+    fleetConfigPath,
+    federationNode,
+    inAgentsConfig,
+  };
+}
+
+export async function cmdLocate(oracle: string | undefined, opts: LocateOpts = {}): Promise<void> {
+  if (!oracle) {
+    console.error("usage: maw locate <oracle> [--path | --json]");
+    console.error("  e.g. maw locate mawjs");
+    throw new UserError("missing oracle name");
+  }
+
+  const info = await gatherInfo(oracle);
+
+  // Nothing found at all → not-found error (mirrors alpha.75 oracle-about fix)
+  if (!info.repoPath && !info.sessionName && !info.fleetConfigPath) {
+    throw new UserError(`no oracle named '${oracle}' — try: maw oracle ls`);
+  }
+
+  if (opts.json) {
+    console.log(JSON.stringify(info, null, 2));
+    return;
+  }
+
+  if (opts.path) {
+    // --path emits ONE clean line for shell substitution: cd $(maw locate X --path)
+    if (!info.repoPath) {
+      throw new UserError(
+        `no repo path for '${oracle}' (session: ${info.sessionName ?? "none"}, fleet: ${info.fleetConfigPath ? "yes" : "no"})`,
+      );
+    }
+    console.log(info.repoPath);
+    return;
+  }
+
+  // Default: human-readable multi-line summary. Omit missing fields rather
+  // than faking values (per #390.2 — fake-success is worse than missing info).
+  console.log(`\n📍 ${oracle}`);
+  if (info.repoPath) {
+    console.log(`   repo:     ${info.repoPath}`);
+    console.log(`   ψ/:       ${info.hasPsi ? "present" : "missing"}`);
+  }
+  if (info.sessionName) {
+    console.log(`   session:  ${info.sessionName} (${info.windowCount} window${info.windowCount === 1 ? "" : "s"})`);
+  }
+  if (info.fleetConfigPath) {
+    console.log(`   fleet:    ${info.fleetConfigPath}`);
+  }
+  if (info.federationNode) {
+    const suffix = info.inAgentsConfig ? " (from config.agents)" : " (this node)";
+    console.log(`   node:     ${info.federationNode}${suffix}`);
+  }
+  console.log();
+}

--- a/plugins/locate/index.ts
+++ b/plugins/locate/index.ts
@@ -1,0 +1,44 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdLocate } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "locate",
+  description: "Locate an oracle — repo path, session, fleet config, federation node.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.args ?? [];
+  const flags = parseFlags(args, {
+    "--path": Boolean,
+    "-p": "--path",
+    "--json": Boolean,
+  }, 0);
+
+  const oracle = flags._[0];
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    await cmdLocate(oracle, {
+      path: flags["--path"],
+      json: flags["--json"],
+    });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: logs.join("\n") || msg, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/locate/locate.test.ts
+++ b/plugins/locate/locate.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Smoke tests for maw locate (alpha.79).
+ *
+ * Strategy: test arg-parsing + error paths directly. Full happy-path
+ * requires live ghq + tmux + fleet state, which is hard to reproduce
+ * reliably — gates those as `.skip` with reason.
+ */
+
+import { describe, test, expect } from "bun:test";
+import handler, { command } from "./index";
+import type { InvokeContext } from "../../../plugin/types";
+
+function makeCtx(args: string[]): InvokeContext {
+  return {
+    args,
+    cwd: process.cwd(),
+    env: process.env,
+  } as InvokeContext;
+}
+
+describe("maw locate — metadata", () => {
+  test("exports command with name + description", () => {
+    expect(command.name).toBe("locate");
+    expect(command.description).toContain("oracle");
+  });
+});
+
+describe("maw locate — error paths", () => {
+  test("missing oracle arg returns ok:false with usage hint", async () => {
+    const result = await handler(makeCtx([]));
+    expect(result.ok).toBe(false);
+    expect(result.error?.toLowerCase()).toContain("usage: maw locate");
+  });
+
+  test("nonexistent oracle returns ok:false with 'no oracle named'", async () => {
+    const result = await handler(makeCtx(["definitely-nonexistent-oracle-xxxyyy"]));
+    expect(result.ok).toBe(false);
+    expect(result.error?.toLowerCase()).toContain("no oracle named");
+    expect(result.error?.toLowerCase()).toContain("maw oracle ls");
+  });
+
+  test("--path on a real oracle returns single line (live — skipped if mawjs missing)", async () => {
+    const result = await handler(makeCtx(["mawjs", "--path"]));
+    // This test runs live — if mawjs-oracle is on the local ghq, the path is emitted.
+    // If not, it'll be ok:false with "no oracle named" — both valid for CI.
+    if (result.ok) {
+      expect(result.output).toContain("/");
+      expect(result.output?.split("\n").filter(Boolean).length).toBe(1);
+    } else {
+      expect(result.error?.toLowerCase()).toMatch(/no oracle named|no repo path/);
+    }
+  });
+
+  test("--json on real oracle returns parseable JSON", async () => {
+    const result = await handler(makeCtx(["mawjs", "--json"]));
+    if (result.ok) {
+      const parsed = JSON.parse(result.output || "{}");
+      expect(parsed.name).toBe("mawjs");
+      // These fields exist in the shape regardless of resolution state
+      expect(parsed).toHaveProperty("repoPath");
+      expect(parsed).toHaveProperty("hasPsi");
+      expect(parsed).toHaveProperty("sessionName");
+      expect(parsed).toHaveProperty("fleetConfigPath");
+      expect(parsed).toHaveProperty("federationNode");
+      expect(parsed).toHaveProperty("inAgentsConfig");
+    } else {
+      // If mawjs isn't resolvable on this machine, the error path is also fine
+      expect(result.error?.toLowerCase()).toContain("no oracle named");
+    }
+  });
+});

--- a/plugins/locate/plugin.json
+++ b/plugins/locate/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "locate",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Locate an oracle — repo path, session, fleet config, federation node. Diagnostic, no side effects.",
+  "cli": {
+    "command": "locate",
+    "help": "maw locate <oracle> [--path | --json]"
+  },
+  "weight": 15
+}

--- a/plugins/on/index.ts
+++ b/plugins/on/index.ts
@@ -1,0 +1,73 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "on",
+  description: "Create event triggers for oracle lifecycle events.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { loadConfig, saveConfig } = await import("../../../config");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    const oracle = args[0];
+    const event = args[1] as "agent-idle" | "agent-wake" | "agent-crash";
+    const isOnce = args.includes("--once");
+    const actionIdx = args.indexOf("--once") !== -1 ? args.indexOf("--once") + 1 : 2;
+    const timeoutIdx = args.indexOf("--timeout");
+    const timeout = timeoutIdx !== -1 ? parseInt(args[timeoutIdx + 1]) : 30;
+
+    // Filter out --once, --timeout, and its value from the action parts
+    const action = args.slice(actionIdx).filter((a, i, arr) => {
+      if (a === "--once") return false;
+      if (a === "--timeout") return false;
+      // skip the value after --timeout
+      if (i > 0 && arr[i - 1] === "--timeout") return false;
+      return true;
+    }).join(" ");
+
+    if (!oracle || !event || !action) {
+      console.log(`\x1b[36mUsage:\x1b[0m maw on <oracle> <event> [--once] [--timeout N] "<action>"`);
+      console.log(`\n\x1b[33mEvents:\x1b[0m agent-idle, agent-wake, agent-crash`);
+      console.log(`\n\x1b[33mExamples:\x1b[0m`);
+      console.log(`  maw on neo idle --once "maw hey homekeeper 'neo done'"`);
+      console.log(`  maw on neo crash "maw wake neo"`);
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    const config = loadConfig();
+    const trigger = {
+      on: `agent-${event}` as any,
+      repo: oracle,
+      timeout,
+      action,
+      name: `on-${oracle}-${event}`,
+      once: isOnce || undefined,
+    };
+    const triggers = [...(config.triggers || []), trigger];
+    saveConfig({ triggers });
+
+    const badge = isOnce ? " \x1b[33m[once]\x1b[0m" : "";
+    console.log(`\x1b[32m✓\x1b[0m trigger added: on ${oracle} ${event}${badge} → ${action}`);
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/on/plugin.json
+++ b/plugins/on/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "on",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Create event triggers for oracle lifecycle events.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "on",
+    "help": "maw on <oracle> <event> [--once] [--timeout N] \"<action>\" — Create event triggers for oracle lifecycle events",
+    "flags": {
+      "--once": "boolean",
+      "--timeout": "string"
+    }
+  },
+  "weight": 10
+}

--- a/plugins/overview/impl.ts
+++ b/plugins/overview/impl.ts
@@ -1,0 +1,157 @@
+import { listSessions, hostExec } from "../../../sdk";
+import { tmux } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import type { Session } from "../../../sdk";
+
+export interface OverviewTarget {
+  session: string;
+  window: number;
+  windowName: string;
+  oracle: string;
+}
+
+export const PANES_PER_PAGE = 9;
+
+export function buildTargets(sessions: Session[], filters: string[]): OverviewTarget[] {
+  let targets = sessions
+    .filter(s => /^\d+-/.test(s.name) && s.name !== "0-overview")
+    .map(s => {
+      const active = s.windows.find(w => w.active) || s.windows[0];
+      const oracleName = s.name.replace(/^\d+-/, "");
+      return { session: s.name, window: active?.index ?? 1, windowName: active?.name ?? oracleName, oracle: oracleName };
+    });
+
+  if (filters.length) {
+    targets = targets.filter(t => filters.some(f => t.oracle.includes(f) || t.session.includes(f)));
+  }
+
+  return targets;
+}
+
+const PANE_COLORS = [
+  "colour204",  // pink
+  "colour114",  // green
+  "colour81",   // blue
+  "colour220",  // yellow
+  "colour177",  // purple
+  "colour208",  // orange
+  "colour44",   // cyan
+  "colour196",  // red
+  "colour83",   // lime
+  "colour141",  // lavender
+];
+
+export function paneColor(index: number): string {
+  return PANE_COLORS[index % PANE_COLORS.length];
+}
+
+export function paneTitle(t: OverviewTarget): string {
+  return `${t.oracle} (${t.session}:${t.window})`;
+}
+
+export function processMirror(raw: string, lines: number): string {
+  const sep = '─'.repeat(60);
+  const filtered = raw
+    .replace(/[─━]{6,}/g, sep)
+    .split('\n')
+    .filter(l => l.trim() !== '');
+  const visible = filtered.slice(-lines);
+  const pad = Math.max(0, lines - visible.length);
+  return '\n'.repeat(pad) + visible.join('\n');
+}
+
+export function mirrorCmd(t: OverviewTarget): string {
+  const target = encodeURIComponent(`${t.session}:${t.window}`);
+  const port = loadConfig().port;
+  return `watch --color -t -n0.5 'curl -s "http://localhost:${port}/api/mirror?target=${target}&lines=$(tput lines)"'`;
+}
+
+export function pickLayout(count: number): string {
+  if (count <= 2) return "even-horizontal";
+  return "tiled";  // 2×2 grid
+}
+
+export function chunkTargets(targets: OverviewTarget[]): OverviewTarget[][] {
+  const pages: OverviewTarget[][] = [];
+  for (let i = 0; i < targets.length; i += PANES_PER_PAGE) {
+    pages.push(targets.slice(i, i + PANES_PER_PAGE));
+  }
+  return pages;
+}
+
+export async function cmdOverview(filterArgs: string[]) {
+  const kill = filterArgs.includes("--kill") || filterArgs.includes("-k");
+  const filters = filterArgs.filter(a => !a.startsWith("-"));
+
+  // Kill existing overview
+  await tmux.killSession("0-overview");
+  if (kill) { console.log("overview killed"); return; }
+
+  // Gather oracle targets
+  const sessions = await listSessions();
+  const targets = buildTargets(sessions, filters);
+
+  if (!targets.length) { console.error("no oracle sessions found"); return; }
+
+  const pages = chunkTargets(targets);
+
+  // Create overview session with first window
+  await tmux.newSession("0-overview", { window: "page-1" });
+
+  // Style: pane borders
+  await tmux.set("0-overview", "pane-border-status", "top");
+  await tmux.set("0-overview", "pane-border-format", " #{pane_title} ");
+  await tmux.set("0-overview", "pane-border-style", "fg=colour238");
+  await tmux.set("0-overview", "pane-active-border-style", "fg=colour45");
+
+  // Style: status bar
+  await tmux.set("0-overview", "status-style", "bg=colour235,fg=colour248");
+  await tmux.set("0-overview", "status-left-length", "40");
+  await tmux.set("0-overview", "status-right-length", "60");
+  await tmux.set("0-overview", "status-left", `#[fg=colour16,bg=colour204,bold] \u2588 MAW #[fg=colour204,bg=colour238] #[fg=colour255,bg=colour238] ${targets.length} oracles #[fg=colour238,bg=colour235] `);
+  await tmux.set("0-overview", "status-right", `#[fg=colour238,bg=colour235]#[fg=colour114,bg=colour238] \u25cf live #[fg=colour81,bg=colour238] %H:%M #[fg=colour16,bg=colour81,bold] %d-%b `);
+  await tmux.set("0-overview", "status-justify", "centre");
+  await tmux.set("0-overview", "window-status-format", "#[fg=colour248,bg=colour235] #I:#W ");
+  await tmux.set("0-overview", "window-status-current-format", "#[fg=colour16,bg=colour45,bold] #I:#W ");
+
+  for (let p = 0; p < pages.length; p++) {
+    const page = pages[p];
+    const winName = `page-${p + 1}`;
+
+    // First page uses the already-created window
+    if (p > 0) {
+      await tmux.newWindow("0-overview", winName);
+    }
+
+    // First pane — set colored title and start mirror
+    const baseIdx = p * PANES_PER_PAGE;
+    const pane0 = `0-overview:${winName}.0`;
+    const color0 = paneColor(baseIdx);
+    await tmux.selectPane(pane0, { title: `#[fg=${color0},bold]${paneTitle(page[0])}#[default]` });
+    await tmux.sendKeys(pane0, mirrorCmd(page[0]), "Enter");
+
+    // Split for remaining targets in this page
+    for (let i = 1; i < page.length; i++) {
+      await tmux.splitWindow(`0-overview:${winName}`);
+      const paneId = `0-overview:${winName}.${i}`;
+      const color = paneColor(baseIdx + i);
+      await tmux.selectPane(paneId, { title: `#[fg=${color},bold]${paneTitle(page[i])}#[default]` });
+      await tmux.sendKeys(paneId, mirrorCmd(page[i]), "Enter");
+      await tmux.selectLayout(`0-overview:${winName}`, "tiled");
+    }
+
+    // Final layout for this page
+    const layout = pickLayout(page.length);
+    await tmux.selectLayout(`0-overview:${winName}`, layout);
+  }
+
+  // Go back to first window
+  await tmux.selectWindow("0-overview:page-1");
+
+  console.log(`\x1b[32m✅\x1b[0m overview: ${targets.length} oracles across ${pages.length} page${pages.length > 1 ? 's' : ''}`);
+  for (let p = 0; p < pages.length; p++) {
+    console.log(`  page-${p + 1}: ${pages[p].map(t => t.oracle).join(', ')}`);
+  }
+  console.log(`\n  attach: tmux attach -t 0-overview`);
+  if (pages.length > 1) console.log(`  navigate: Ctrl-b n/p (next/prev page)`);
+}

--- a/plugins/overview/index.ts
+++ b/plugins/overview/index.ts
@@ -1,0 +1,31 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdOverview } from "./impl";
+
+export const command = {
+  name: "overview",
+  description: "Show fleet overview / war room dashboard.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    await cmdOverview(args);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/overview/plugin.json
+++ b/plugins/overview/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "overview",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Show fleet overview / war room dashboard.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "overview",
+    "aliases": [
+      "warroom",
+      "ov"
+    ],
+    "help": "maw overview [args] — show fleet overview / war room dashboard"
+  },
+  "weight": 10
+}

--- a/plugins/pair/codes.ts
+++ b/plugins/pair/codes.ts
@@ -1,0 +1,71 @@
+/**
+ * Pair codes — gen, shape, TTL, single-use (#573).
+ * 32-char reduced alphabet (no I/O/0/1/l). 6 chars = 30 bits entropy.
+ */
+
+export const ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+export interface PairEntry {
+  code: string;          // normalized: no hyphen, upper-case
+  expiresAt: number;
+  consumed: boolean;
+  createdAt: number;
+}
+
+export function normalize(raw: string): string {
+  return raw.replace(/[-\s]/g, "").toUpperCase();
+}
+
+export function isValidShape(code: string): boolean {
+  const c = normalize(code);
+  if (c.length !== 6) return false;
+  for (const ch of c) if (!ALPHABET.includes(ch)) return false;
+  return true;
+}
+
+export function pretty(code: string): string {
+  const c = normalize(code);
+  return c.length === 6 ? `${c.slice(0, 3)}-${c.slice(3)}` : c;
+}
+
+export function redact(code: string): string {
+  const c = normalize(code);
+  return c.length >= 3 ? `${c.slice(0, 3)}-***` : "***";
+}
+
+export function generateCode(): string {
+  const bytes = new Uint8Array(6);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < 6; i++) out += ALPHABET[bytes[i] % 32];
+  return out;
+}
+
+const store = new Map<string, PairEntry>();
+
+export function register(code: string, ttlMs: number): PairEntry {
+  const entry: PairEntry = { code: normalize(code), expiresAt: Date.now() + ttlMs, consumed: false, createdAt: Date.now() };
+  store.set(entry.code, entry);
+  return entry;
+}
+
+export type LookupResult = { ok: true; entry: PairEntry } | { ok: false; reason: "not_found" | "expired" | "consumed" };
+
+export function lookup(code: string): LookupResult {
+  const entry = store.get(normalize(code));
+  if (!entry) return { ok: false, reason: "not_found" };
+  if (entry.consumed) return { ok: false, reason: "consumed" };
+  if (Date.now() > entry.expiresAt) return { ok: false, reason: "expired" };
+  return { ok: true, entry };
+}
+
+/** Atomically mark consumed. */
+export function consume(code: string): LookupResult {
+  const r = lookup(code);
+  if (!r.ok) return r;
+  r.entry.consumed = true;
+  return r;
+}
+
+export function _resetStore(): void { store.clear(); }
+export function _inject(entry: PairEntry): void { store.set(entry.code, entry); }

--- a/plugins/pair/handshake.ts
+++ b/plugins/pair/handshake.ts
@@ -1,0 +1,49 @@
+/**
+ * Pair handshake HTTP client — acceptor side (#573).
+ * No HMAC here — the code itself authenticates this single exchange.
+ */
+
+export interface HandshakeRequest { node: string; url: string }
+export interface HandshakeSuccess { ok: true; node: string; url: string; federationToken: string }
+export interface HandshakeFailure { ok: false; error: string; status: number }
+export type HandshakeResult = HandshakeSuccess | HandshakeFailure;
+
+/** POST <baseUrl>/api/pair/<code> with acceptor identity. */
+export async function postHandshake(
+  baseUrl: string,
+  code: string,
+  body: HandshakeRequest,
+  timeoutMs = 5000,
+): Promise<HandshakeResult> {
+  const url = new URL(`/api/pair/${encodeURIComponent(code)}`, baseUrl);
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: ctrl.signal,
+    });
+    const j = await res.json().catch(() => ({})) as Record<string, unknown>;
+    if (res.ok && j.ok) {
+      return { ok: true, node: String(j.node ?? ""), url: String(j.url ?? ""), federationToken: String(j.federationToken ?? "") };
+    }
+    return { ok: false, error: String(j.error ?? res.statusText ?? "unknown"), status: res.status };
+  } catch (e: any) {
+    return { ok: false, error: e?.name === "AbortError" ? "timeout" : (e?.message ?? "network_error"), status: 0 };
+  } finally {
+    clearTimeout(t);
+  }
+}
+
+/** Warn if handshake targets plain-HTTP over non-loopback. */
+export function warnIfPlainHttp(targetUrl: string): void {
+  try {
+    const u = new URL(targetUrl);
+    const isLoopback = u.hostname === "localhost" || u.hostname === "127.0.0.1" || u.hostname === "::1";
+    if (u.protocol === "http:" && !isLoopback) {
+      console.warn("⚠ pairing over plain HTTP — TLS recommended for cross-network pairing");
+    }
+  } catch { /* bad URL — fetch will surface */ }
+}

--- a/plugins/pair/impl.ts
+++ b/plugins/pair/impl.ts
@@ -1,0 +1,91 @@
+/**
+ * maw pair — CLI glue (#573). pairGenerate (recipient) + pairAccept (initiator).
+ * HTTP server-to-server: initiator supplies the target URL explicitly.
+ * Both paths end with cmdAdd() so peers.json has reciprocal aliases.
+ */
+
+import { loadConfig } from "../../../config";
+import { cmdAdd } from "./internal/peers-impl";
+import { postHandshake, warnIfPlainHttp } from "./handshake";
+import { normalize, isValidShape, redact } from "./codes";
+
+export interface GenerateOpts { expiresSec?: number; pollIntervalMs?: number; localUrl?: string }
+export interface GenerateResult { ok: boolean; code?: string; remoteNode?: string; error?: string }
+
+function validateUrl(raw: string): string | null {
+  let u: URL;
+  try { u = new URL(raw); } catch { return `invalid URL "${raw}"`; }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return `invalid URL "${raw}" (must be http:// or https://)`;
+  return null;
+}
+
+export async function pairGenerate(opts: GenerateOpts = {}): Promise<GenerateResult> {
+  const port = loadConfig().port ?? 3456;
+  const base = opts.localUrl ?? `http://localhost:${port}`;
+  const ttlMs = (opts.expiresSec ?? 120) * 1000;
+  let gen: Response;
+  try {
+    gen = await fetch(new URL("/api/pair/generate", base), {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ttlMs }),
+    });
+  } catch (e: any) {
+    return { ok: false, error: `cannot reach local server at ${base}: ${e?.message ?? "network_error"} (is 'maw serve' running?)` };
+  }
+  if (!gen.ok) return { ok: false, error: `generate failed: ${gen.status}` };
+  const body = await gen.json() as { code: string; expiresAt: number };
+  const code = body.code;
+  const expiresSec = Math.ceil((body.expiresAt - Date.now()) / 1000);
+  console.log(`🤝 pair code: ${code}  (expires ${expiresSec}s)`);
+  console.log(`   listening on ${base}/api/pair/${normalize(code)}`);
+
+  const interval = opts.pollIntervalMs ?? 1000;
+  const deadline = body.expiresAt;
+  while (Date.now() < deadline) {
+    await new Promise(r => setTimeout(r, interval));
+    const r = await fetch(new URL(`/api/pair/${normalize(code)}/status`, base)).catch(() => null);
+    if (!r) continue;
+    if (r.status === 410) return { ok: false, error: "code expired before acceptor arrived" };
+    const s = await r.json().catch(() => ({})) as { consumed?: boolean; remoteNode?: string; remoteUrl?: string };
+    if (s.consumed) {
+      console.log(`✅ paired with ${s.remoteNode} at ${s.remoteUrl}`);
+      console.log(`   added peer alias: ${s.remoteNode} → ${s.remoteUrl}`);
+      return { ok: true, code, remoteNode: s.remoteNode };
+    }
+  }
+  return { ok: false, error: "pair code expired — no acceptor" };
+}
+
+export interface AcceptOpts { localUrl?: string }
+
+export async function pairAccept(url: string, rawCode: string, opts: AcceptOpts = {}): Promise<GenerateResult> {
+  const urlErr = validateUrl(url);
+  if (urlErr) return { ok: false, error: urlErr };
+  if (!isValidShape(rawCode)) return { ok: false, error: `invalid code shape: ${redact(rawCode)}` };
+  const code = normalize(rawCode);
+  warnIfPlainHttp(url);
+
+  const myPort = loadConfig().port ?? 3456;
+  const myNode = loadConfig().node ?? "local";
+  const myUrl = opts.localUrl ?? `http://localhost:${myPort}`;
+  console.log(`🤝 posting to ${url}/api/pair/${code} ...`);
+  const res = await postHandshake(url, code, { node: myNode, url: myUrl });
+  if (!res.ok) {
+    const hint = res.status === 410 ? " (code expired or already consumed)"
+      : res.status === 404 ? " (code not found — check spelling or regenerate)"
+      : res.status === 400 ? " (bad request — check code shape)"
+      : res.status === 0   ? " (network unreachable — check URL + server running)"
+      : "";
+    return { ok: false, error: `handshake failed: ${res.error}${hint}` };
+  }
+
+  try {
+    await cmdAdd({ alias: res.node, url: res.url || url, node: res.node });
+    console.log(`✅ paired: ${res.node} ↔ ${myNode}`);
+    console.log(`   added peer alias: ${res.node} → ${res.url || url}`);
+  } catch (e: any) {
+    return { ok: false, error: `paired but peer write failed: ${e?.message ?? "unknown"}` };
+  }
+  return { ok: true, code, remoteNode: res.node };
+}

--- a/plugins/pair/index.ts
+++ b/plugins/pair/index.ts
@@ -1,0 +1,77 @@
+/**
+ * maw pair — dispatcher (#573).
+ * HTTP server-to-server pairing with explicit URL + ephemeral code.
+ *
+ *   maw pair generate [--expires <sec>]   — recipient: mint code, listen
+ *   maw pair <url> <code>                 — initiator: post to remote server
+ */
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "pair",
+  description: "HTTP server-to-server federation pairing — ephemeral code handshake (#573).",
+};
+
+function help(): string {
+  return [
+    "usage:",
+    "  maw pair generate [--expires <sec>]    — recipient: print code, listen",
+    "  maw pair <url> <code>                  — initiator: post handshake to <url>",
+    "",
+    "example: B: `maw pair generate` → prints W4K-7F3; A: `maw pair http://b:5002 W4K-7F3`",
+    "replaces manual federation-token copy-paste (#565 facet 3).",
+  ].join("\n");
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { pairGenerate, pairAccept } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log, origErr = console.error, origWarn = console.warn;
+  console.log = (...a: any[]) => ctx.writer ? ctx.writer(...a) : logs.push(a.map(String).join(" "));
+  console.error = (...a: any[]) => ctx.writer ? ctx.writer(...a) : logs.push(a.map(String).join(" "));
+  console.warn = (...a: any[]) => ctx.writer ? ctx.writer(...a) : logs.push(a.map(String).join(" "));
+  const out = () => logs.join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter(a => !a.startsWith("--"));
+    const flagVal = (n: string) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : undefined; };
+
+    if (positional.length === 0) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    if (positional[0] === "generate") {
+      const expires = flagVal("--expires");
+      const expiresSec = expires ? parseInt(expires, 10) : undefined;
+      if (expires && (!expiresSec || expiresSec < 5 || expiresSec > 3600)) {
+        return { ok: false, error: "--expires must be 5..3600 seconds" };
+      }
+      const res = await pairGenerate({ expiresSec });
+      if (!res.ok) return { ok: false, error: res.error, output: out() || undefined };
+      return { ok: true, output: out() };
+    }
+
+    if (positional.length >= 2 && /^https?:\/\//.test(positional[0])) {
+      const [url, code] = positional;
+      const res = await pairAccept(url, code);
+      if (!res.ok) return { ok: false, error: res.error, output: out() || undefined };
+      return { ok: true, output: out() };
+    }
+
+    console.log(help());
+    return {
+      ok: false,
+      error: `maw pair: unexpected args (got "${positional.join(" ")}") — expected 'generate' or '<url> <code>'`,
+      output: out() || help(),
+    };
+  } catch (e: any) {
+    return { ok: false, error: e?.message ?? String(e), output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+    console.warn = origWarn;
+  }
+}

--- a/plugins/pair/internal/lock.ts
+++ b/plugins/pair/internal/lock.ts
@@ -1,0 +1,78 @@
+/**
+ * maw peers — file lock for concurrent writers (#572 nit 3).
+ *
+ * Mirrors the pattern in src/cli/update-lock.ts: O_EXCL create on a
+ * sibling `.lock` file, write our pid, retry on EEXIST. If the holder
+ * pid is gone (kill -0 → ESRCH) we steal the lock immediately rather
+ * than waiting out the timeout. Synchronous (no await) so it composes
+ * with the existing sync savePeers signature without a contract change.
+ *
+ * Sized for CLI use: 5s deadline, 50ms poll. peers.json writes are
+ * sub-millisecond, so racing CLIs almost always succeed on first try.
+ */
+import { openSync, closeSync, unlinkSync, writeSync, readSync, existsSync } from "fs";
+
+const DEADLINE_MS = 5_000;
+const POLL_MS = 50;
+
+function isAlive(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e: any) {
+    return e.code === "EPERM";
+  }
+}
+
+function sleepSync(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) { /* spin — short waits only */ }
+}
+
+/** Run fn() while holding an exclusive lock on `<path>.lock`. Synchronous. */
+export function withPeersLock<T>(path: string, fn: () => T): T {
+  const lockPath = `${path}.lock`;
+  const deadline = Date.now() + DEADLINE_MS;
+  let fd: number | null = null;
+
+  while (true) {
+    try {
+      fd = openSync(lockPath, "wx"); // O_CREAT | O_EXCL
+      // fd-based write — prevents path-TOCTOU symlink swap between open and write.
+      // See #562 / #581 (exemplar fix in src/cli/update-lock.ts).
+      const pidBytes = Buffer.from(String(process.pid));
+      writeSync(fd, pidBytes, 0, pidBytes.length, 0);
+      break;
+    } catch (e: any) {
+      if (e.code !== "EEXIST") throw e;
+      // fd-based read for the same TOCTOU reason as the write above.
+      // Fixed 64-byte buffer — PIDs are ≤20 digits on every supported OS, so
+      // no fstatSync needed (also avoids the CodeQL "stat-then-read" pattern).
+      let holderPid = NaN;
+      let readFd: number | null = null;
+      try {
+        readFd = openSync(lockPath, "r");
+        const buf = Buffer.alloc(64);
+        const n = readSync(readFd, buf, 0, buf.length, 0);
+        holderPid = parseInt(buf.subarray(0, n).toString("utf-8").trim(), 10);
+      } catch { /* empty/racy — treat as stale */ }
+      finally { if (readFd !== null) { try { closeSync(readFd); } catch {} } }
+      if (!isAlive(holderPid)) {
+        try { unlinkSync(lockPath); } catch { /* race with another stealer is fine */ }
+        continue;
+      }
+      if (Date.now() > deadline) {
+        throw new Error(`peers lock timeout: pid ${holderPid} still holds ${lockPath}`);
+      }
+      sleepSync(POLL_MS);
+    }
+  }
+
+  try {
+    return fn();
+  } finally {
+    try { if (fd !== null) closeSync(fd); } catch { /* ignore */ }
+    try { if (existsSync(lockPath)) unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+}

--- a/plugins/pair/internal/peers-impl.ts
+++ b/plugins/pair/internal/peers-impl.ts
@@ -1,0 +1,270 @@
+/**
+ * maw peers — subcommand implementations (#568).
+ *
+ * Pure(-ish) functions for CRUD over `~/.maw/peers.json`. No CLI
+ * parsing here — the dispatcher in index.ts peels off `args[0]` and
+ * hands typed positional + flag data to these functions.
+ *
+ * Node resolution (when `--node` is not given) is intentionally
+ * best-effort: we try `<url>/info`, and on any error (missing endpoint,
+ * DNS, timeout) we store `node: null`. An alias without a node is still
+ * valid — it just means `alias:<agent>` routing needs the URL-to-node
+ * map from another source. That's a follow-up concern.
+ */
+import { loadPeers, mutatePeers, type Peer, type LastError } from "./store";
+import { probePeer } from "./probe";
+import { evaluatePeerIdentity, applyTofuDecision, PeerPubkeyMismatchError } from "./tofu";
+
+const ALIAS_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
+
+export function validateAlias(alias: string): string | null {
+  if (!ALIAS_RE.test(alias)) {
+    return `invalid alias "${alias}" (must match ^[a-z0-9][a-z0-9_-]{0,31}$)`;
+  }
+  return null;
+}
+
+export function validateUrl(raw: string): string | null {
+  let parsed: URL;
+  try { parsed = new URL(raw); } catch { return `invalid URL "${raw}"`; }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `invalid URL "${raw}" (must be http:// or https://)`;
+  }
+  return null;
+}
+
+/**
+ * Thin back-compat wrapper returning `string | null`. New callers should
+ * use probePeer() directly to get structured errors — but pre-#565 code
+ * paths that only want the node name keep working unchanged.
+ */
+export async function resolveNode(url: string): Promise<string | null> {
+  const res = await probePeer(url);
+  return res.node;
+}
+
+export interface AddOptions {
+  alias: string;
+  url: string;
+  node?: string;
+}
+
+export interface AddResult {
+  alias: string;
+  overwrote: boolean;
+  peer: Peer;
+  /** Probe error, if the /info handshake failed. Caller prints a loud warning. */
+  probeError?: LastError;
+  /** Set when the cached pubkey did not match the peer's advertised pubkey (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdAdd(opts: AddOptions): Promise<AddResult> {
+  const aliasErr = validateAlias(opts.alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const urlErr = validateUrl(opts.url);
+  if (urlErr) throw new Error(urlErr);
+
+  // Probe OUTSIDE the lock — it does network I/O. If --node was supplied
+  // we still probe to surface errors, but the user-supplied node wins.
+  const probe = await probePeer(opts.url);
+  const resolvedNode = opts.node ?? probe.node ?? null;
+
+  // TOFU evaluation against any pre-existing cache entry for this alias.
+  // Decided BEFORE we overwrite so a re-`add` of the same alias against a
+  // peer whose key changed is refused at the cache layer (operator must
+  // `maw peers forget` first). Bootstrap path stamps the pubkey on the
+  // freshly-written entry, so we evaluate now but apply after the write.
+  const existingForTofu = loadPeers().peers[opts.alias];
+  const tofuDecision = evaluatePeerIdentity(opts.alias, existingForTofu, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias: opts.alias,
+      overwrote: Boolean(existingForTofu),
+      peer: existingForTofu!, // unchanged on disk — we refuse the write
+      probeError: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        opts.alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  const peer: Peer = {
+    url: opts.url,
+    node: resolvedNode,
+    addedAt: new Date().toISOString(),
+    lastSeen: probe.error ? null : new Date().toISOString(),
+  };
+  if (probe.error) peer.lastError = probe.error;
+  if (probe.nickname) peer.nickname = probe.nickname;
+  // Preserve cached pubkey across re-adds — TOFU has already certified it
+  // matches (or is absent). On bootstrap, stamp the new pubkey now so the
+  // returned AddResult.peer reflects on-disk state in one go.
+  if (existingForTofu?.pubkey) {
+    peer.pubkey = existingForTofu.pubkey;
+    peer.pubkeyFirstSeen = existingForTofu.pubkeyFirstSeen;
+  } else if (tofuDecision.kind === "tofu-bootstrap") {
+    peer.pubkey = tofuDecision.observed!;
+    peer.pubkeyFirstSeen = new Date().toISOString();
+  }
+  // Identity (#804 Step 3): capture from probe when available; fall back to
+  // any previously-cached identity so a transient /api/identity blip on
+  // re-add doesn't lose what we already know about this peer.
+  if (probe.identity) {
+    peer.identity = probe.identity;
+  } else if (existingForTofu?.identity) {
+    peer.identity = existingForTofu.identity;
+  }
+
+  let existed = false;
+  mutatePeers((data) => {
+    existed = Boolean(data.peers[opts.alias]);
+    data.peers[opts.alias] = peer;
+  });
+
+  // applyTofuDecision is a no-op for match / legacy-*; for tofu-bootstrap
+  // we already stamped the pubkey above, so the call is defensive (it
+  // checks `if (p.pubkey) return` and bails). Keeping the call documents
+  // the contract: every probePeer response goes through TOFU exactly once.
+  applyTofuDecision(tofuDecision);
+
+  return { alias: opts.alias, overwrote: existed, peer, probeError: probe.error };
+}
+
+/**
+ * Re-run the /info handshake for an existing alias. On success clears
+ * lastError and sets lastSeen; on failure records lastError.
+ *
+ * Throws if the alias does not exist.
+ */
+export interface ProbeResult {
+  alias: string;
+  url: string;
+  node: string | null;
+  ok: boolean;
+  error?: LastError;
+  /** Set when the peer's advertised pubkey did not match the cached one (#804 Step 2). */
+  pubkeyMismatch?: PeerPubkeyMismatchError;
+}
+
+export async function cmdProbe(alias: string): Promise<ProbeResult> {
+  const data = loadPeers();
+  const existing = data.peers[alias];
+  if (!existing) throw new Error(`peer "${alias}" not found`);
+
+  const probe = await probePeer(existing.url);
+  const now = new Date().toISOString();
+
+  // TOFU first — if the peer rotated its key without operator approval, the
+  // probe's "ok" status is misleading: their /info answered, but their
+  // identity changed. Surface as `pubkeyMismatch` and *do not* update
+  // lastSeen — operator must run `maw peers forget` to re-TOFU.
+  const tofuDecision = evaluatePeerIdentity(alias, existing, probe.pubkey);
+  if (tofuDecision.kind === "mismatch") {
+    return {
+      alias,
+      url: existing.url,
+      node: probe.node ?? existing.node,
+      ok: false,
+      error: probe.error,
+      pubkeyMismatch: new PeerPubkeyMismatchError(
+        alias,
+        tofuDecision.cached!,
+        tofuDecision.observed!,
+      ),
+    };
+  }
+
+  mutatePeers((d) => {
+    const p = d.peers[alias];
+    if (!p) return; // removed between load and mutate — race-safe no-op
+    if (probe.error) {
+      p.lastError = probe.error;
+    } else {
+      delete p.lastError;
+      p.lastSeen = now;
+      if (probe.node) p.node = probe.node;
+      // Refresh nickname on success: string updates, null clears.
+      if (probe.nickname) p.nickname = probe.nickname;
+      else if (probe.nickname === null) delete p.nickname;
+      // Refresh identity on success (#804 Step 3) — only updates, never clears,
+      // so a transient /api/identity blip won't drop a known-good pin.
+      if (probe.identity) p.identity = probe.identity;
+    }
+  });
+
+  // Persist the bootstrap (only on first sight, after the peer entry exists).
+  applyTofuDecision(tofuDecision);
+
+  return {
+    alias,
+    url: existing.url,
+    node: probe.node ?? existing.node,
+    ok: !probe.error,
+    error: probe.error,
+  };
+}
+
+export function cmdList(): Array<{ alias: string } & Peer> {
+  const data = loadPeers();
+  return Object.entries(data.peers)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([alias, p]) => ({ alias, ...p }));
+}
+
+export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
+  const data = loadPeers();
+  const p = data.peers[alias];
+  return p ? { alias, ...p } : null;
+}
+
+export function cmdRemove(alias: string): boolean {
+  let existed = false;
+  mutatePeers((data) => {
+    if (data.peers[alias]) {
+      existed = true;
+      delete data.peers[alias];
+    }
+  });
+  return existed;
+}
+
+/**
+ * Clear the TOFU-cached pubkey for an alias so the next /api/identity
+ * contact re-TOFUs (#804 Step 2).
+ *
+ * Use cases:
+ *   - Legitimate operator-initiated key rotation on the peer side.
+ *   - Factory reset / key loss recovery.
+ *   - Resolving a `peer pubkey changed` refusal after the operator has
+ *     verified out-of-band that the change is intentional.
+ *
+ * Does NOT remove the alias itself — `maw peers remove` is the destructive
+ * one. Forget is a re-TOFU primitive, not a delete.
+ */
+export type ForgetOutcome = "cleared" | "no-pubkey" | "not-found";
+
+export async function cmdForget(alias: string): Promise<ForgetOutcome> {
+  const aliasErr = validateAlias(alias);
+  if (aliasErr) throw new Error(aliasErr);
+  const { forgetPeerPubkey } = await import("./tofu");
+  return forgetPeerPubkey(alias);
+}
+
+export function formatList(rows: Array<{ alias: string } & Peer>): string {
+  if (!rows.length) return "no peers";
+  const header = ["alias", "url", "node", "nickname", "lastSeen"];
+  const lines = rows.map(r => [
+    r.alias,
+    r.url,
+    r.node ?? "-",
+    r.nickname ?? "-",
+    r.lastSeen ?? "-",
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map(l => l[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+}

--- a/plugins/pair/internal/probe.ts
+++ b/plugins/pair/internal/probe.ts
@@ -1,0 +1,329 @@
+/**
+ * maw peers — handshake probe + error classifier (#565).
+ *
+ * Replaces the silent try/catch→null in resolveNode(). probePeer()
+ * fetches <url>/info, classifies failures into a small enum, and
+ * returns both resolved node (if any) and structured error (if any).
+ * The old resolveNode() wrapper in impl.ts is kept as a thin
+ * `string | null` fallback for pre-#565 call sites.
+ */
+import type { LastError } from "./store";
+import { lookup } from "dns/promises";
+
+export type ProbeErrorCode = LastError["code"];
+
+export interface ProbeResult {
+  node: string | null;
+  /** Peer's self-reported nickname from /info (#643 Phase 2). Null means peer did not advertise one. */
+  nickname?: string | null;
+  /**
+   * Peer's pubkey from /api/identity (#804 Step 2). Undefined when:
+   *   - the /info handshake itself failed (no second fetch attempted), OR
+   *   - the peer is pre-Step-1 and does not expose /api/identity, OR
+   *   - /api/identity responded but did not advertise a pubkey field.
+   *
+   * Caller passes this through `tofuRecordPeerIdentity` to pin / validate.
+   */
+  pubkey?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` so the local cache can
+   * detect duplicate-claim collisions across peers (e.g. two peers both
+   * declaring themselves `mawjs:m5`). Undefined when /api/identity did not
+   * respond or omitted both `oracle` and `node` fields.
+   *
+   * `oracle` defaults to `"mawjs"` when the response only carries `node` —
+   * this is the family default per ADR docs/federation/0001-peer-identity.md
+   * and lets pre-Step-3 peers still participate in the collision check.
+   */
+  identity?: { oracle: string; node: string };
+  error?: LastError;
+}
+
+/**
+ * Exit code per probe error family — fail-loud for scripts.
+ *
+ * Scripts that chain `maw peers add` with subsequent commands need a
+ * non-zero exit to branch on. The old `ok:true + ⚠ block on stderr`
+ * behavior was easy to miss in CI logs.
+ *
+ *   2 — generic/structural (UNKNOWN, BAD_BODY, TLS)
+ *   3 — DNS (host does not resolve)
+ *   4 — REFUSED (resolved but port closed)
+ *   5 — TIMEOUT (no response in 2s)
+ *   6 — HTTP_4XX / HTTP_5XX (peer responded but /info failed)
+ */
+export const PROBE_EXIT_CODES: Record<ProbeErrorCode, number> = {
+  DNS: 3,
+  REFUSED: 4,
+  TIMEOUT: 5,
+  HTTP_4XX: 6,
+  HTTP_5XX: 6,
+  TLS: 2,
+  BAD_BODY: 2,
+  UNKNOWN: 2,
+};
+
+/** Actionable hint per error code — shown in CLI output. */
+export const PROBE_HINTS: Record<ProbeErrorCode, string> = {
+  DNS: "Host does not resolve. Check /etc/hosts, DNS, or VPN.",
+  REFUSED: "Host resolves but port is closed. Is the peer process running?",
+  TIMEOUT: "Peer did not respond within 2s. Network path may be blocked.",
+  TLS: "TLS handshake failed. Check cert validity / chain.",
+  HTTP_4XX: "Peer responded with a client error. /info endpoint may be missing OR peer is running an old maw version — if you control the peer, try restarting it.",
+  HTTP_5XX: "Peer returned a server error. Server-side fault.",
+  BAD_BODY: "/info responded but body shape was unexpected.",
+  UNKNOWN: "Probe failed for an unclassified reason.",
+};
+
+/**
+ * Classify a thrown fetch error OR a failed Response into a ProbeErrorCode.
+ * Node/undici → err.cause.code; AbortError → 2s timeout; TLS → CERT_*;
+ * HTTP → non-ok Response. Bun collapses DNS+refused → "ConnectionRefused";
+ * run prefetchDnsCheck() first to recover the DNS distinction.
+ */
+export function classifyProbeError(input: unknown): ProbeErrorCode {
+  // HTTP: non-ok Response
+  if (typeof input === "object" && input !== null && "status" in input && "ok" in input) {
+    const res = input as { status: number; ok: boolean };
+    if (!res.ok) {
+      if (res.status >= 400 && res.status < 500) return "HTTP_4XX";
+      if (res.status >= 500) return "HTTP_5XX";
+    }
+  }
+
+  // Thrown error: inspect cause.code, code, name
+  const err = input as { name?: string; code?: string; cause?: { code?: string } } | null;
+  if (!err || typeof err !== "object") return "UNKNOWN";
+
+  const code = err.cause?.code ?? err.code;
+  // ENOTIMP = resolver method unimplemented (e.g. mDNS/.local without Avahi); EAI_FAIL = unrecoverable DNS (#593).
+  if (code === "ENOTFOUND" || code === "ENOTIMP" || code === "EAI_FAIL" || code === "EAI_AGAIN" || code === "EAI_NODATA") return "DNS";
+  // Bun conflates DNS + refused into "ConnectionRefused" — we run a DNS
+  // precheck upstream, so any code that reaches here means connect failed.
+  if (code === "ECONNREFUSED" || code === "ConnectionRefused") return "REFUSED";
+  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return "TIMEOUT";
+  if (err.name === "AbortError" || err.name === "TimeoutError") return "TIMEOUT";
+  if (typeof code === "string" && (code.startsWith("CERT_") || code.startsWith("SELF_SIGNED") || code.startsWith("DEPTH_ZERO_") || code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE")) {
+    return "TLS";
+  }
+
+  return "UNKNOWN";
+}
+
+/**
+ * DNS precheck — resolves host-doesn't-resolve vs connection-refused before
+ * fetch (Bun conflates them). Returns DNS LastError on failure, null on ok.
+ */
+async function prefetchDnsCheck(url: string): Promise<LastError | null> {
+  let hostname: string;
+  try { hostname = new URL(url).hostname; } catch { return null; }
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname) || hostname.startsWith("[")) return null;
+  try {
+    await lookup(hostname);
+    return null;
+  } catch (e: any) {
+    return {
+      code: classifyProbeError(e),
+      message: typeof e?.message === "string" ? e.message : `DNS lookup failed for ${hostname}`,
+      at: new Date().toISOString(),
+    };
+  }
+}
+
+/** Build a LastError record from a thrown error + url context. */
+function errToLast(err: unknown, fallbackMsg: string): LastError {
+  const code = classifyProbeError(err);
+  const message = (err && typeof err === "object" && "message" in err && typeof (err as any).message === "string")
+    ? (err as any).message
+    : fallbackMsg;
+  return { code, message, at: new Date().toISOString() };
+}
+
+/**
+ * Probe <url>/info with a 2s timeout. Success → { node } (body.node or
+ * body.name). Failure → { node: null, error } — caller persists + warns.
+ */
+export async function probePeer(url: string, timeoutMs = 2000): Promise<ProbeResult> {
+  // DNS precheck first — cheaper than fetch and gives us clean ENOTFOUND
+  // classification on Bun (whose fetch conflates DNS/refused into one code).
+  const dnsErr = await prefetchDnsCheck(url);
+  if (dnsErr) return { node: null, error: dnsErr };
+
+  let res: Response;
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    try {
+      res = await fetch(new URL("/info", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+  } catch (e) {
+    return { node: null, error: errToLast(e, `fetch ${url}/info failed`) };
+  }
+
+  if (!res.ok) {
+    return {
+      node: null,
+      error: {
+        code: classifyProbeError(res),
+        message: `HTTP ${res.status} from ${url}/info`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  let body: { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  try {
+    body = await res.json() as { node?: unknown; name?: unknown; nickname?: unknown; maw?: unknown };
+  } catch (e) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info body was not valid JSON`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Accept both the old handshake (#596 — `maw: true`) and the new
+  // self-describing shape (#628 — `maw: { schema: "1", ... }`). Any
+  // truthy `maw` value passes; missing/falsy fails as BAD_BODY so we
+  // don't paint random HTTP 200 endpoints as maw peers.
+  if (!isValidMawHandshake(body.maw)) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response missing valid "maw" handshake field`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  const node = (typeof body.node === "string" && body.node)
+    || (typeof body.name === "string" && body.name)
+    || null;
+
+  if (!node) {
+    return {
+      node: null,
+      error: {
+        code: "BAD_BODY",
+        message: `/info response had neither "node" nor "name" string`,
+        at: new Date().toISOString(),
+      },
+    };
+  }
+
+  // Nickname is optional and strictly cosmetic — only accept non-empty strings.
+  const nickname = typeof body.nickname === "string" && body.nickname.length > 0
+    ? body.nickname
+    : null;
+
+  // Best-effort pubkey + identity fetch (#804 Steps 2 + 3). Pre-Step-1 peers
+  // don't expose /api/identity at all; we tolerate that and return without
+  // either field — TOFU layer treats the result as a legacy peer, and the
+  // duplicate-detection layer skips peers without identity (no false positive).
+  const ident = await fetchPeerIdentityFields(url, timeoutMs);
+
+  const result: ProbeResult = { node, nickname };
+  if (ident?.pubkey) result.pubkey = ident.pubkey;
+  if (ident?.identity) result.identity = ident.identity;
+  return result;
+}
+
+/**
+ * Best-effort second fetch — `/api/identity` (#804 Steps 2 + 3).
+ *
+ * Keep this *separate* from the /info handshake so a missing/older endpoint
+ * does not poison the primary probe. We swallow every failure here: TOFU
+ * only acts on a confirmed pubkey value, and the caller already classified
+ * /info errors elsewhere.
+ *
+ * Returns whatever subset of `{ pubkey, identity }` the response advertised,
+ * or `undefined` if the endpoint is missing / unreachable / malformed.
+ *
+ * `identity` is synthesised from the response's `oracle` (defaulting to
+ * `"mawjs"` per ADR family-default) + `node` fields. Both fields must be
+ * non-empty strings for `identity` to be returned — a peer that reports
+ * neither is treated as legacy and skipped by the dedup check upstream.
+ */
+async function fetchPeerIdentityFields(
+  url: string,
+  timeoutMs: number,
+): Promise<{ pubkey?: string; identity?: { oracle: string; node: string } } | undefined> {
+  try {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), timeoutMs);
+    let res: Response;
+    try {
+      res = await fetch(new URL("/api/identity", url), { signal: ctrl.signal });
+    } finally {
+      clearTimeout(t);
+    }
+    if (!res.ok) return undefined;
+    const body = (await res.json()) as { pubkey?: unknown; oracle?: unknown; node?: unknown };
+    const out: { pubkey?: string; identity?: { oracle: string; node: string } } = {};
+    if (typeof body.pubkey === "string" && body.pubkey.length > 0) out.pubkey = body.pubkey;
+    const node = typeof body.node === "string" && body.node.length > 0 ? body.node : undefined;
+    const oracle = typeof body.oracle === "string" && body.oracle.length > 0 ? body.oracle : "mawjs";
+    if (node) out.identity = { oracle, node };
+    return out;
+  } catch {
+    // Pre-Step-1 peers: no /api/identity yet. Step 4 will reject this — for
+    // now (alpha migration window) we silently accept.
+  }
+  return undefined;
+}
+
+/**
+ * Handshake gate — accepts the pre-#628 `maw: true` form AND the new
+ * `maw: { schema: "1", ... }` form. Objects must carry at least a
+ * `schema` string to count as a valid new-shape handshake (bare `{}`
+ * is rejected so a typo doesn't silently pass). Anything truthy but
+ * not one of these shapes (e.g. `maw: "yes"`, `maw: 1`) is rejected —
+ * future shapes should bump the schema field rather than changing the
+ * outer type.
+ */
+export function isValidMawHandshake(maw: unknown): boolean {
+  if (maw === true) return true;
+  if (maw && typeof maw === "object") {
+    const m = maw as { schema?: unknown };
+    return typeof m.schema === "string" && m.schema.length > 0;
+  }
+  return false;
+}
+
+/** Hint chooser — DNS bucket sub-types for ENOTIMP get a distinct hint (#593). */
+export function pickHint(err: LastError): string {
+  if (err.code === "DNS" && /ENOTIMP/i.test(err.message)) {
+    return "install avahi-daemon (Linux) for mDNS, or add white.local to /etc/hosts";
+  }
+  return PROBE_HINTS[err.code] ?? PROBE_HINTS.UNKNOWN;
+}
+
+/** Colored, multi-line stderr block with actionable hint. */
+export function formatProbeError(err: LastError, url: string, alias: string): string {
+  const hint = pickHint(err);
+  const host = safeHost(url);
+  return [
+    `\x1b[33m⚠\x1b[0m peer handshake failed: \x1b[1m${err.code}\x1b[0m`,
+    `   host: ${host}`,
+    `   error: ${err.message}`,
+    `   hint: ${hint}`,
+    `   retry: maw peers probe ${alias}`,
+  ].join("\n");
+}
+
+function safeHost(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.port ? `${u.hostname}:${u.port}` : u.hostname;
+  } catch {
+    return url;
+  }
+}

--- a/plugins/pair/internal/store.ts
+++ b/plugins/pair/internal/store.ts
@@ -1,0 +1,190 @@
+/**
+ * maw peers — storage layer (#568, #572).
+ *
+ * Atomic read/write of `~/.maw/peers.json`. Writes go via a temp file
+ * and rename(2) so a crash mid-write leaves either the old file intact
+ * or the new file fully in place — never a truncated file. A stale tmp
+ * file from a crashed previous write is cleaned on load (the live file
+ * is still valid; the tmp is leftover from a crashed writer).
+ *
+ * Schema v1:
+ *   { version: 1, peers: { <alias>: { url, node, addedAt, lastSeen,
+ *                                     [lastError, nickname, pubkey, pubkeyFirstSeen,
+ *                                      identity] } } }
+ *   — fields in brackets are optional. `pubkey` / `pubkeyFirstSeen` were
+ *   added in #804 Step 2 for TOFU peer-identity pinning. `identity` was
+ *   added in #804 Step 3 to capture the peer's self-reported `<oracle>:<node>`
+ *   pair for duplicate-detection (doctor + boot-time warn).
+ *
+ * Path resolution is a function (not a const) so tests can override
+ * `HOME` / the path via `PEERS_FILE` and get a fresh value each call.
+ *
+ * Concurrency: savePeers takes a short-lived file lock around the
+ * read-modify-write critical section so concurrent `maw peers add`
+ * calls don't lose each other's updates (#572 nit 3). See ./lock.ts.
+ *
+ * Corruption: if the live file fails to parse, OR if it parses but
+ * the shape is wrong (e.g. `{"peers":[]}` — array instead of object),
+ * we rename it aside to `peers.json.corrupt-<ISO>` and start fresh —
+ * non-destructive, with an audit trail (#572 nit 1, follow-up to #579).
+ */
+import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync, unlinkSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { withPeersLock } from "./lock";
+
+/**
+ * Structured last-probe failure — opt-in field on Peer (#565).
+ *
+ * Absent (undefined) means either the peer has never been probed, or
+ * the most recent probe succeeded. Readers that don't know about this
+ * field continue to work — schema v1 is unchanged.
+ */
+export interface LastError {
+  /** Classified code — see probe.ts classifyProbeError(). */
+  code: "DNS" | "REFUSED" | "TIMEOUT" | "TLS" | "HTTP_4XX" | "HTTP_5XX" | "BAD_BODY" | "UNKNOWN";
+  /** Raw error message (from err.message or synthesized for HTTP cases). */
+  message: string;
+  /** ISO timestamp when the failure was recorded. */
+  at: string;
+}
+
+export interface Peer {
+  url: string;
+  node: string | null;
+  addedAt: string;
+  lastSeen: string | null;
+  /** Optional — set by probePeer() when handshake fails; cleared on success. */
+  lastError?: LastError;
+  /** Optional human-friendly nickname, propagated from peer's /info (#643 Phase 2). */
+  nickname?: string | null;
+  /**
+   * TOFU-cached pubkey from the peer's /api/identity response (#804 Step 2).
+   *
+   * Absent until the first successful identity fetch that returned a `pubkey`
+   * field. Once cached, every subsequent identity check validates the response
+   * against this value — mismatch is treated as either rotation or
+   * impersonation and is refused (see ADR docs/federation/0001-peer-identity.md
+   * O6 table). Operator clears via `maw peers forget <alias>` to re-TOFU.
+   */
+  pubkey?: string;
+  /** ISO timestamp when the pubkey was first cached (TOFU). */
+  pubkeyFirstSeen?: string;
+  /**
+   * Peer's self-reported `<oracle>:<node>` pair from /api/identity (#804 Step 3).
+   *
+   * Captured opportunistically alongside `pubkey` during TOFU bootstrap and on
+   * every subsequent successful probe. Drives the duplicate-detection check
+   * in `maw doctor` and the boot-time warning in `maw serve` — two peers
+   * claiming the same `<oracle>:<node>` is operator confusion that crypto
+   * (Step 2) cannot solve, and operator must investigate.
+   *
+   * Absent for legacy peers (pre-Step-1 nodes that don't expose /api/identity)
+   * and for peers whose /api/identity response omitted both `node` and `oracle`.
+   * Doctor + boot-warn skip undefined identity (no false-positive collision).
+   */
+  identity?: { oracle: string; node: string };
+}
+
+export interface PeersFile {
+  version: 1;
+  peers: Record<string, Peer>;
+}
+
+export function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function emptyStore(): PeersFile {
+  return { version: 1, peers: {} };
+}
+
+export function loadPeers(): PeersFile {
+  clearStaleTmp();
+  const path = peersPath();
+  if (!existsSync(path)) return emptyStore();
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf-8");
+  } catch {
+    return emptyStore();
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) throw new Error("invalid store shape (expected { peers: { ... } } object)");
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch (e: any) {
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const aside = `${path}.corrupt-${stamp}`;
+    try { renameSync(path, aside); } catch { /* ignore — caller still gets empty store */ }
+    console.error(`\x1b[33m⚠\x1b[0m peers store at ${path} failed to parse (${e?.message || e}); moved aside to ${aside}`);
+    return emptyStore();
+  }
+}
+
+/**
+ * Validate the parsed JSON matches the expected store shape:
+ * a non-null object whose `peers` field is itself a non-null,
+ * non-array object. Guards against `{"peers":[]}` (array) and
+ * other junk that would silently no-op every write (follow-up
+ * to #579).
+ */
+function isValidStoreShape(parsed: unknown): parsed is PeersFile {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+  const peers = (parsed as { peers?: unknown }).peers;
+  if (peers === undefined) return true; // missing peers is ok — we default to {}
+  return typeof peers === "object" && peers !== null && !Array.isArray(peers);
+}
+
+export function savePeers(data: PeersFile): void {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  withPeersLock(path, () => writeAtomic(path, data));
+}
+
+/**
+ * Atomic read-modify-write under the peers lock. Use this whenever a
+ * mutation depends on current contents (add/remove) — it re-reads
+ * inside the lock so concurrent writers don't lose each other's
+ * updates. The mutator runs synchronously inside the critical section.
+ */
+export function mutatePeers(mutate: (data: PeersFile) => void): PeersFile {
+  const path = peersPath();
+  mkdirSync(dirname(path), { recursive: true });
+  return withPeersLock(path, () => {
+    const fresh = readUnlocked(path);
+    mutate(fresh);
+    writeAtomic(path, fresh);
+    return fresh;
+  });
+}
+
+/** Read + parse without taking the lock or doing corruption-handling rename. */
+function readUnlocked(path: string): PeersFile {
+  if (!existsSync(path)) return emptyStore();
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as Partial<PeersFile>;
+    if (!isValidStoreShape(parsed)) return emptyStore();
+    return {
+      version: 1,
+      peers: (parsed.peers ?? {}) as Record<string, Peer>,
+    };
+  } catch {
+    return emptyStore();
+  }
+}
+
+function writeAtomic(path: string, data: PeersFile): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n");
+  renameSync(tmp, path);
+}
+
+/** Best-effort cleanup of a stale tmp file (ignore errors). */
+export function clearStaleTmp(): void {
+  const tmp = `${peersPath()}.tmp`;
+  try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
+}

--- a/plugins/pair/internal/tofu.ts
+++ b/plugins/pair/internal/tofu.ts
@@ -1,0 +1,219 @@
+/**
+ * peers/tofu.ts — Trust On First Use cache for peer pubkeys (#804 Step 2).
+ *
+ * Pure, no-network logic that gets called by every code path which has just
+ * fetched a peer's `/api/identity` response. The peer's reply may carry a
+ * `pubkey` (Step 1 advertised it; pre-Step-1 peers omit it). We cache the
+ * pubkey on first sight and refuse mismatches thereafter.
+ *
+ * O6 table from ADR docs/federation/0001-peer-identity.md drives the four
+ * outcomes here — see `evaluatePeerIdentity` for the truth-table mapping.
+ *
+ * Design rules (deliberately not in store.ts):
+ *   - This module owns the *policy* (when to accept / refuse / warn).
+ *   - store.ts owns the *persistence* (how to read/write peers.json safely).
+ *   - This module never throws on absent-from-cache — it returns a tagged
+ *     decision the caller acts on. Throwing here would couple network code
+ *     paths to TOFU state shape.
+ *
+ * The receive-side (Step 4 signature verification) will reuse the same cache
+ * shape; this module is the only writer of `pubkey` / `pubkeyFirstSeen` so
+ * there's exactly one place that decides "this pubkey is now pinned".
+ */
+import type { Peer } from "./store";
+import { mutatePeers } from "./store";
+
+export type TofuDecisionKind =
+  /** First time we ever see a pubkey for this peer. Cache it. */
+  | "tofu-bootstrap"
+  /** Cached pubkey matches incoming pubkey. No-op write needed. */
+  | "match"
+  /** Cached pubkey, peer responded with a different pubkey. Refuse. */
+  | "mismatch"
+  /**
+   * Peer is a legacy node with no `pubkey` field at all. First contact —
+   * cache the entry without a pubkey; future Step-1+ contacts will TOFU.
+   */
+  | "legacy-first-contact"
+  /**
+   * Peer previously advertised a pubkey but this response omits it.
+   * During the v26.5.x migration window we accept-with-warning (rollback
+   * scenario). v27 will hard-cut this — see ADR Step 6.
+   */
+  | "legacy-after-pinned";
+
+export interface TofuDecision {
+  kind: TofuDecisionKind;
+  alias: string;
+  /** The cached pubkey (if any) BEFORE this call. */
+  cached?: string;
+  /** The pubkey the peer just advertised (if any). */
+  observed?: string;
+  /** Human-readable description for logs / errors. */
+  message: string;
+}
+
+export class PeerPubkeyMismatchError extends Error {
+  alias: string;
+  cached: string;
+  observed: string;
+  constructor(alias: string, cached: string, observed: string) {
+    super(
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+        `manually \`maw peers forget ${alias}\` to re-TOFU`,
+    );
+    this.name = "PeerPubkeyMismatchError";
+    this.alias = alias;
+    this.cached = cached;
+    this.observed = observed;
+  }
+}
+
+/**
+ * Pure decision function — given the current cache entry and the peer's
+ * advertised pubkey (or `undefined` for legacy peers), return what should
+ * happen. Persistence is the caller's job (`applyTofuDecision`).
+ *
+ * The four decisions map directly onto the O6 table cells that are
+ * relevant to the *receive an identity response* event (the other O6
+ * cells about signed messages are Step 4's concern).
+ */
+export function evaluatePeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const cached = peer?.pubkey;
+
+  // Case 1: peer is brand-new to us OR we've never cached a pubkey.
+  if (!cached) {
+    if (observed) {
+      return {
+        kind: "tofu-bootstrap",
+        alias,
+        observed,
+        message: `[tofu] caching pubkey for ${alias} (first sight)`,
+      };
+    }
+    return {
+      kind: "legacy-first-contact",
+      alias,
+      message: `[tofu] ${alias} did not advertise a pubkey (legacy peer; no pin established)`,
+    };
+  }
+
+  // Case 2: cached pubkey present — must validate.
+  if (!observed) {
+    return {
+      kind: "legacy-after-pinned",
+      alias,
+      cached,
+      message:
+        `[tofu] ${alias} previously advertised pubkey ${cached.slice(0, 16)}… but this response omits it; ` +
+        `accepting during alpha migration, will hard-fail at v27`,
+    };
+  }
+
+  if (cached === observed) {
+    return {
+      kind: "match",
+      alias,
+      cached,
+      observed,
+      message: `[tofu] ${alias} pubkey verified`,
+    };
+  }
+
+  return {
+    kind: "mismatch",
+    alias,
+    cached,
+    observed,
+    message:
+      `peer pubkey changed for ${alias}: ${cached.slice(0, 16)}… → ${observed.slice(0, 16)}…; ` +
+      `manually \`maw peers forget ${alias}\` to re-TOFU`,
+  };
+}
+
+/**
+ * Persist the side-effect of `evaluatePeerIdentity`. Bootstrap writes the
+ * pubkey + timestamp; mismatch throws; match / legacy-* are no-ops on disk.
+ *
+ * Throws `PeerPubkeyMismatchError` on `kind === "mismatch"` — caller decides
+ * whether to surface to user or swallow (e.g. background sweepers may log
+ * and skip; interactive `maw peers add` may fail loud).
+ */
+export function applyTofuDecision(decision: TofuDecision): void {
+  switch (decision.kind) {
+    case "tofu-bootstrap": {
+      const now = new Date().toISOString();
+      mutatePeers((data) => {
+        const p = data.peers[decision.alias];
+        if (!p) return; // race-safe: peer was forgotten between fetch+apply
+        // Defensive: if someone else cached a pubkey between evaluate and
+        // apply, treat that as authoritative — re-evaluate would mismatch
+        // or match; we don't silently overwrite.
+        if (p.pubkey) return;
+        p.pubkey = decision.observed!;
+        p.pubkeyFirstSeen = now;
+      });
+      return;
+    }
+    case "mismatch":
+      throw new PeerPubkeyMismatchError(
+        decision.alias,
+        decision.cached!,
+        decision.observed!,
+      );
+    case "match":
+    case "legacy-first-contact":
+    case "legacy-after-pinned":
+      return;
+  }
+}
+
+/**
+ * One-shot helper: evaluate + apply. Returns the decision so callers can log.
+ *
+ * Throws `PeerPubkeyMismatchError` on mismatch (caller chooses recovery).
+ */
+export function tofuRecordPeerIdentity(
+  alias: string,
+  peer: Peer | undefined,
+  observed: string | undefined,
+): TofuDecision {
+  const decision = evaluatePeerIdentity(alias, peer, observed);
+  applyTofuDecision(decision);
+  return decision;
+}
+
+/**
+ * Operator-driven re-TOFU: clears the pinned pubkey for an alias. Used by
+ * `maw peers forget <alias>`. Idempotent — clearing a peer that has no
+ * pubkey is fine and reports nothing-changed via the return value.
+ *
+ * Returns:
+ *   - "cleared" — pubkey was present and is now removed
+ *   - "no-pubkey" — alias exists but had no pubkey (legacy peer)
+ *   - "not-found" — alias does not exist
+ */
+export function forgetPeerPubkey(
+  alias: string,
+): "cleared" | "no-pubkey" | "not-found" {
+  let outcome: "cleared" | "no-pubkey" | "not-found" = "not-found";
+  mutatePeers((data) => {
+    const p = data.peers[alias];
+    if (!p) {
+      outcome = "not-found";
+      return;
+    }
+    if (p.pubkey === undefined) {
+      outcome = "no-pubkey";
+      return;
+    }
+    delete p.pubkey;
+    delete p.pubkeyFirstSeen;
+    outcome = "cleared";
+  });
+  return outcome;
+}

--- a/plugins/pair/plugin.json
+++ b/plugins/pair/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "pair",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Bluetooth-style federation pairing — ephemeral code handshake (#573, facet 3 of #565).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "pair",
+    "aliases": [],
+    "help": "maw pair | maw pair accept <code> [--at <url>] — ephemeral federation pairing"
+  },
+  "weight": 50
+}

--- a/plugins/panes/impl.ts
+++ b/plugins/panes/impl.ts
@@ -1,0 +1,125 @@
+import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+
+export interface PanesOpts {
+  /** Include a PID column (for /proc inspection / ghost detection). */
+  pid?: boolean;
+  /** Enumerate every pane across every session (tmux list-panes -a). */
+  all?: boolean;
+}
+
+interface PaneRow {
+  target: string;   // session:window.pane
+  dims: string;     // WIDTHxHEIGHT
+  command: string;
+  title: string;
+  pid?: string;     // only populated when opts.pid
+}
+
+/**
+ * maw panes [target]
+ *
+ * List panes with metadata. Default target is the current tmux window.
+ * If target is a bare session name, lists panes across ALL its windows.
+ * If target is session:window, lists panes of that window.
+ *
+ * Output columns — target, dims, command, title — match the style of
+ * `maw ls`: plain text, ANSI-colored header, one row per pane.
+ */
+export async function cmdPanes(target?: string, opts: PanesOpts = {}) {
+  const tmux = tmuxCmd();
+
+  let filter: string | null = null; // tmux -t target for list-panes; null = current
+  if (opts.all) {
+    if (target) console.log(`  \x1b[90m⚠ --all ignores target argument\x1b[0m`);
+    // skip target resolution entirely — --all enumerates everything
+  } else if (target) {
+    if (target.includes(":")) {
+      // Resolve session portion only; window stays as-is
+      const [rawSession, rest] = target.split(":", 2);
+      const sessions = await listSessions();
+      const r = resolveSessionTarget(rawSession, sessions);
+      if (r.kind === "ambiguous") {
+        console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${r.candidates.length} sessions:`);
+        for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+        throw new Error(`'${rawSession}' is ambiguous — matches ${r.candidates.length} sessions`);
+      }
+      if (r.kind === "none") {
+        if (r.hints && r.hints.length > 0) {
+          console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+          for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+        }
+        throw new Error(`session '${rawSession}' not found`);
+      }
+      filter = `${r.match.name}:${rest}`;
+    } else {
+      const sessions = await listSessions();
+      const r = resolveSessionTarget(target, sessions);
+      if (r.kind === "ambiguous") {
+        console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+        for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+        throw new Error(`'${target}' is ambiguous — matches ${r.candidates.length} sessions`);
+      }
+      if (r.kind === "none") {
+        if (r.hints && r.hints.length > 0) {
+          console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+          for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+        } else {
+          console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+        }
+        throw new Error(`session '${target}' not found`);
+      }
+      // Session-wide: use list-panes -s
+      filter = r.match.name;
+    }
+  }
+
+  // Build list-panes command. Format uses ||| as field separator.
+  // #{pane_pid} only appended when --pid requested, to keep default output stable.
+  const baseFmt = "#{session_name}:#{window_index}.#{pane_index}|||#{pane_width}x#{pane_height}|||#{pane_current_command}|||#{pane_title}";
+  const fmt = opts.pid ? `${baseFmt}|||#{pane_pid}` : baseFmt;
+  const targetFlag = opts.all ? "-a" : (filter ? `-s -t '${filter}'` : "");
+  let raw: string;
+  try {
+    raw = await hostExec(`${tmux} list-panes ${targetFlag} -F '${fmt}'`);
+  } catch (e: any) {
+    throw new Error(`list-panes failed: ${e.message || e}`);
+  }
+
+  const rows: PaneRow[] = raw.split("\n").filter(Boolean).map(line => {
+    const parts = line.split("|||");
+    return {
+      target: parts[0]!,
+      dims: parts[1]!,
+      command: parts[2]!,
+      title: parts[3] || "",
+      pid: opts.pid ? parts[4] : undefined,
+    };
+  });
+
+  if (rows.length === 0) {
+    console.log("  \x1b[90m(no panes)\x1b[0m");
+    return;
+  }
+
+  // Column widths
+  const w = {
+    target: Math.max(6, ...rows.map(r => r.target.length)),
+    dims:   Math.max(6, ...rows.map(r => r.dims.length)),
+    cmd:    Math.max(7, ...rows.map(r => r.command.length)),
+    pid:    opts.pid ? Math.max(3, ...rows.map(r => (r.pid || "").length)) : 0,
+  };
+  const pad = (s: string, n: number) => s + " ".repeat(Math.max(0, n - s.length));
+
+  if (opts.pid) {
+    console.log(`  \x1b[90m${pad("TARGET", w.target)}  ${pad("SIZE", w.dims)}  ${pad("PID", w.pid)}  ${pad("COMMAND", w.cmd)}  TITLE\x1b[0m`);
+    for (const row of rows) {
+      console.log(`  ${pad(row.target, w.target)}  ${pad(row.dims, w.dims)}  ${pad(row.pid || "", w.pid)}  ${pad(row.command, w.cmd)}  \x1b[90m${row.title}\x1b[0m`);
+    }
+  } else {
+    console.log(`  \x1b[90m${pad("TARGET", w.target)}  ${pad("SIZE", w.dims)}  ${pad("COMMAND", w.cmd)}  TITLE\x1b[0m`);
+    for (const row of rows) {
+      console.log(`  ${pad(row.target, w.target)}  ${pad(row.dims, w.dims)}  ${pad(row.command, w.cmd)}  \x1b[90m${row.title}\x1b[0m`);
+    }
+  }
+}

--- a/plugins/panes/index.ts
+++ b/plugins/panes/index.ts
@@ -1,0 +1,57 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdPanes } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "panes",
+  description: "List tmux panes with metadata.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string | undefined;
+
+    let pid = false;
+    let all = false;
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, { "--pid": Boolean, "--all": Boolean, "-a": "--all" }, 0);
+
+      const first = flags._[0];
+      if (first === "--help" || first === "-h") {
+        return { ok: false, error: "usage: maw panes [target] [--pid] [--all|-a]" };
+      }
+      if (first && first.startsWith("-")) {
+        return { ok: false, error: `"${first}" looks like a flag, not a target.\n  usage: maw panes [target] [--pid] [--all|-a]` };
+      }
+      target = first;
+      pid = !!flags["--pid"];
+      all = !!flags["--all"];
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      target = body.target as string | undefined;
+      pid = !!body.pid;
+      all = !!body.all;
+    }
+
+    await cmdPanes(target, { pid, all });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/panes/plugin.json
+++ b/plugins/panes/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "panes",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "List tmux panes with metadata (index, size, command, title).",
+  "cli": {
+    "command": "panes",
+    "help": "maw panes [target] [--pid] [--all|-a] — list panes in current window, or all panes in <target>, or --all to list every pane across every session",
+    "flags": {
+      "--pid": "boolean",
+      "--all": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/panes",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/ping/impl.ts
+++ b/plugins/ping/impl.ts
@@ -1,0 +1,60 @@
+import { loadConfig, cfgTimeout } from "../../../config";
+import { curlFetch } from "../../../sdk";
+
+export async function cmdPing(node?: string) {
+  const config = loadConfig();
+  const peers = config.namedPeers || [];
+  const legacyPeers = (config.peers || []).filter(
+    (url: string) => !peers.some((p: any) => p.url === url)
+  );
+
+  const targets: { name: string; url: string }[] = [];
+
+  if (node) {
+    // Ping specific node
+    const peer = peers.find((p: any) => p.name === node);
+    if (peer) {
+      targets.push({ name: peer.name, url: peer.url });
+    } else {
+      const legacy = legacyPeers.find((u: string) => u.includes(node));
+      if (legacy) targets.push({ name: node, url: legacy });
+      else {
+        console.error(`\x1b[33mknown\x1b[0m: ${peers.map((p: any) => p.name).join(", ") || "(none)"}`);
+        throw new Error(`unknown node "${node}"`);
+      }
+    }
+  } else {
+    // Ping all
+    for (const p of peers) targets.push({ name: p.name, url: p.url });
+    for (const url of legacyPeers) targets.push({ name: url, url });
+  }
+
+  if (targets.length === 0) {
+    console.log("\x1b[90mno peers configured\x1b[0m");
+    return;
+  }
+
+  const results = await Promise.all(targets.map(async ({ name, url }) => {
+    const start = Date.now();
+    try {
+      const res = await curlFetch(`${url}/api/auth/status`, { timeout: cfgTimeout("ping") });
+      const ms = Date.now() - start;
+      if (res.ok) {
+        const auth = res.data?.enabled ? "auth: ok" : "auth: off";
+        const token = res.data?.tokenPreview || "";
+        return { name, url, ok: true, ms, auth, token };
+      }
+      return { name, url, ok: false, ms, auth: `${res.status}`, token: "" };
+    } catch {
+      return { name, url, ok: false, ms: Date.now() - start, auth: "unreachable", token: "" };
+    }
+  }));
+
+  for (const r of results) {
+    if (r.ok) {
+      console.log(`\x1b[32m✅\x1b[0m ${r.name} \x1b[90m(${r.url})\x1b[0m — ${r.ms}ms, ${r.auth}${r.token ? ` (${r.token})` : ""}`);
+    } else {
+      console.log(`\x1b[31m❌\x1b[0m ${r.name} \x1b[90m(${r.url})\x1b[0m — ${r.ms}ms, ${r.auth}`);
+    }
+  }
+}

--- a/plugins/ping/index.ts
+++ b/plugins/ping/index.ts
@@ -1,0 +1,38 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdPing } from "./impl";
+
+export const command = {
+  name: "ping",
+  description: "Ping peer nodes to check connectivity and auth status.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let node: string | undefined;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      node = args[0];
+    } else {
+      const args = ctx.args as Record<string, unknown>;
+      node = args.node as string | undefined;
+    }
+    await cmdPing(node);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/ping/ping.test.ts
+++ b/plugins/ping/ping.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+const root = join(import.meta.dir, "../../..");
+const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
+
+mock.module(join(root, "config"), () => mockConfigModule(() => ({
+  namedPeers: [{ name: "white", url: "http://white.local:3456" }],
+  peers: [],
+  federationToken: "test-token",
+})));
+
+mock.module(join(root, "core/transport/curl-fetch"), () => ({
+  curlFetch: async (_url: string) => ({
+    ok: true,
+    data: { node: "white", version: "2.0.0-alpha.10" },
+  }),
+}));
+
+const { default: handler } = await import("./index");
+
+describe("ping plugin", () => {
+  it("CLI — pings known peer", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["white"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+  });
+
+  it("API — ping returns ok", async () => {
+    const ctx: InvokeContext = { source: "api", args: { node: "white" } };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/plugins/ping/plugin.json
+++ b/plugins/ping/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "ping",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Ping peer nodes to check connectivity and auth status.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "ping",
+    "help": "maw ping [node] — ping all peers or a specific node"
+  },
+  "api": {
+    "path": "/api/ping",
+    "methods": [
+      "GET"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/pr/impl.ts
+++ b/plugins/pr/impl.ts
@@ -1,0 +1,77 @@
+import { Tmux } from "../../../core/transport/tmux";
+
+function branchToTitle(branch: string): string {
+  // Strip prefix like "agents/" or "feature/"
+  const stripped = branch.replace(/^[^/]+\//, "");
+  // Convert hyphens/underscores to spaces, title-case
+  return stripped
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function extractIssueNum(branch: string): number | null {
+  const m = branch.match(/issue-(\d+)/i);
+  return m ? parseInt(m[1]) : null;
+}
+
+export async function cmdPr(window?: string): Promise<void> {
+  if (!process.env.TMUX) {
+    throw new Error("not in a tmux session — run inside tmux");
+  }
+
+  const t = new Tmux();
+
+  // Get cwd of target window (or current pane)
+  let cwd: string;
+  if (window) {
+    const session = (await t.run("display-message", "-p", "#{session_name}")).trim();
+    cwd = (await t.run("display-message", "-t", `${session}:${window}`, "-p", "#{pane_current_path}")).trim();
+  } else {
+    cwd = (await t.run("display-message", "-p", "#{pane_current_path}")).trim();
+  }
+
+  if (!cwd) {
+    throw new Error("could not detect working directory");
+  }
+
+  // Get current branch — use Bun.spawn arg-array to avoid cwd single-quote injection
+  let branch: string;
+  try {
+    const proc = Bun.spawn(["git", "-C", cwd, "branch", "--show-current"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    branch = (await new Response(proc.stdout).text()).trim();
+  } catch {
+    throw new Error(`not a git repo: ${cwd}`);
+  }
+  if (!branch) {
+    throw new Error("detached HEAD — cannot create PR");
+  }
+
+  const title = branchToTitle(branch);
+  const issueNum = extractIssueNum(branch);
+
+  console.log(`\x1b[36m⚡\x1b[0m creating PR: "${title}" (${branch})`);
+  if (issueNum) console.log(`\x1b[36m⚡\x1b[0m linking to issue #${issueNum}`);
+
+  const body = issueNum ? `Closes #${issueNum}` : "";
+
+  // Use Bun.spawn arg-array with cwd option — eliminates cd + shell-quoting workarounds
+  try {
+    const ghArgs = ["pr", "create", "--title", title];
+    if (body) ghArgs.push("--body", body);
+    else ghArgs.push("--body", "");
+    const ghProc = Bun.spawn(["gh", ...ghArgs], { stdout: "pipe", stderr: "pipe", cwd });
+    const [out, , code] = await Promise.all([
+      new Response(ghProc.stdout).text(),
+      new Response(ghProc.stderr).text(),
+      ghProc.exited,
+    ]);
+    if (code !== 0) throw new Error(`gh pr create failed (exit ${code})`);
+    const result = out.trim();
+    console.log(`\x1b[32m✅\x1b[0m ${result}`);
+  } catch (e: any) {
+    throw new Error(e.message);
+  }
+}

--- a/plugins/pr/index.ts
+++ b/plugins/pr/index.ts
@@ -1,0 +1,31 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdPr } from "./impl";
+
+export const command = {
+  name: "pr",
+  description: "View or manage pull requests.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    await cmdPr(args[0]);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/pr/plugin.json
+++ b/plugins/pr/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "pr",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "View or manage pull requests.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "pr",
+    "help": "maw pr [number]"
+  },
+  "weight": 50
+}

--- a/plugins/pr/pr.test.ts
+++ b/plugins/pr/pr.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import type { InvokeContext } from "../../../plugin/types";
+import handler, { command } from "./index";
+
+describe("pr plugin — smoke", () => {
+  const origTmux = process.env.TMUX;
+
+  beforeEach(() => {
+    // Force the "not in tmux" guard path so the test is deterministic
+    // regardless of whether `bun test` is invoked from inside tmux.
+    delete process.env.TMUX;
+  });
+
+  afterEach(() => {
+    if (origTmux !== undefined) process.env.TMUX = origTmux;
+    else delete process.env.TMUX;
+  });
+
+  it("exports command metadata", () => {
+    expect(command.name).toBe("pr");
+    expect(command.description).toBeTruthy();
+  });
+
+  it("CLI — outside tmux returns error about tmux", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error ?? "").toContain("tmux");
+  });
+
+  it("CLI — window arg outside tmux still errors on tmux guard", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["some-window"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error ?? "").toContain("tmux");
+  });
+
+  // Inside-tmux path requires live tmux + git repo + gh auth. Pure smoke
+  // covers the argument + env-guard branch only.
+  it.skip("CLI — inside tmux creates PR (requires live tmux + git + gh)", () => {});
+});

--- a/plugins/profile/impl.ts
+++ b/plugins/profile/impl.ts
@@ -1,0 +1,70 @@
+/**
+ * maw profile — subcommand implementations (#888 / Phase 1 of #640).
+ *
+ * Thin shell around `src/lib/profile-loader.ts`. Phase 1 ships READ + active-
+ * pointer-write only; profile authoring (`maw profile create`) is intentionally
+ * NOT here yet — operators write the JSON themselves in Phase 1, and a follow-up
+ * sub-issue will add a scaffolding verb once Phase 2 wires the loader into the
+ * registry.
+ *
+ * Verb shape mirrors `src/commands/plugins/scope/impl.ts` (#642 Phase 1 — same
+ * primitive-with-CLI pattern).
+ */
+
+import {
+  getActiveProfile,
+  loadAllProfiles,
+  loadProfile,
+  setActiveProfile,
+} from "../../../lib/profile-loader";
+import type { TProfile } from "../../../lib/schemas";
+
+export function cmdList(): TProfile[] {
+  return loadAllProfiles();
+}
+
+export function cmdShow(name: string): TProfile | null {
+  return loadProfile(name);
+}
+
+export function cmdCurrent(): string {
+  return getActiveProfile();
+}
+
+/**
+ * Switch the active profile. Refuses to point at a profile file that doesn't
+ * exist — Phase 1 has no scaffolder, so a typo would silently brick plugin
+ * activation in Phase 2 if we let unknown names through.
+ */
+export function cmdUse(name: string): TProfile {
+  const profile = loadProfile(name);
+  if (!profile) {
+    throw new Error(`profile "${name}" not found — see "maw profile list"`);
+  }
+  setActiveProfile(name);
+  return profile;
+}
+
+// ─── Format ──────────────────────────────────────────────────────────────────
+
+export function formatList(rows: TProfile[], active: string): string {
+  if (!rows.length) return "no profiles";
+  const header = ["", "name", "plugins", "tiers", "description"];
+  const lines = rows.map((r) => [
+    r.name === active ? "*" : " ",
+    r.name,
+    r.plugins ? String(r.plugins.length) : "-",
+    r.tiers && r.tiers.length ? r.tiers.join(",") : "-",
+    r.description ?? "",
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...lines.map((l) => l[i].length))
+  );
+  const fmt = (cols: string[]) =>
+    cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  return [
+    fmt(header),
+    fmt(widths.map((w) => "-".repeat(w))),
+    ...lines.map(fmt),
+  ].join("\n");
+}

--- a/plugins/profile/index.ts
+++ b/plugins/profile/index.ts
@@ -1,0 +1,122 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "profile",
+  description: "Profile primitive — named plugin bundles (Phase 1 of #640 / #888).",
+};
+
+/**
+ * maw profile — primitive plugin (#888, Phase 1 of #640 lean-core epic).
+ *
+ * Phase 1 ships READ verbs + the active-profile pointer write. Profile JSON
+ * authoring is operator-driven (write the file by hand at
+ * `<CONFIG_DIR>/profiles/<name>.json`); a Phase 1.5 follow-up will add a
+ * scaffolder. Phase 2 (separate sub-issue) wires `getActiveProfile()` into the
+ * plugin registry so the chosen profile actually narrows the loader. Until
+ * then this module is purely additive.
+ *
+ * Subcommand dispatcher mirrors the `scope` plugin (#642 Phase 1).
+ */
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const impl = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  const out = () => logs.join("\n");
+  const help = () =>
+    [
+      "usage: maw profile <list|use|show|current>",
+      "  list                 — list all profiles (active is marked with *)",
+      "  use     <name>       — set active profile (refuses unknown names)",
+      "  show    <name>       — print one profile's JSON",
+      "  current              — print active profile name",
+      "",
+      "storage:",
+      "  <CONFIG_DIR>/profiles/<name>.json   — one file per profile",
+      "  <CONFIG_DIR>/profile-active         — active profile pointer (text)",
+      "",
+      "note: Phase 1 of #640 — additive read + active-pointer only. Profile",
+      "      authoring is operator-driven (hand-edit JSON). Phase 2 wires this",
+      "      into the plugin loader.",
+    ].join("\n");
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const positional = args.filter((a) => !a.startsWith("--"));
+    const sub = positional[0];
+
+    if (!sub) {
+      console.log(help());
+      return { ok: true, output: out() || help() };
+    }
+
+    switch (sub) {
+      case "list":
+      case "ls": {
+        const rows = impl.cmdList();
+        const active = impl.cmdCurrent();
+        console.log(impl.formatList(rows, active));
+        return { ok: true, output: out() };
+      }
+      case "use":
+      case "set": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw profile use <name>" };
+        try {
+          const used = impl.cmdUse(name);
+          console.log(`active profile: "${used.name}"`);
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "show":
+      case "info": {
+        const name = positional[1];
+        if (!name) return { ok: false, error: "usage: maw profile show <name>" };
+        try {
+          const found = impl.cmdShow(name);
+          if (!found) {
+            return {
+              ok: false,
+              error: `profile "${name}" not found`,
+              output: out(),
+            };
+          }
+          console.log(JSON.stringify(found, null, 2));
+          return { ok: true, output: out() };
+        } catch (e: any) {
+          return { ok: false, error: e?.message || String(e), output: out() };
+        }
+      }
+      case "current":
+      case "active": {
+        console.log(impl.cmdCurrent());
+        return { ok: true, output: out() };
+      }
+      default: {
+        console.log(help());
+        return {
+          ok: false,
+          error: `maw profile: unknown subcommand "${sub}" (expected list|use|show|current)`,
+          output: out() || help(),
+        };
+      }
+    }
+  } catch (e: any) {
+    return { ok: false, error: out() || e.message, output: out() || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/profile/plugin.json
+++ b/plugins/profile/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "profile",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Profile primitive — named plugin bundles (Phase 1 of #640 / #888).",
+  "author": "Soul-Brews-Studio",
+  "tier": "core",
+  "cli": {
+    "command": "profile",
+    "aliases": ["profiles"],
+    "help": "maw profile <list|use|show|current> [...] — manage plugin profiles (Phase 1 of #640)"
+  },
+  "weight": 50
+}

--- a/plugins/pulse/index.ts
+++ b/plugins/pulse/index.ts
@@ -1,0 +1,85 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "pulse",
+  description: "Task pulse — add, list, and clean up work items.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const subcmd = args[0];
+
+    if (subcmd === "add") {
+      const flags = parseFlags(args.slice(1), {
+        "--oracle": String,
+        "--priority": String,
+        "--wt": String,
+        "--worktree": "--wt",
+      }, 0);
+      const title = flags._.find(a => !a.startsWith("--")) ?? "";
+      const pulseOpts = {
+        oracle: flags["--oracle"],
+        priority: flags["--priority"],
+        wt: flags["--wt"],
+      };
+      if (!title) {
+        return {
+          ok: false,
+          error: 'usage: maw pulse add "task title" --oracle <name> [--wt <repo>]',
+        };
+      }
+      const { cmdPulseAdd } = await import("../../shared/pulse");
+      await cmdPulseAdd(title, pulseOpts);
+    } else if (subcmd === "ls" || subcmd === "list") {
+      const sync = args.includes("--sync");
+      const { cmdPulseLs } = await import("../../shared/pulse");
+      await cmdPulseLs({ sync });
+    } else if (subcmd === "cleanup" || subcmd === "clean") {
+      const { scanWorktrees, cleanupWorktree } = await import("../../../worktrees");
+      const worktrees = await scanWorktrees();
+      const stale = worktrees.filter(wt => wt.status !== "active");
+      if (!stale.length) {
+        console.log("\x1b[32m✓\x1b[0m All worktrees are active. Nothing to clean.");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+      console.log(`\n\x1b[36mWorktree Cleanup\x1b[0m\n`);
+      console.log(`  \x1b[32m${worktrees.filter(w => w.status === "active").length} active\x1b[0m | \x1b[33m${worktrees.filter(w => w.status === "stale").length} stale\x1b[0m | \x1b[31m${worktrees.filter(w => w.status === "orphan").length} orphan\x1b[0m\n`);
+      for (const wt of stale) {
+        const color = wt.status === "orphan" ? "\x1b[31m" : "\x1b[33m";
+        console.log(`${color}${wt.status}\x1b[0m  ${wt.name} (${wt.mainRepo}) [${wt.branch}]`);
+        if (!args.includes("--dry-run")) {
+          const log = await cleanupWorktree(wt.path);
+          for (const line of log) console.log(`  \x1b[32m✓\x1b[0m ${line}`);
+        }
+      }
+      if (args.includes("--dry-run")) console.log(`\n\x1b[90m(dry run — use without --dry-run to clean)\x1b[0m`);
+      console.log();
+    } else {
+      return {
+        ok: false,
+        error: "usage: maw pulse <add|ls|cleanup> [opts]",
+      };
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/pulse/plugin.json
+++ b/plugins/pulse/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "pulse",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Task pulse — add, list, and clean up work items.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "pulse",
+    "help": "maw pulse <add|ls|cleanup> [opts]"
+  },
+  "weight": 10
+}

--- a/plugins/restart/impl.ts
+++ b/plugins/restart/impl.ts
@@ -1,0 +1,120 @@
+/**
+ * maw restart — clean slate: kill stale views, update, stop fleet, wake all.
+ *
+ * Like restarting Claude Code but for the whole fleet.
+ *
+ * Steps:
+ *   1. Kill all *-view sessions (stale grouped sessions)
+ *   2. Update maw-js (optional, --no-update to skip)
+ *   3. Stop fleet (maw stop)
+ *   4. Wake fleet (maw wake all)
+ */
+
+import { listSessions } from "../../../sdk";
+import { Tmux } from "../../../sdk";
+import { cmdSleep, cmdWakeAll } from "../../shared/fleet";
+import { execSync } from "child_process";
+import { ghqFindSync } from "../../../core/ghq";
+
+const HELP_TEXT = [
+  "usage: maw restart [--no-update] [--ref <git-ref>]",
+  "",
+  "  Restart the whole maw fleet:",
+  "    1. kill stale *-view sessions",
+  "    2. update maw-js (unless --no-update)",
+  "    3. stop fleet (maw stop)",
+  "    4. wake fleet (maw wake all)",
+  "",
+  "  Flags:",
+  "    --no-update   skip the git pull + rebuild step",
+  "    --ref <ref>   update to a specific ref (branch/tag/sha) instead of default",
+  "    --help, -h    show this message and exit (no side effects)",
+].join("\n");
+
+export async function cmdRestart(opts: { noUpdate?: boolean; ref?: string; help?: boolean } = {}) {
+  // #349 — defense-in-depth guard. The index.ts handler should catch --help
+  // first, but a broken dispatch could call cmdRestart directly with opts=defaults.
+  // Check process.argv too since we're the destructive core.
+  if (opts.help || process.argv.includes("--help") || process.argv.includes("-h")) {
+    console.log(HELP_TEXT);
+    return;
+  }
+  const tmux = new Tmux();
+  console.log(`\n  \x1b[36m🔄 maw restart\x1b[0m\n`);
+
+  // 1. Kill stale sessions (views, PTYs, bash leftovers)
+  const sessions = await listSessions();
+  const stale = sessions.filter(s =>
+    s.name.endsWith("-view") || s.name.startsWith("maw-pty-") ||
+    s.windows.every(w => w.name === "bash")
+  );
+  if (stale.length > 0) {
+    console.log(`  \x1b[33m1. Cleaning ${stale.length} stale sessions...\x1b[0m`);
+    for (const v of stale) {
+      await tmux.killSession(v.name);
+      console.log(`    \x1b[90m✗ ${v.name}\x1b[0m`);
+    }
+  } else {
+    console.log(`  \x1b[90m1. No stale sessions\x1b[0m`);
+  }
+
+  // 2. Update maw-js
+  if (!opts.noUpdate) {
+    const ref = opts.ref || "main";
+    console.log(`\n  \x1b[33m2. Updating maw-js (${ref})...\x1b[0m`);
+    try {
+      const pkg = require("../../../../package.json");
+      const before = `v${pkg.version}`;
+      // Atomic install sequence — try install over existing FIRST so that a
+      // transient failure (network, auth, bun version) cannot leave the user
+      // with an uninstalled maw. `bun remove` only runs as a fallback when
+      // the initial install fails. Mirrors the alpha.132 fix in cmd-update.ts
+      // (regression #507 — this site was missed in the original sweep).
+      const tryInstall = (): boolean => {
+        try {
+          execSync(`bun add -g github:${pkg.repository}#${ref}`, { stdio: "pipe" });
+          return true;
+        } catch { return false; }
+      };
+      if (!tryInstall()) {
+        console.log(`    \x1b[33m⚠ first install attempt failed — clearing stale global refs and retrying\x1b[0m`);
+        try { execSync(`bun remove -g maw`, { stdio: "pipe" }); } catch {}
+        if (!tryInstall()) {
+          console.log(`    \x1b[31m✗ update failed — manual recovery: bun add -g github:${pkg.repository}#alpha\x1b[0m`);
+          return;
+        }
+      }
+      let after = "";
+      try { after = execSync(`maw --version`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim(); } catch {}
+      console.log(`    ${before} → ${after || "updated"}`);
+      // Link SDK for plugins
+      try {
+        const mawDir = ghqFindSync("/Soul-Brews-Studio/maw-js");
+        if (mawDir) {
+          execSync(`cd ${mawDir} && bun link`, { stdio: "pipe" });
+          const oDir = require("os").homedir() + "/.oracle";
+          require("fs").mkdirSync(oDir, { recursive: true });
+          if (!require("fs").existsSync(oDir + "/package.json")) {
+            require("fs").writeFileSync(oDir + "/package.json", '{"name":"oracle-plugins","private":true}\n');
+          }
+          execSync(`cd ${oDir} && bun link maw`, { stdio: "pipe" });
+          console.log(`    🔗 SDK linked`);
+        }
+      } catch { /* non-fatal */ }
+    } catch (e: any) {
+      console.log(`    \x1b[33m⚠ update failed: ${e.message?.slice(0, 80) || e}\x1b[0m`);
+    }
+  } else {
+    console.log(`\n  \x1b[90m2. Update skipped (--no-update)\x1b[0m`);
+  }
+
+  // 3. Stop fleet
+  console.log(`\n  \x1b[33m3. Stopping fleet...\x1b[0m`);
+  await cmdSleep();
+
+  // 4. Wake fleet
+  console.log(`  \x1b[33m4. Waking fleet...\x1b[0m`);
+  await cmdWakeAll();
+
+  console.log(`\n  \x1b[32m✓ restart complete\x1b[0m\n`);
+}

--- a/plugins/restart/index.ts
+++ b/plugins/restart/index.ts
@@ -1,0 +1,76 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdRestart } from "./impl";
+
+/** Dual-dispatcher ctx: old plugin/registry.ts passes InvokeContext;
+ *  new cli/command-registry.ts passes positional args as string[]. */
+type DualCtx = InvokeContext | string[];
+
+export const command = {
+  name: "restart",
+  description: "Restart the maw server with optional update.",
+};
+
+const HELP_TEXT = [
+  "usage: maw restart [--no-update] [--ref <git-ref>]",
+  "",
+  "  Restart the whole maw fleet:",
+  "    1. kill stale *-view sessions",
+  "    2. update maw-js (unless --no-update)",
+  "    3. stop fleet (maw stop)",
+  "    4. wake fleet (maw wake all)",
+  "",
+  "  Flags:",
+  "    --no-update   skip the git pull + rebuild step",
+  "    --ref <ref>   update to a specific ref (branch/tag/sha) instead of default",
+  "    --help, -h    show this message and exit (no side effects)",
+].join("\n");
+
+/**
+ * Extract args from either calling convention:
+ *   OLD (plugin/registry.ts): handler({ source: "cli", args: [...] })
+ *   NEW (cli/command-registry.ts): handler(positional: string[], flags: object)
+ * Both dispatchers are live; we must support both until unified.
+ */
+function extractArgs(ctx: DualCtx): string[] {
+  if (Array.isArray(ctx)) return ctx;                        // NEW dispatcher
+  if (ctx?.source === "cli" && Array.isArray(ctx.args)) return ctx.args; // OLD
+  return [];
+}
+
+export default async function handler(ctx: DualCtx, _flags?: Record<string, unknown>): Promise<InvokeResult | void> {
+  const args = extractArgs(ctx);
+  const writer = !Array.isArray(ctx) ? ctx.writer : undefined;
+
+  // #349 — --help MUST short-circuit BEFORE any side effects. This plugin
+  // performs destructive fleet operations; silent flag-fallthrough on --help
+  // would kill sessions + restart fleet when the user just wanted docs.
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(HELP_TEXT);
+    return { ok: true, output: HELP_TEXT };
+  }
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: unknown[]) => {
+    if (writer) writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: unknown[]) => {
+    if (writer) writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const noUpdate = args.includes("--no-update");
+    const refIdx = args.indexOf("--ref");
+    const ref = refIdx >= 0 ? args[refIdx + 1] : undefined;
+    await cmdRestart({ noUpdate, ref });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: logs.join("\n") || msg, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/restart/plugin.json
+++ b/plugins/restart/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "restart",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Restart the maw server with optional update.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "restart",
+    "aliases": [
+      "reboot"
+    ],
+    "help": "maw restart [--no-update] [--ref <branch>] — restart the maw server"
+  },
+  "weight": 10
+}

--- a/plugins/run/impl.ts
+++ b/plugins/run/impl.ts
@@ -1,0 +1,88 @@
+/**
+ * run — type text into any tmux pane and submit with Enter.
+ *
+ * Idiomatic verb for shell panes: `maw run <target> "<cmd>"` is the same as
+ * `maw send <target> "<cmd>" && maw send-enter <target>`. See #757.
+ *
+ * Unlike `maw hey`, this verb:
+ *   - accepts ANY tmux pane (bash, claude, anything) — no readiness guard
+ *   - uses `tmux send-keys -l` (literal) — no paste-mode, no smart escaping
+ *   - always appends Enter — submits the line
+ *
+ *   maw run <target> "<cmd>"
+ */
+
+import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface RunOpts {
+  target: string;
+  text: string;
+}
+
+export async function cmdRun(opts: RunOpts): Promise<void> {
+  const { target: query, text } = opts;
+  if (!query) throw new Error('usage: maw run <target> "<cmd>"');
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Cross-node — route via federation /api/pane-keys (#757).
+    const res = await curlFetch(`${result.peerUrl}/api/pane-keys`, {
+      method: "POST",
+      body: JSON.stringify({ target: result.target, text, enter: true }),
+      from: "auto", // #804 Step 4 SIGN — sign cross-node /api/pane-keys
+    });
+    if (!res.ok || !res.data?.ok) {
+      const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+      throw new Error(`peer run failed (${result.node} ${result.peerUrl}): ${underlying}`);
+    }
+    console.log(`\x1b[32mran\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
+    return;
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  const t = new Tmux();
+  if (text.length > 0) {
+    await t.sendKeysLiteral(target, text);
+  }
+  await t.sendKeys(target, "Enter");
+
+  console.log(`\x1b[32mran\x1b[0m → ${target}: ${truncate(text)}`);
+}
+
+function truncate(s: string, n = 200): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}
+
+/**
+ * Parse args: <target> <cmd...>. The first positional (non-flag) arg is the
+ * target; everything after is the cmd, joined with spaces. Dashes inside
+ * the cmd are preserved so `maw run pane "ls -la"` and unquoted
+ * `maw run pane ls -la` both work. Empty cmd is allowed (degenerates to a
+ * bare Enter, same as `maw send-enter`).
+ *   ["bash-pane", "ls", "-la"]  → { target: "bash-pane", text: "ls -la" }
+ *   ["bash-pane"]               → { target: "bash-pane", text: "" }
+ */
+export function parseRunArgs(args: string[]): RunOpts {
+  const targetIdx = args.findIndex(a => !a.startsWith("-"));
+  if (targetIdx < 0) throw new Error('usage: maw run <target> "<cmd>"');
+  const target = args[targetIdx];
+  const text = args.slice(targetIdx + 1).join(" ");
+  return { target, text };
+}

--- a/plugins/run/index.ts
+++ b/plugins/run/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdRun, parseRunArgs } from "./impl";
+
+export const command = {
+  name: "run",
+  description: "Type text into a tmux pane and submit with Enter (idiomatic for shells).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseRunArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const text = (a.text as string) ?? "";
+      opts = { target, text };
+    }
+
+    await cmdRun(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/run/plugin.json
+++ b/plugins/run/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "run",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Type text into a tmux pane and submit with Enter — idiomatic for shells (#757).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "run",
+    "help": "maw run <target> \"<cmd>\" — type text into a tmux pane and press Enter"
+  },
+  "weight": 0
+}

--- a/plugins/run/run.test.ts
+++ b/plugins/run/run.test.ts
@@ -1,0 +1,45 @@
+/**
+ * run — argument parser tests (#757).
+ */
+
+import { test, expect } from "bun:test";
+import { parseRunArgs } from "./impl";
+
+test("parseRunArgs: target + single-word cmd", () => {
+  const opts = parseRunArgs(["bash-pane", "ls"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("ls");
+});
+
+test("parseRunArgs: target + multi-word cmd", () => {
+  const opts = parseRunArgs(["bash-pane", "ls", "-la", "/tmp"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("ls -la /tmp");
+});
+
+test("parseRunArgs: empty cmd allowed (bare Enter)", () => {
+  const opts = parseRunArgs(["bash-pane"]);
+  expect(opts.target).toBe("bash-pane");
+  expect(opts.text).toBe("");
+});
+
+test("parseRunArgs: shell metacharacters preserved", () => {
+  const opts = parseRunArgs(["local:bash-pane", "echo", "hi", "&&", "ls"]);
+  expect(opts.text).toBe("echo hi && ls");
+});
+
+test("parseRunArgs: missing target throws", () => {
+  expect(() => parseRunArgs([])).toThrow(/usage/);
+});
+
+test("parseRunArgs: cross-node target accepted", () => {
+  const opts = parseRunArgs(["clinic:01-mawjs", "make", "test"]);
+  expect(opts.target).toBe("clinic:01-mawjs");
+  expect(opts.text).toBe("make test");
+});
+
+test("parseRunArgs: pane-specific target accepted", () => {
+  const opts = parseRunArgs(["session:1.2", "exit"]);
+  expect(opts.target).toBe("session:1.2");
+  expect(opts.text).toBe("exit");
+});

--- a/plugins/send-enter/impl.ts
+++ b/plugins/send-enter/impl.ts
@@ -1,0 +1,100 @@
+/**
+ * send-enter — manually submit pending input on a maw target.
+ *
+ * `maw hey` sometimes leaves text as pending input on the target pane
+ * (older targets / interactive UIs without the #714 1500ms paste-render
+ * delay). This is the manual escape hatch — sends Enter to any maw target
+ * without attaching.
+ *
+ * Phase 1 (#728): local-only. Federation can be a follow-up.
+ *
+ *   maw send-enter <target>          # send single Enter
+ *   maw send-enter <target> --N 3    # send N Enters
+ */
+
+import { listSessions, resolveTarget, tmux } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface SendEnterOpts {
+  target: string;
+  count?: number;
+}
+
+export async function cmdSendEnter(opts: SendEnterOpts): Promise<void> {
+  const { target: query } = opts;
+  const count = Math.max(1, opts.count ?? 1);
+
+  if (!query) throw new Error("usage: maw send-enter <target> [--N <count>]");
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Phase 1: local-only. Federation deferred to follow-up (see #728).
+    throw new Error(
+      `send-enter: cross-node target '${query}' (node '${result.node}') not yet supported — Phase 1 is local-only. ` +
+        `Workaround: ssh ${result.node} && maw send-enter ${result.target}`,
+    );
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  for (let i = 0; i < count; i++) {
+    await tmux.sendKeys(target, "Enter");
+  }
+
+  const plural = count === 1 ? "Enter" : `${count} Enters`;
+  console.log(`\x1b[32mdelivered\x1b[0m → ${target}: ${plural}`);
+}
+
+/**
+ * Parse args: positional target, optional `--N <count>`.
+ *   ["mba:sloworacle"]              → { target: "mba:sloworacle", count: 1 }
+ *   ["mba:sloworacle", "--N", "3"]  → { target: "mba:sloworacle", count: 3 }
+ *   ["--N", "3", "mba:sloworacle"]  → { target: "mba:sloworacle", count: 3 }
+ */
+export function parseSendEnterArgs(args: string[]): SendEnterOpts {
+  let target: string | undefined;
+  let count = 1;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--N" || a === "-N" || a === "--n") {
+      const next = args[i + 1];
+      const n = parseInt(next ?? "", 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--N requires a positive integer (got: ${next ?? "nothing"})`);
+      }
+      count = n;
+      i++;
+      continue;
+    }
+    if (a.startsWith("--N=") || a.startsWith("--n=")) {
+      const n = parseInt(a.split("=")[1] ?? "", 10);
+      if (!Number.isFinite(n) || n < 1) {
+        throw new Error(`--N requires a positive integer (got: ${a})`);
+      }
+      count = n;
+      continue;
+    }
+    if (!target && !a.startsWith("-")) {
+      target = a;
+      continue;
+    }
+  }
+
+  if (!target) throw new Error("usage: maw send-enter <target> [--N <count>]");
+  return { target, count };
+}

--- a/plugins/send-enter/index.ts
+++ b/plugins/send-enter/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSendEnter, parseSendEnterArgs } from "./impl";
+
+export const command = {
+  name: "send-enter",
+  description: "Send Enter key to a maw target — manually submit pending input on stuck panes.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseSendEnterArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const count = typeof a.N === "number" ? (a.N as number) : typeof a.count === "number" ? (a.count as number) : 1;
+      opts = { target, count };
+    }
+
+    await cmdSendEnter(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/send-enter/plugin.json
+++ b/plugins/send-enter/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "send-enter",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Send Enter key to a maw target — manually submit pending input on stuck panes (#728).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "send-enter",
+    "help": "maw send-enter <target> [--N <count>] — send Enter key to a tmux pane"
+  },
+  "weight": 0
+}

--- a/plugins/send-enter/send-enter.test.ts
+++ b/plugins/send-enter/send-enter.test.ts
@@ -1,0 +1,51 @@
+/**
+ * send-enter — argument parser tests (#728).
+ */
+
+import { test, expect } from "bun:test";
+import { parseSendEnterArgs } from "./impl";
+
+test("parseSendEnterArgs: positional target only", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(1);
+});
+
+test("parseSendEnterArgs: target then --N", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--N", "3"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(3);
+});
+
+test("parseSendEnterArgs: --N then target", () => {
+  const opts = parseSendEnterArgs(["--N", "5", "mba:sloworacle"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(5);
+});
+
+test("parseSendEnterArgs: --N=N inline form", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--N=4"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(4);
+});
+
+test("parseSendEnterArgs: lowercase --n", () => {
+  const opts = parseSendEnterArgs(["mba:sloworacle", "--n", "2"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.count).toBe(2);
+});
+
+test("parseSendEnterArgs: missing target throws", () => {
+  expect(() => parseSendEnterArgs([])).toThrow(/usage/);
+  expect(() => parseSendEnterArgs(["--N", "3"])).toThrow(/usage/);
+});
+
+test("parseSendEnterArgs: invalid --N value throws", () => {
+  expect(() => parseSendEnterArgs(["target", "--N", "foo"])).toThrow(/positive integer/);
+  expect(() => parseSendEnterArgs(["target", "--N", "0"])).toThrow(/positive integer/);
+  expect(() => parseSendEnterArgs(["target", "--N", "-1"])).toThrow(/positive integer/);
+});
+
+test("parseSendEnterArgs: --N missing value throws", () => {
+  expect(() => parseSendEnterArgs(["target", "--N"])).toThrow();
+});

--- a/plugins/send/impl.ts
+++ b/plugins/send/impl.ts
@@ -1,0 +1,89 @@
+/**
+ * send — type raw text into any tmux pane (no Enter, composable).
+ *
+ * Dual of `maw send-enter` (#728). `maw send` puts characters on the prompt
+ * line without submitting; pair with `maw send-enter` to submit, or use
+ * `maw run` for the text+Enter combo. See #757.
+ *
+ * Unlike `maw hey`, this verb:
+ *   - accepts ANY tmux pane (bash, claude, anything) — no readiness guard
+ *   - uses `tmux send-keys -l` (literal) — no paste-mode, no smart escaping
+ *   - never appends Enter — the caller composes
+ *
+ *   maw send <target> "<text>"
+ */
+
+import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveOraclePane } from "../../shared/comm-send";
+
+export interface SendOpts {
+  target: string;
+  text: string;
+}
+
+export async function cmdSend(opts: SendOpts): Promise<void> {
+  const { target: query, text } = opts;
+  if (!query) throw new Error('usage: maw send <target> "<text>"');
+
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(query, config, sessions);
+
+  if (!result) {
+    throw new Error(`could not resolve target: ${query}`);
+  }
+
+  if (result.type === "error") {
+    const hint = result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`${result.detail}${hint}`);
+  }
+
+  if (result.type === "peer") {
+    // Cross-node — route via federation /api/pane-keys (#757).
+    const res = await curlFetch(`${result.peerUrl}/api/pane-keys`, {
+      method: "POST",
+      body: JSON.stringify({ target: result.target, text, enter: false }),
+      from: "auto", // #804 Step 4 SIGN — sign cross-node /api/pane-keys
+    });
+    if (!res.ok || !res.data?.ok) {
+      const underlying = res.data?.error || (res.status ? `HTTP ${res.status}` : "connection failed");
+      throw new Error(`peer send failed (${result.node} ${result.peerUrl}): ${underlying}`);
+    }
+    console.log(`\x1b[32mtyped\x1b[0m ⚡ ${result.node} → ${res.data.target || result.target}: ${truncate(text)}`);
+    return;
+  }
+
+  // Local or self-node — resolve to specific pane (handles multi-pane oracle windows)
+  const target = await resolveOraclePane(result.target);
+
+  const t = new Tmux();
+  await t.sendKeysLiteral(target, text);
+
+  console.log(`\x1b[32mtyped\x1b[0m → ${target}: ${truncate(text)}`);
+}
+
+function truncate(s: string, n = 200): string {
+  if (s.length <= n) return s;
+  return s.slice(0, n) + "…";
+}
+
+/**
+ * Parse args: <target> <text...>. The first positional (non-flag) arg is the
+ * target; everything after is the text, joined with spaces. Dashes inside
+ * the text are preserved so `maw send pane "ls -la"` and unquoted
+ * `maw send pane ls -la` both work.
+ *   ["mba:sloworacle", "echo hi"]              → { target, text: "echo hi" }
+ *   ["mba:sloworacle", "echo", "hi"]           → { target, text: "echo hi" }
+ *   ["mba:sloworacle", "ls", "-la", "/tmp"]    → { target, text: "ls -la /tmp" }
+ */
+export function parseSendArgs(args: string[]): SendOpts {
+  // Find the first non-flag arg — that's the target. Everything after
+  // (regardless of dashes) is text.
+  const targetIdx = args.findIndex(a => !a.startsWith("-"));
+  if (targetIdx < 0) throw new Error('usage: maw send <target> "<text>"');
+  const target = args[targetIdx];
+  const text = args.slice(targetIdx + 1).join(" ");
+  if (text.length === 0) throw new Error('usage: maw send <target> "<text>" — text is required');
+  return { target, text };
+}

--- a/plugins/send/index.ts
+++ b/plugins/send/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSend, parseSendArgs } from "./impl";
+
+export const command = {
+  name: "send",
+  description: "Type raw text into a tmux pane (no Enter, composable).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    let opts;
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      opts = parseSendArgs(args);
+    } else {
+      const a = ctx.args as Record<string, unknown>;
+      const target = (a.target as string) ?? "";
+      const text = (a.text as string) ?? "";
+      opts = { target, text };
+    }
+
+    await cmdSend(opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/send/plugin.json
+++ b/plugins/send/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "send",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Type raw text into a tmux pane (no Enter, composable) — dual of send-enter (#757).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "send",
+    "help": "maw send <target> \"<text>\" — type raw text into a tmux pane (no Enter)"
+  },
+  "weight": 0
+}

--- a/plugins/send/send.test.ts
+++ b/plugins/send/send.test.ts
@@ -1,0 +1,43 @@
+/**
+ * send — argument parser tests (#757).
+ */
+
+import { test, expect } from "bun:test";
+import { parseSendArgs } from "./impl";
+
+test("parseSendArgs: target + single-word text", () => {
+  const opts = parseSendArgs(["mba:sloworacle", "echo"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.text).toBe("echo");
+});
+
+test("parseSendArgs: target + multi-word text joined with spaces", () => {
+  const opts = parseSendArgs(["mba:sloworacle", "echo", "hello", "world"]);
+  expect(opts.target).toBe("mba:sloworacle");
+  expect(opts.text).toBe("echo hello world");
+});
+
+test("parseSendArgs: text with shell metacharacters preserved", () => {
+  const opts = parseSendArgs(["local:bash-pane", "ls", "|", "grep", "foo"]);
+  expect(opts.text).toBe("ls | grep foo");
+});
+
+test("parseSendArgs: missing target throws", () => {
+  expect(() => parseSendArgs([])).toThrow(/usage/);
+});
+
+test("parseSendArgs: missing text throws", () => {
+  expect(() => parseSendArgs(["mba:sloworacle"])).toThrow(/text is required/);
+});
+
+test("parseSendArgs: cross-node target accepted", () => {
+  const opts = parseSendArgs(["clinic:01-mawjs", "make", "test"]);
+  expect(opts.target).toBe("clinic:01-mawjs");
+  expect(opts.text).toBe("make test");
+});
+
+test("parseSendArgs: pane-specific target accepted", () => {
+  const opts = parseSendArgs(["session:1.2", "exit"]);
+  expect(opts.target).toBe("session:1.2");
+  expect(opts.text).toBe("exit");
+});

--- a/plugins/signals/index.ts
+++ b/plugins/signals/index.ts
@@ -1,0 +1,76 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+import { scanSignals } from "../../shared/scan-signals";
+import type { ScannedSignal } from "../../shared/scan-signals";
+
+export const command = {
+  name: "signals",
+  description: "List bud signals written to ψ/memory/signals/",
+};
+
+const KIND_COLOR: Record<string, string> = {
+  alert: "\x1b[31m",
+  pattern: "\x1b[33m",
+  info: "\x1b[36m",
+};
+const RESET = "\x1b[0m";
+const DIM = "\x1b[90m";
+
+function formatSignal(s: ScannedSignal): string {
+  const color = KIND_COLOR[s.kind] ?? "\x1b[37m";
+  const date = s.timestamp.slice(0, 10);
+  return `  ${color}[${s.kind}]${RESET} ${DIM}${date}${RESET} ${s.bud}: ${s.message}`;
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const body = ctx.source === "api" ? (ctx.args as Record<string, unknown>) : {};
+
+    const flags = parseFlags(args, {
+      "--days": Number,
+      "--root": String,
+      "--json": Boolean,
+    }, 0);
+
+    const root = (flags["--root"] ?? body.root ?? process.cwd()) as string;
+    const days = (flags["--days"] ?? body.days ?? 7) as number;
+    const asJson = (flags["--json"] ?? body.json ?? false) as boolean;
+
+    const signals = scanSignals(root, { days });
+
+    if (asJson) {
+      console.log(JSON.stringify(signals, null, 2));
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (signals.length === 0) {
+      console.log(`  ${DIM}no signals in the last ${days} days${RESET}`);
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    console.log(`\n  \x1b[36mBud signals\x1b[0m (last ${days}d — ${signals.length} total)\n`);
+    for (const s of signals) {
+      console.log(formatSignal(s));
+    }
+    console.log();
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/signals/plugin.json
+++ b/plugins/signals/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "signals",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "List bud signals written to ψ/memory/signals/",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "signals",
+    "help": "maw signals [--days N] [--root <path>] [--json] — list bud signals",
+    "flags": {
+      "--days": "number",
+      "--root": "string",
+      "--json": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/signals",
+    "methods": ["GET"]
+  },
+  "weight": 50
+}

--- a/plugins/split/impl.ts
+++ b/plugins/split/impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/plugins/split/index.ts
+++ b/plugins/split/index.ts
@@ -1,0 +1,68 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdSplit } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "split",
+  description: "Split current tmux pane and attach to a session.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pct?: number; vertical?: boolean; noAttach?: boolean } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, {
+        "--pct": Number,
+        "--vertical": Boolean,
+        "--no-attach": Boolean,
+      }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw split <target> [--pct N] [--vertical] [--no-attach]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw split <target>` };
+      }
+
+      opts = {
+        pct: flags["--pct"],
+        vertical: flags["--vertical"],
+        noAttach: flags["--no-attach"],
+      };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) {
+        return { ok: false, error: "target is required" };
+      }
+      target = body.target as string;
+      opts = {
+        pct: body.pct as number | undefined,
+        vertical: body.vertical as boolean | undefined,
+        noAttach: body.noAttach as boolean | undefined,
+      };
+    }
+
+    await cmdSplit(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/split/plugin.json
+++ b/plugins/split/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "split",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Split current tmux pane and attach to a session (vesicle beside).",
+  "cli": {
+    "command": "split",
+    "help": "maw split <target> [--pct N] [--vertical] [--no-attach]",
+    "flags": {
+      "--pct": "number",
+      "--vertical": "boolean",
+      "--no-attach": "boolean"
+    }
+  },
+  "api": {
+    "path": "/api/split",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/tab/impl.ts
+++ b/plugins/tab/impl.ts
@@ -1,0 +1,80 @@
+import { hostExec } from "../../../sdk";
+import { tmux, tmuxCmd } from "../../../sdk";
+import { cmdPeek, cmdSend } from "../../shared/comm";
+import { cmdTalkTo } from "./internal/talk-to-impl";
+
+/**
+ * Get current tmux session name (whoami).
+ * Uses tmux display-message which returns the session of the calling terminal.
+ */
+async function currentSession(): Promise<string> {
+  try {
+    return (await tmux.run("display-message", "-p", "#S")).trim();
+  } catch {
+    throw new Error("not inside a tmux session");
+  }
+}
+
+/**
+ * List windows in current session, mapping index → name.
+ */
+async function listTabs(session: string): Promise<{ index: number; name: string; active: boolean }[]> {
+  const raw = await hostExec(
+    `${tmuxCmd()} list-windows -t '${session}' -F '#{window_index}:#{window_name}:#{window_active}'`
+  );
+  return raw.split("\n").filter(Boolean).map(line => {
+    const [idx, name, active] = line.split(":");
+    return { index: +idx, name, active: active === "1" };
+  });
+}
+
+/**
+ * maw tab          — list tabs in current session
+ * maw tab N        — peek tab N
+ * maw tab N "msg"  — hey tab N
+ * maw tab N --talk "msg" — talk-to tab N (future: #78)
+ */
+export async function cmdTab(tabArgs: string[]) {
+  const session = await currentSession();
+  const tabNum = tabArgs[0] ? parseInt(tabArgs[0], 10) : NaN;
+
+  // maw tab — list all tabs
+  if (isNaN(tabNum)) {
+    const tabs = await listTabs(session);
+    console.log(`\x1b[36m${session}\x1b[0m tabs:`);
+    for (const t of tabs) {
+      const marker = t.active ? " \x1b[32m← you are here\x1b[0m" : "";
+      console.log(`  ${t.index}: ${t.name}${marker}`);
+    }
+    return;
+  }
+
+  // Resolve tab number → window name
+  const tabs = await listTabs(session);
+  const tab = tabs.find(t => t.index === tabNum);
+  if (!tab) {
+    console.error(`available: ${tabs.map(t => t.index).join(", ")}`);
+    throw new Error(`tab ${tabNum} not found in session ${session}`);
+  }
+
+  const hasTalk = tabArgs.includes("--talk");
+  const remaining = tabArgs.slice(1).filter(a => a !== "--force" && a !== "--talk");
+  const force = tabArgs.includes("--force");
+
+  // maw tab N — peek
+  if (!remaining.length) {
+    await cmdPeek(tab.name);
+    return;
+  }
+
+  const message = remaining.join(" ");
+
+  // maw tab N --talk "msg" — talk-to (MCP + hey)
+  if (hasTalk) {
+    await cmdTalkTo(tab.name, message, force);
+    return;
+  }
+
+  // maw tab N "msg" — hey
+  await cmdSend(tab.name, message, force);
+}

--- a/plugins/tab/index.ts
+++ b/plugins/tab/index.ts
@@ -1,0 +1,33 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "tab",
+  description: "Manage tmux tabs.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { cmdTab } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    await cmdTab(args);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/tab/internal/talk-to-impl.ts
+++ b/plugins/tab/internal/talk-to-impl.ts
@@ -1,0 +1,202 @@
+import { loadConfig } from "../../../../config";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../../sdk";
+import { runHook } from "../../../../sdk";
+import { resolveOraclePane } from "../../../shared/comm-send";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir, hostname } from "os";
+import { join } from "path";
+
+const ORACLE_URL = () => process.env.ORACLE_URL || loadConfig().oracleUrl;
+
+interface ThreadResponse {
+  thread_id: number;
+  message_id: number;
+  status: string;
+  oracle_response?: {
+    content: string;
+    principles_found: number;
+    patterns_found: number;
+  } | null;
+}
+
+interface ThreadInfo {
+  thread: {
+    id: number;
+    title: string;
+    status: string;
+    created_at: string;
+  };
+  messages: {
+    id: number;
+    role: string;
+    content: string;
+    created_at: string;
+  }[];
+}
+
+/**
+ * Find or create a channel thread for a target.
+ * Convention: thread title = "channel:<target>"
+ */
+async function findChannelThread(target: string): Promise<number | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/threads?limit=50`);
+    if (!res.ok) return null;
+    const data = await res.json() as { threads: { id: number; title: string; status: string }[] };
+    const channel = data.threads.find(t => t.title === `channel:${target}` && t.status !== "closed");
+    return channel?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Post message to oracle_thread (MCP persistence layer).
+ */
+async function postToThread(target: string, message: string): Promise<ThreadResponse | null> {
+  const threadId = await findChannelThread(target);
+  const body: Record<string, unknown> = {
+    message,
+    role: "claude",
+  };
+  if (threadId) {
+    body.thread_id = threadId;
+  } else {
+    body.title = `channel:${target}`;
+  }
+
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`\x1b[31merror\x1b[0m: Oracle API returned ${res.status}`);
+      return null;
+    }
+    return await res.json() as ThreadResponse;
+  } catch (e: any) {
+    console.error(`\x1b[31merror\x1b[0m: Oracle unreachable — ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get thread message count.
+ */
+async function getThreadInfo(threadId: number): Promise<{ messageCount: number } | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread/${threadId}`);
+    if (!res.ok) return null;
+    const data = await res.json() as ThreadInfo;
+    return { messageCount: data.messages.length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * maw talk-to <target> "message"
+ *
+ * 1. Post to oracle_thread (MCP) → persistent
+ * 2. Send maw hey to target → notification with context
+ *
+ * MCP first, hey after. Order matters.
+ */
+export async function cmdTalkTo(target: string, message: string, force = false) {
+  // Step 1: Post to oracle_thread
+  console.log(`\x1b[36m💬\x1b[0m posting to thread channel:${target}...`);
+  const threadResult = await postToThread(target, message);
+
+  if (!threadResult) {
+    console.error(`\x1b[33mwarn\x1b[0m: thread post failed — falling back to maw hey only`);
+  }
+
+  // Step 2: Build notification with context
+  const from = process.env.CLAUDE_AGENT_NAME || "cli";
+  const preview = message.length > 80 ? message.slice(0, 77) + "..." : message;
+
+  let notification: string;
+  if (threadResult) {
+    const info = await getThreadInfo(threadResult.thread_id);
+    const msgCount = info?.messageCount ?? "?";
+    notification = [
+      `💬 channel:${target} (#${threadResult.thread_id}) — ${msgCount} msgs`,
+      `From: ${from}`,
+      `Preview: "${preview}"`,
+      `→ อ่านเต็มที่ thread #${threadResult.thread_id} หรือพิมพ์ /talk-to #${threadResult.thread_id}`,
+    ].join("\n");
+  } else {
+    notification = [
+      `💬 from ${from}`,
+      `"${preview}"`,
+    ].join("\n");
+  }
+
+  // Step 3: Send hey with context
+  // Route through resolveTarget so the #758 writable filter (drop -view mirrors
+  // and federated peer records before the ambiguity check) applies to talk-to too.
+  // talk-to is local-only delivery: only "local" / "self-node" results map to a tmux pane.
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const resolved = resolveTarget(target, config, sessions);
+  // Resolve to a specific pane: when the oracle window has multiple panes
+  // (team-agents spawned beside it), `send-keys -t session:window` would
+  // otherwise land in whichever pane is currently active, not the oracle's
+  // claude pane. Mirrors comm-send (#764).
+  const tmuxTarget =
+    resolved?.type === "local" || resolved?.type === "self-node"
+      ? await resolveOraclePane(resolved.target)
+      : null;
+  if (!tmuxTarget) {
+    // Thread was posted but target window not found — still useful
+    if (threadResult) {
+      console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      console.log(`\x1b[33mwarn\x1b[0m: ${reason} — message saved to thread only`);
+    } else {
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      throw new Error(reason);
+    }
+    return;
+  }
+
+  // Check if agent is running
+  if (!force) {
+    const cmd = await getPaneCommand(tmuxTarget);
+    const isAgent = /claude|codex|node/i.test(cmd);
+    if (!isAgent) {
+      if (threadResult) {
+        console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+        console.log(`\x1b[33mwarn\x1b[0m: no active Claude in ${tmuxTarget} — message saved to thread only`);
+      } else {
+        throw new Error(`no active Claude session in ${tmuxTarget} (use --force)`);
+      }
+      return;
+    }
+  }
+
+  await sendKeys(tmuxTarget, notification);
+  await runHook("after_send", { to: target, message: notification });
+
+  // Log to maw-log.jsonl
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const host = hostname();
+  const sid = process.env.CLAUDE_SESSION_ID || null;
+  const ch = threadResult ? `thread:${threadResult.thread_id}` : undefined;
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    from,
+    to: target,
+    target: tmuxTarget,
+    msg: message,
+    host,
+    sid,
+    ch,
+  }) + "\n";
+  try { await mkdir(logDir, { recursive: true }); await appendFile(logFile, line); } catch (e) { console.error(`\x1b[33m⚠\x1b[0m talk-to log write failed: ${e}`); }
+
+  console.log(`\x1b[32m✓\x1b[0m thread #${threadResult?.thread_id ?? "?"} + sent → ${tmuxTarget}`);
+}

--- a/plugins/tab/plugin.json
+++ b/plugins/tab/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "tab",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Manage tmux tabs.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "tab",
+    "aliases": [
+      "tabs"
+    ],
+    "help": "maw tab [args] — manage tmux tabs"
+  },
+  "weight": 50
+}

--- a/plugins/tag/impl.ts
+++ b/plugins/tag/impl.ts
@@ -1,0 +1,144 @@
+import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+
+export interface TagOpts {
+  /** Pane index within the target window (default: active pane of the window). */
+  pane?: number;
+  /** Pane title — surfaces in status bar + tmux list-panes output. */
+  title?: string;
+  /** User-defined options as key=val pairs. Sets tmux @custom options on the pane. */
+  meta?: string[];
+}
+
+/**
+ * maw tag <target> [--pane N] [--title <text>] [--meta key=val ...]
+ *
+ * Set pane metadata so callers can identify panes deterministically
+ * instead of guessing via active-pane heuristics. Wraps two tmux knobs:
+ *
+ *   - tmux select-pane -T '<title>'   — sets pane_title
+ *   - tmux set-option -p @<key> '<val>' — sets user option on the pane
+ *
+ * Why: enables route-by-name for skills that need to distinguish the
+ * oracle's main pane from team-agent panes, without depending on pane
+ * index ordering or process name. Example:
+ *
+ *   maw tag mawjs --title 'oracle' --meta agent-name=mawjs --meta role=oracle
+ *   maw tag mawjs --pane 1 --title 'scout' --meta agent-name=scout --meta role=teammate
+ *
+ * Then `maw panes` shows the title column; skills can grep it or read
+ * the @custom options via `tmux show-options -p -t <target>`.
+ */
+export async function cmdTag(target: string, opts: TagOpts = {}) {
+  if (!target) {
+    console.error("usage: maw tag <target> [--pane N] [--title <text>] [--meta key=val]");
+    console.error("       maw tag <target>                   (read mode — show current tags)");
+    throw new Error("usage: maw tag <target> [--pane N] [--title <text>] [--meta key=val]");
+  }
+
+  // Read mode: no write flags → show current tags on the target pane.
+  const isRead = !opts.title && (!opts.meta || opts.meta.length === 0);
+
+  const tmux = tmuxCmd();
+
+  // Resolve target (session:window or bare session) via canonical matcher.
+  let resolvedTarget: string;
+  if (target.includes(":")) {
+    const [rawSession, winPart] = target.split(":", 2);
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(rawSession, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${rawSession}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${rawSession}' not found`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      throw new Error(`session '${rawSession}' not found`);
+    }
+    resolvedTarget = `${r.match.name}:${winPart ?? "0"}`;
+  } else {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      } else {
+        console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      }
+      throw new Error(`session '${target}' not found`);
+    }
+    resolvedTarget = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Append .pane if supplied; otherwise tmux targets the window's active pane.
+  const fullTarget = opts.pane !== undefined ? `${resolvedTarget}.${opts.pane}` : resolvedTarget;
+
+  // Read mode: print title + all @custom options for the pane.
+  if (isRead) {
+    try {
+      const title = (await hostExec(
+        `${tmux} display-message -p -t '${fullTarget}' '#{pane_title}'`,
+      )).trim();
+      const optsRaw = await hostExec(`${tmux} show-options -p -t '${fullTarget}'`).catch(() => "");
+      const customLines = optsRaw
+        .split("\n")
+        .map(l => l.trim())
+        .filter(l => l.startsWith("@"));
+
+      console.log(`  \x1b[36m${fullTarget}\x1b[0m`);
+      console.log(`  \x1b[90m  title:\x1b[0m ${title || "(none)"}`);
+      if (customLines.length === 0) {
+        console.log(`  \x1b[90m  meta:  (none)\x1b[0m`);
+      } else {
+        console.log(`  \x1b[90m  meta:\x1b[0m`);
+        for (const line of customLines) {
+          console.log(`  \x1b[90m    ${line}\x1b[0m`);
+        }
+      }
+      return;
+    } catch (e: any) {
+      throw new Error(`read failed: ${e.message || e}`);
+    }
+  }
+
+  // Set title — tmux handles the empty-string case by clearing the title.
+  if (opts.title !== undefined) {
+    const escapedTitle = opts.title.replace(/'/g, "'\\''");
+    try {
+      await hostExec(`${tmux} select-pane -t '${fullTarget}' -T '${escapedTitle}'`);
+      console.log(`  \x1b[32m✓\x1b[0m title: ${fullTarget} = '${opts.title}'`);
+    } catch (e: any) {
+      throw new Error(`select-pane -T failed: ${e.message || e}`);
+    }
+  }
+
+  // Apply each --meta key=val as a pane-scoped user option (@custom).
+  for (const kv of opts.meta ?? []) {
+    const eqIdx = kv.indexOf("=");
+    if (eqIdx <= 0) {
+      throw new Error(`--meta must be key=val (got: ${kv})`);
+    }
+    const key = kv.slice(0, eqIdx).trim();
+    const val = kv.slice(eqIdx + 1);
+    const optKey = key.startsWith("@") ? key : `@${key}`;
+    const escapedVal = val.replace(/'/g, "'\\''");
+    try {
+      await hostExec(`${tmux} set-option -p -t '${fullTarget}' '${optKey}' '${escapedVal}'`);
+      console.log(`  \x1b[32m✓\x1b[0m meta: ${fullTarget} ${optKey} = '${val}'`);
+    } catch (e: any) {
+      throw new Error(`set-option failed: ${e.message || e}`);
+    }
+  }
+}

--- a/plugins/tag/index.ts
+++ b/plugins/tag/index.ts
@@ -1,0 +1,68 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdTag } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "tag",
+  description: "Set pane metadata (title + @custom options).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pane?: number; title?: string; meta?: string[] } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, {
+        "--pane": Number,
+        "--title": String,
+        "--meta": [String],
+      }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw tag <target> [--pane N] [--title <text>] [--meta key=val]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw tag <target> ...` };
+      }
+
+      opts = {
+        pane: flags["--pane"],
+        title: flags["--title"],
+        meta: flags["--meta"],
+      };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) {
+        return { ok: false, error: "target is required" };
+      }
+      target = body.target as string;
+      opts = {
+        pane: body.pane as number | undefined,
+        title: body.title as string | undefined,
+        meta: body.meta as string[] | undefined,
+      };
+    }
+
+    await cmdTag(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/tag/plugin.json
+++ b/plugins/tag/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "tag",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Set pane metadata: title, custom options. Enables deterministic routing by agent name.",
+  "cli": {
+    "command": "tag",
+    "help": "maw tag <target> [--pane N] [--title <text>] [--meta key=val ...]",
+    "flags": {
+      "--pane": "number",
+      "--title": "string",
+      "--meta": "string"
+    }
+  },
+  "api": {
+    "path": "/api/tag",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/plugins/take/impl.ts
+++ b/plugins/take/impl.ts
@@ -1,0 +1,78 @@
+import { listSessions, hostExec } from "../../../sdk";
+import { tmux } from "../../../sdk";
+import { buildCommandInDir } from "../../../config";
+
+/**
+ * maw take <source-session>:<window> [target-session]
+ *
+ * Vesicle transport — move a tmux window from one oracle session to another.
+ * If target-session is omitted, uses the current tmux session.
+ *
+ * The window's worktree/cwd stays the same. Only the tmux home changes.
+ */
+export async function cmdTake(source: string, targetSession?: string) {
+  // Parse source — "neo:skills-cli" or "neo:3"
+  const [srcSession, srcWindow] = source.includes(":") ? source.split(":", 2) : [source, ""];
+
+  if (!srcWindow) {
+    console.error("usage: maw take <session>:<window> [target-session]");
+    console.error("  e.g. maw take neo:neo-skills pulse");
+    throw new Error("usage: maw take <session>:<window> [target-session]");
+  }
+
+  // Resolve target session
+  let target = targetSession;
+  const split = !target; // no target = split into own session
+
+  if (split) {
+    // Create a new session named after the window
+    target = srcWindow;
+    try {
+      await hostExec(`tmux new-session -d -s '${target}'`);
+    } catch (e: any) {
+      if (!e.message?.includes("duplicate")) {
+        throw new Error(`could not create session '${target}': ${e.message}`);
+      }
+    }
+  }
+
+  if (target === srcSession) {
+    console.log("  \x1b[33m⚠\x1b[0m source and target are the same session");
+    return;
+  }
+
+  // Verify source window exists
+  const sessions = await listSessions();
+  const srcSess = sessions.find(s => s.name.toLowerCase() === srcSession.toLowerCase());
+  if (!srcSess) {
+    throw new Error(`session '${srcSession}' not found`);
+  }
+
+  const srcWin = srcSess.windows.find(w =>
+    w.name.toLowerCase() === srcWindow.toLowerCase() || String(w.index) === srcWindow
+  );
+  if (!srcWin) {
+    throw new Error(`window '${srcWindow}' not found in session '${srcSession}'`);
+  }
+
+  // Get the window's cwd before moving
+  let paneCwd = "";
+  try {
+    paneCwd = (await hostExec(`tmux display-message -t '${srcSess.name}:${srcWin.name}' -p '#{pane_current_path}'`)).trim();
+  } catch { /* ok */ }
+
+  // Move the window: tmux move-window -s source:window -t target:
+  try {
+    await hostExec(`tmux move-window -s '${srcSess.name}:${srcWin.name}' -t '${target}:'`);
+    // Kill the empty default window from new-session (if split)
+    if (split) {
+      try { await hostExec(`tmux kill-window -t '${target}:1' 2>/dev/null`); } catch {}
+    }
+    console.log(`  \x1b[32m✓\x1b[0m ${srcSess.name}:${srcWin.name} → ${target}${split ? " (new session)" : ""}`);
+    if (paneCwd) {
+      console.log(`  \x1b[90m  cwd: ${paneCwd}\x1b[0m`);
+    }
+  } catch (e: any) {
+    throw new Error(`move failed: ${e.message || e}`);
+  }
+}

--- a/plugins/take/index.ts
+++ b/plugins/take/index.ts
@@ -1,0 +1,49 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdTake } from "./impl";
+
+export const command = {
+  name: ["take", "handover"],
+  description: "Move a tmux window from one oracle session to another (vesicle transport).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let source: string;
+    let target: string | undefined;
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      if (!args[0]) {
+        return { ok: false, error: "usage: maw take <session>:<window> [target-session]" };
+      }
+      source = args[0];
+      target = args[1];
+    } else {
+      const args = ctx.args as Record<string, unknown>;
+      if (!args.source) {
+        return { ok: false, error: "source is required" };
+      }
+      source = args.source as string;
+      target = args.target as string | undefined;
+    }
+
+    await cmdTake(source, target);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/take/plugin.json
+++ b/plugins/take/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "take",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Move a tmux window from one oracle session to another (vesicle transport).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "take",
+    "aliases": [
+      "handover"
+    ],
+    "help": "maw take <session>:<window> [target-session] — move a window between sessions"
+  },
+  "api": {
+    "path": "/api/take",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 0
+}

--- a/plugins/take/take.test.ts
+++ b/plugins/take/take.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, mock } from "bun:test";
+import { join } from "path";
+import type { InvokeContext } from "../../../plugin/types";
+
+const root = join(import.meta.dir, "../../..");
+
+mock.module(join(root, "commands/plugins/take/impl"), () => ({
+  cmdTake: async (source: string, target?: string) => {
+    console.log(`take ${source}${target ? ` → ${target}` : " (new session)"}`);
+  },
+}));
+
+const { default: handler } = await import("./index");
+
+describe("take plugin", () => {
+  it("CLI — source without target creates new session", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo:neo-skills"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("take neo:neo-skills");
+  });
+
+  it("CLI — source with target moves to session", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["neo:neo-skills", "pulse"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("→ pulse");
+  });
+
+  it("CLI — missing source returns error", async () => {
+    const ctx: InvokeContext = { source: "cli", args: [] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("usage");
+  });
+
+  it("API — source and target ok", async () => {
+    const ctx: InvokeContext = { source: "api", args: { source: "neo:neo-skills", target: "pulse" } };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("→ pulse");
+  });
+
+  it("API — missing source returns error", async () => {
+    const ctx: InvokeContext = { source: "api", args: {} };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("source is required");
+  });
+});

--- a/plugins/talk-to/impl.ts
+++ b/plugins/talk-to/impl.ts
@@ -1,0 +1,202 @@
+import { loadConfig } from "../../../config";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../sdk";
+import { runHook } from "../../../sdk";
+import { resolveOraclePane } from "../../shared/comm-send";
+import { appendFile, mkdir } from "fs/promises";
+import { homedir, hostname } from "os";
+import { join } from "path";
+
+const ORACLE_URL = () => process.env.ORACLE_URL || loadConfig().oracleUrl;
+
+interface ThreadResponse {
+  thread_id: number;
+  message_id: number;
+  status: string;
+  oracle_response?: {
+    content: string;
+    principles_found: number;
+    patterns_found: number;
+  } | null;
+}
+
+interface ThreadInfo {
+  thread: {
+    id: number;
+    title: string;
+    status: string;
+    created_at: string;
+  };
+  messages: {
+    id: number;
+    role: string;
+    content: string;
+    created_at: string;
+  }[];
+}
+
+/**
+ * Find or create a channel thread for a target.
+ * Convention: thread title = "channel:<target>"
+ */
+async function findChannelThread(target: string): Promise<number | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/threads?limit=50`);
+    if (!res.ok) return null;
+    const data = await res.json() as { threads: { id: number; title: string; status: string }[] };
+    const channel = data.threads.find(t => t.title === `channel:${target}` && t.status !== "closed");
+    return channel?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Post message to oracle_thread (MCP persistence layer).
+ */
+async function postToThread(target: string, message: string): Promise<ThreadResponse | null> {
+  const threadId = await findChannelThread(target);
+  const body: Record<string, unknown> = {
+    message,
+    role: "claude",
+  };
+  if (threadId) {
+    body.thread_id = threadId;
+  } else {
+    body.title = `channel:${target}`;
+  }
+
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      console.error(`\x1b[31merror\x1b[0m: Oracle API returned ${res.status}`);
+      return null;
+    }
+    return await res.json() as ThreadResponse;
+  } catch (e: any) {
+    console.error(`\x1b[31merror\x1b[0m: Oracle unreachable — ${e.message}`);
+    return null;
+  }
+}
+
+/**
+ * Get thread message count.
+ */
+async function getThreadInfo(threadId: number): Promise<{ messageCount: number } | null> {
+  try {
+    const res = await fetch(`${ORACLE_URL()}/api/thread/${threadId}`);
+    if (!res.ok) return null;
+    const data = await res.json() as ThreadInfo;
+    return { messageCount: data.messages.length };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * maw talk-to <target> "message"
+ *
+ * 1. Post to oracle_thread (MCP) → persistent
+ * 2. Send maw hey to target → notification with context
+ *
+ * MCP first, hey after. Order matters.
+ */
+export async function cmdTalkTo(target: string, message: string, force = false) {
+  // Step 1: Post to oracle_thread
+  console.log(`\x1b[36m💬\x1b[0m posting to thread channel:${target}...`);
+  const threadResult = await postToThread(target, message);
+
+  if (!threadResult) {
+    console.error(`\x1b[33mwarn\x1b[0m: thread post failed — falling back to maw hey only`);
+  }
+
+  // Step 2: Build notification with context
+  const from = process.env.CLAUDE_AGENT_NAME || "cli";
+  const preview = message.length > 80 ? message.slice(0, 77) + "..." : message;
+
+  let notification: string;
+  if (threadResult) {
+    const info = await getThreadInfo(threadResult.thread_id);
+    const msgCount = info?.messageCount ?? "?";
+    notification = [
+      `💬 channel:${target} (#${threadResult.thread_id}) — ${msgCount} msgs`,
+      `From: ${from}`,
+      `Preview: "${preview}"`,
+      `→ อ่านเต็มที่ thread #${threadResult.thread_id} หรือพิมพ์ /talk-to #${threadResult.thread_id}`,
+    ].join("\n");
+  } else {
+    notification = [
+      `💬 from ${from}`,
+      `"${preview}"`,
+    ].join("\n");
+  }
+
+  // Step 3: Send hey with context
+  // Route through resolveTarget so the #758 writable filter (drop -view mirrors
+  // and federated peer records before the ambiguity check) applies to talk-to too.
+  // talk-to is local-only delivery: only "local" / "self-node" results map to a tmux pane.
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const resolved = resolveTarget(target, config, sessions);
+  // Resolve to a specific pane: when the oracle window has multiple panes
+  // (team-agents spawned beside it), `send-keys -t session:window` would
+  // otherwise land in whichever pane is currently active, not the oracle's
+  // claude pane. Mirrors comm-send (#764).
+  const tmuxTarget =
+    resolved?.type === "local" || resolved?.type === "self-node"
+      ? await resolveOraclePane(resolved.target)
+      : null;
+  if (!tmuxTarget) {
+    // Thread was posted but target window not found — still useful
+    if (threadResult) {
+      console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      console.log(`\x1b[33mwarn\x1b[0m: ${reason} — message saved to thread only`);
+    } else {
+      const reason = resolved?.type === "error" ? resolved.detail : `window "${target}" not found`;
+      throw new Error(reason);
+    }
+    return;
+  }
+
+  // Check if agent is running
+  if (!force) {
+    const cmd = await getPaneCommand(tmuxTarget);
+    const isAgent = /claude|codex|node/i.test(cmd);
+    if (!isAgent) {
+      if (threadResult) {
+        console.log(`\x1b[32m✓\x1b[0m thread #${threadResult.thread_id} updated`);
+        console.log(`\x1b[33mwarn\x1b[0m: no active Claude in ${tmuxTarget} — message saved to thread only`);
+      } else {
+        throw new Error(`no active Claude session in ${tmuxTarget} (use --force)`);
+      }
+      return;
+    }
+  }
+
+  await sendKeys(tmuxTarget, notification);
+  await runHook("after_send", { to: target, message: notification });
+
+  // Log to maw-log.jsonl
+  const logDir = join(homedir(), ".oracle");
+  const logFile = join(logDir, "maw-log.jsonl");
+  const host = hostname();
+  const sid = process.env.CLAUDE_SESSION_ID || null;
+  const ch = threadResult ? `thread:${threadResult.thread_id}` : undefined;
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    from,
+    to: target,
+    target: tmuxTarget,
+    msg: message,
+    host,
+    sid,
+    ch,
+  }) + "\n";
+  try { await mkdir(logDir, { recursive: true }); await appendFile(logFile, line); } catch (e) { console.error(`\x1b[33m⚠\x1b[0m talk-to log write failed: ${e}`); }
+
+  console.log(`\x1b[32m✓\x1b[0m thread #${threadResult?.thread_id ?? "?"} + sent → ${tmuxTarget}`);
+}

--- a/plugins/talk-to/index.ts
+++ b/plugins/talk-to/index.ts
@@ -1,0 +1,31 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdTalkTo } from "./impl";
+
+export const command = { name: "talk-to", description: "Talk to a remote agent on another node." };
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const force = args.includes("--force");
+    const filtered = args.filter(a => a !== "--force");
+    if (!filtered[0] || filtered.length < 2) throw new Error("usage: maw talk-to <agent> <message> [--force]");
+    await cmdTalkTo(filtered[0], filtered.slice(1).join(" "), force);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/talk-to/plugin.json
+++ b/plugins/talk-to/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "talk-to",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Talk to a remote agent on another node.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "talk-to",
+    "aliases": [
+      "talkto",
+      "talk"
+    ],
+    "help": "maw talk-to <agent> <message> [--force] — talk to a remote agent on another node",
+    "flags": {
+      "--force": "boolean"
+    }
+  },
+  "weight": 50
+}

--- a/plugins/view/impl.ts
+++ b/plugins/view/impl.ts
@@ -1,0 +1,376 @@
+import { listSessions } from "../../../sdk";
+import { Tmux, tmuxCmd, resolveSocket } from "../../../sdk";
+import { loadConfig } from "../../../config";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { logAnomaly } from "../../../core/fleet/audit";
+import { execFileSync } from "child_process";
+import { ttyAsk } from "./internal/prompts";
+
+/**
+ * Decide whether to offer a wake prompt on missing target. Extracted for
+ * testability — tests can stub `isTTY` and `wakeFlag` directly.
+ *
+ * #549 contract:
+ *  - --no-wake → never prompt, never wake (back-compat for scripts)
+ *  - --wake    → wake unconditionally, no prompt (force opt-in)
+ *  - non-TTY   → never prompt (CI/script safety, current behavior)
+ *  - TTY       → prompt y/N
+ */
+export type WakePromptDecision = "skip" | "force" | "ask";
+export function decideWakePrompt(opts: {
+  isTTY: boolean;
+  wake?: boolean;
+  noWake?: boolean;
+}): WakePromptDecision {
+  if (opts.noWake) return "skip";
+  if (opts.wake) return "force";
+  if (!opts.isTTY) return "skip";
+  return "ask";
+}
+
+export interface ViewOpts {
+  windowHint?: string;
+  clean?: boolean;
+  kill?: boolean;
+  splitAnchor?: string | true;
+  wake?: boolean;
+  noWake?: boolean;
+  /** Test seam: ask user yes/no. Default = ttyAsk via /dev/tty. */
+  ask?: (question: string) => Promise<string>;
+  /** Test seam: stand-in for cmdWake. Default = real cmdWake. */
+  wakeImpl?: (target: string) => Promise<void>;
+}
+
+export async function cmdView(
+  agent: string,
+  windowHintOrOpts?: string | ViewOpts,
+  clean = false,
+  kill = false,
+  splitAnchor?: string | true,
+  extraOpts: Pick<ViewOpts, "wake" | "noWake" | "ask" | "wakeImpl"> = {},
+) {
+  // Backward-compatible signature: callers pass either a windowHint string
+  // OR a full ViewOpts object as the second arg.
+  let windowHint: string | undefined;
+  if (typeof windowHintOrOpts === "object" && windowHintOrOpts !== null) {
+    windowHint = windowHintOrOpts.windowHint;
+    clean = windowHintOrOpts.clean ?? clean;
+    kill = windowHintOrOpts.kill ?? kill;
+    splitAnchor = windowHintOrOpts.splitAnchor ?? splitAnchor;
+    extraOpts = {
+      wake: windowHintOrOpts.wake,
+      noWake: windowHintOrOpts.noWake,
+      ask: windowHintOrOpts.ask,
+      wakeImpl: windowHintOrOpts.wakeImpl,
+    };
+  } else {
+    windowHint = windowHintOrOpts;
+  }
+  // Find the session
+  const sessions = await listSessions();
+  const allWindows = sessions.flatMap(s => s.windows.map(w => ({ session: s.name, ...w })));
+
+  // Historic cruft filter for *-view-view sessions created pre-#358.
+  // #358 (src/core/fleet/validate.ts) rejects the `-view` suffix at every
+  // user-input creation boundary, so new ones can't be made — but *-view-view
+  // sessions from earlier alphas still exist on some nodes. Dropping this
+  // filter before a fleet-wide sweep re-introduces the alpha.30 ambiguity
+  // (confirmed by team-lead on 2026-04-15). Safe to remove after sweep.
+  const candidateSessions = sessions.filter(s => !/-view-view$/.test(s.name));
+
+  // Resolve agent → session via canonical matcher (exact > fuzzy > ambiguous > none).
+  // Fallback: if no name match, check whether a window name contains the agent
+  // (e.g. `maw view foo` hits a window named "foo-work" inside an unrelated session).
+  const resolved = resolveSessionTarget(agent, candidateSessions);
+  let sessionName: string | null = null;
+  if (resolved.kind === "exact" || resolved.kind === "fuzzy") {
+    sessionName = resolved.match.name;
+  } else if (resolved.kind === "ambiguous") {
+    console.error(`  \x1b[31m✗\x1b[0m '${agent}' is ambiguous — matches ${resolved.candidates.length} sessions:`);
+    for (const s of resolved.candidates) {
+      console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+    }
+    console.error(`  \x1b[90m  use the full name: maw view <exact-session>\x1b[0m`);
+    throw new Error(`'${agent}' is ambiguous — matches ${resolved.candidates.length} sessions`);
+  } else {
+    const agentLower = agent.toLowerCase();
+    const byWindow = candidateSessions.find(s => s.windows.some(w => w.name.toLowerCase().includes(agentLower)));
+    if (byWindow) sessionName = byWindow.name;
+  }
+  if (!sessionName) {
+    // #549 — offer to wake the missing target before erroring out.
+    // Decision matrix encoded in decideWakePrompt; see WakePromptDecision.
+    //
+    // Fleet-known oracles skip the y/N prompt — if the user typed `maw a <x>`
+    // and fleet configs pin <x>, we're confident this isn't a typo. Typos
+    // (unknown names) still hit the prompt as a guard against accidental wake.
+    //
+    // #835 — the fleet-known decision is now delegated to the unified
+    // shouldAutoWake() helper. View's policy: --wake force / --no-wake skip /
+    // fleet-known silent wake / unknown ⇒ caller ask via decideWakePrompt.
+    let autoWake = extraOpts.wake;
+    if (!autoWake && !extraOpts.noWake) {
+      try {
+        const { resolveFleetSession } = await import("../../shared/wake-resolve");
+        const { shouldAutoWake } = await import("../../shared/should-auto-wake");
+        const isFleetKnown = Boolean(resolveFleetSession(agent));
+        const decision = shouldAutoWake(agent, {
+          site: "view",
+          isLive: false, // we already know sessionName is null
+          isFleetKnown,
+        });
+        if (decision.wake) {
+          console.log(`\x1b[36m⚡\x1b[0m '${agent}' is fleet-known — auto-wake`);
+          autoWake = true;
+        }
+      } catch { /* fleet check best-effort — fall through to prompt */ }
+    }
+    const decision = decideWakePrompt({
+      isTTY: Boolean(process.stdin.isTTY),
+      wake: autoWake,
+      noWake: extraOpts.noWake,
+    });
+
+    if (decision !== "skip") {
+      let proceed = decision === "force";
+      if (decision === "ask") {
+        const ask = extraOpts.ask ?? ttyAsk;
+        try {
+          const answer = (await ask(
+            `\x1b[36m?\x1b[0m Oracle '${agent}' is not running. Wake it now? [y/N]`,
+          )).trim().toLowerCase();
+          proceed = answer === "y" || answer === "yes";
+        } catch (e) {
+          // /dev/tty unavailable — fall through to the existing error.
+          proceed = false;
+        }
+      }
+
+      if (proceed) {
+        const wakeImpl =
+          extraOpts.wakeImpl ??
+          (async (target: string) => {
+            const { cmdWake } = await import("../../shared/wake-cmd");
+            await cmdWake(target, { attach: true });
+          });
+        console.log(`\x1b[36m⚡\x1b[0m waking '${agent}'...`);
+        await wakeImpl(agent);
+        // cmdWake({ attach: true }) handles the attach itself, so we're done.
+        return;
+      }
+    }
+
+    if (resolved.kind === "none" && resolved.hints?.length) {
+      console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+      for (const h of resolved.hints) {
+        console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+      }
+    }
+    console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+    throw new Error(`session not found for: ${agent}`);
+  }
+
+  const t = new Tmux();
+  // #713: with bind/host split, config.host is never a bind address (0.0.0.0 etc.)
+  const host = process.env.MAW_HOST || loadConfig().host || "local";
+  const isLocal = host === "local" || host === "localhost";
+  const socket = resolveSocket();
+
+  // If the resolved session is already a view, attach directly — skip the
+  // grouped-session dance that would otherwise create X-view-view.
+  if (sessionName.endsWith("-view")) {
+    // Resolved to an existing view — attach directly (don't create -view-view stutter)
+    if (agent.endsWith("-view")) {
+      // User typed the literal view name (re-attach reflex). Log it.
+      logAnomaly("view-attach-via-view-name", {
+        input: { agent, windowHint, clean },
+        context: { resolvedSession: sessionName, action: "attach-existing-view" },
+      });
+      console.warn(`\x1b[90m  note: '${agent}' is a view session — attaching to existing view (no new session created)\x1b[0m`);
+    }
+    if (windowHint) {
+      const win = allWindows.find(w =>
+        w.session === sessionName && (
+          w.name === windowHint ||
+          w.name.includes(windowHint) ||
+          String(w.index) === windowHint
+        )
+      );
+      if (win) {
+        await t.selectWindow(`${sessionName}:${win.index}`);
+        console.log(`\x1b[36mwindow\x1b[0m  → ${win.name} (${win.index})`);
+      } else {
+        console.error(`\x1b[33mwarn\x1b[0m: window '${windowHint}' not found, using default`);
+      }
+    }
+    if (clean) {
+      await t.set(sessionName, "status", "off");
+    }
+    if (splitAnchor !== undefined) {
+      const { cmdSplit } = await import("./internal/split-impl");
+      const anchorPane = typeof splitAnchor === "string"
+        ? await resolveAnchorPane(splitAnchor)
+        : undefined;
+      await cmdSplit(sessionName, { anchorPane });
+      return;
+    }
+    console.log(`\x1b[36mattach\x1b[0m  → ${sessionName}${clean ? " (clean)" : ""}`);
+    if (isLocal && process.env.TMUX) {
+      await t.switchClient(sessionName);
+      console.log(
+        `\x1b[90mhint\x1b[0m    → detach with prefix+d, then \`tmux kill-session -t ${sessionName}\` when done`,
+      );
+      return;
+    }
+    try {
+      attachViaTmux({ isLocal, socket, host, target: sessionName });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`\x1b[33mwarn\x1b[0m: attach exited non-zero — ${msg}`);
+    }
+    // We did NOT create this session, so we do NOT kill it on cleanup.
+    return;
+  }
+
+  // Generate view name from RESOLVED session (not raw input) — prevents duplicates
+  // e.g. "maw a worm" and "maw a wormhole" both resolve to "102-white-wormhole"
+  // and should reuse the same view session instead of creating worm-view + wormhole-view
+  const viewBase = sessionName.replace(/^\d+-/, "");
+  const viewName = `${viewBase}-view${windowHint ? `-${windowHint}` : ""}`;
+
+  // Reuse existing view if present — killing it would evict anyone else
+  // already attached (e.g. a second terminal on the same view).
+  const viewExists = await t.hasSession(viewName);
+  if (!viewExists) {
+    await t.newGroupedSession(sessionName, viewName, { windowSize: "largest" });
+    console.log(`\x1b[36mcreated\x1b[0m → ${viewName} (grouped with ${sessionName})`);
+  } else {
+    console.log(`\x1b[36mreuse\x1b[0m   → ${viewName} (existing grouped session — ${sessionName})`);
+  }
+
+  // Select specific window if requested
+  if (windowHint) {
+    const win = allWindows.find(w =>
+      w.session === sessionName && (
+        w.name === windowHint ||
+        w.name.includes(windowHint) ||
+        String(w.index) === windowHint
+      )
+    );
+    if (win) {
+      await t.selectWindow(`${viewName}:${win.index}`);
+      console.log(`\x1b[36mwindow\x1b[0m  → ${win.name} (${win.index})`);
+    } else {
+      console.error(`\x1b[33mwarn\x1b[0m: window '${windowHint}' not found, using default`);
+    }
+  }
+
+  // Hide status bar if --clean
+  if (clean) {
+    await t.set(viewName, "status", "off");
+  }
+
+  // --split[=<anchor>]: open the view in a new tmux pane instead of
+  // detaching+attaching the whole client. Explicit anchor breaks the
+  // active-pane-drift that caused the fractal-split cascade (#545/#546).
+  if (splitAnchor !== undefined) {
+    const { cmdSplit } = await import("./internal/split-impl");
+    const anchorPane = typeof splitAnchor === "string"
+      ? await resolveAnchorPane(splitAnchor)
+      : undefined;
+    await cmdSplit(viewName, { anchorPane });
+    return;
+  }
+
+  // Attach interactively
+  console.log(`\x1b[36mattach\x1b[0m  → ${viewName}${clean ? " (clean)" : ""}`);
+
+  // Already inside tmux? switch-client is the only option — nested
+  // `attach-session` would fail with "sessions should be nested with care".
+  // Fire-and-forget: we can't block until the user detaches, so we skip the
+  // automatic kill-session cleanup and print a hint instead.
+  if (isLocal && process.env.TMUX) {
+    await t.switchClient(viewName);
+    console.log(
+      `\x1b[90mhint\x1b[0m    → detach with prefix+d, then \`tmux kill-session -t ${viewName}\` when done`,
+    );
+    return;
+  }
+
+  // Use execFileSync (not Bun.spawn) for the blocking attach — Bun.spawn with
+  // stdin:"inherit" has TTY handoff issues that can propagate SIGHUP up to
+  // the parent SSH session when tmux detaches, closing the whole terminal.
+  // execFileSync + stdio:"inherit" matches the proven pattern in wake.ts
+  // (attachToSession helper, e07b7e9). argv form avoids local shell
+  // interpretation of session names (js/indirect-command-line-injection, #474).
+  try {
+    attachViaTmux({ isLocal, socket, host, target: viewName });
+  } catch (err) {
+    // tmux exits non-zero when attach fails (session gone, socket missing,
+    // etc). Log but do NOT re-throw — a failed attach should not cascade
+    // into process.exit(1) that might take the SSH session with it.
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`\x1b[33mwarn\x1b[0m: attach exited non-zero — ${msg}`);
+  }
+
+  // #420: no auto-cleanup on detach. The view is grouped (shares state with
+  // the oracle session), so keeping it idle is cheap — and killing it here
+  // forces the next `maw a <agent>` to pay the create cost again. Stale
+  // views are reaped by `maw cleanup --zombie-agents` (#400/#418) or by
+  // explicit `--kill` on this command.
+  if (kill) {
+    await t.killSession(viewName);
+    console.log(`\x1b[90mcleaned\x1b[0m → ${viewName}`);
+  }
+}
+
+/**
+ * Resolve a `--split=<anchor>` argument to a tmux pane selector for cmdSplit.
+ *   - "session:window"  → passed through (tmux resolves to that window's active pane)
+ *   - bare name         → find <name>-view; auto-bootstrap via newGroupedSession
+ *                         if it doesn't exist yet; return "<name>-view:0"
+ */
+async function resolveAnchorPane(anchor: string): Promise<string> {
+  if (anchor.includes(":")) return anchor;
+  const t = new Tmux();
+  const viewName = `${anchor.replace(/-view$/, "")}-view`;
+  if (!(await t.hasSession(viewName))) {
+    const sessions = await listSessions();
+    const candidates = sessions.filter(
+      s => !/-view$/.test(s.name) && !/-view-view$/.test(s.name),
+    );
+    const r = resolveSessionTarget(anchor, candidates);
+    if (r.kind !== "exact" && r.kind !== "fuzzy") {
+      throw new Error(`--split=${anchor}: no matching session or existing view`);
+    }
+    await t.newGroupedSession(r.match.name, viewName, { windowSize: "largest" });
+  }
+  return `${viewName}:0`;
+}
+
+// Reject tmux session names that contain anything a remote shell could parse.
+// Tmux itself accepts only a restricted set, and our fleet validators
+// (src/core/fleet/validate.ts) tighten that further — but defense in depth
+// protects the ssh branch, where the remote command is shell-interpreted.
+const SAFE_SESSION_NAME = /^[A-Za-z0-9._-]+$/;
+
+function attachViaTmux(opts: {
+  isLocal: boolean;
+  socket: string | undefined;
+  host: string;
+  target: string;
+}): void {
+  const { isLocal, socket, host, target } = opts;
+  if (isLocal) {
+    const args = socket
+      ? ["-S", socket, "attach-session", "-t", target]
+      : ["attach-session", "-t", target];
+    execFileSync("tmux", args, { stdio: "inherit" });
+    return;
+  }
+  if (!SAFE_SESSION_NAME.test(target)) {
+    throw new Error(`refusing ssh attach: unsafe session name '${target}'`);
+  }
+  const remoteCmd = `${tmuxCmd()} attach-session -t '${target}'`;
+  execFileSync("ssh", ["-tt", host, remoteCmd], { stdio: "inherit" });
+}

--- a/plugins/view/index.ts
+++ b/plugins/view/index.ts
@@ -1,0 +1,65 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+
+export const command = {
+  name: "view",
+  description: "Create or attach to an agent's tmux view.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const { cmdView } = await import("./impl");
+
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const rawArgs = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    // --split accepts both a bare form (`--split`, caller's active pane) and
+    // a valued form (`--split=<anchor>`, anchor at another oracle's view).
+    // Scan explicitly — the handler below uses includes()/filter() rather
+    // than an arg parser, and the valued form needs an extra pass anyway.
+    let splitAnchor: string | true | undefined = undefined;
+    const scanned: string[] = [];
+    for (const a of rawArgs) {
+      const m = /^--split=(.+)$/.exec(a);
+      if (m) {
+        splitAnchor = m[1]!;
+      } else if (a === "--split") {
+        splitAnchor = true;
+      } else {
+        scanned.push(a);
+      }
+    }
+
+    if (!scanned[0]) {
+      return {
+        ok: false,
+        error: "usage: maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]]",
+      };
+    }
+
+    const clean = scanned.includes("--clean");
+    const kill = scanned.includes("--kill");
+    const wake = scanned.includes("--wake");
+    const noWake = scanned.includes("--no-wake");
+    const filtered = scanned.filter(
+      a => a !== "--clean" && a !== "--kill" && a !== "--wake" && a !== "--no-wake",
+    );
+    await cmdView(filtered[0], filtered[1], clean, kill, splitAnchor, { wake, noWake });
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/view/internal/prompts.ts
+++ b/plugins/view/internal/prompts.ts
@@ -1,0 +1,146 @@
+import { createInterface } from "readline";
+import { createReadStream, openSync } from "fs";
+
+export type AskFn = (question: string, defaultVal?: string) => Promise<string>;
+
+export async function ttyAsk(question: string, defaultVal = ""): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const prompt = defaultVal ? `${question} [${defaultVal}]: ` : `${question}: `;
+    let fd: number;
+    try {
+      fd = openSync("/dev/tty", "r+");
+    } catch (e) {
+      reject(new Error("/dev/tty unavailable — use --non-interactive"));
+      return;
+    }
+    const rl = createInterface({
+      input: createReadStream("/dev/tty", { fd }),
+      output: process.stdout,
+      terminal: true,
+    });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim() || defaultVal);
+    });
+  });
+}
+
+const NODE_NAME_RE = /^[a-z0-9][a-z0-9-]{0,62}$/i;
+const PEER_NAME_RE = /^[a-z0-9][a-z0-9-]{0,30}$/i;
+
+export function validateNodeName(name: string): string | null {
+  if (!NODE_NAME_RE.test(name)) {
+    return "Node name must be 1-63 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+/**
+ * @deprecated (#680) — `ghqRoot` is no longer asked at init. Retained only so
+ * third-party callers that imported this validator keep compiling. The init
+ * flow resolves ghq root on demand via `getGhqRoot()`.
+ */
+export function validateGhqRoot(input: string, homedir: string): { ok: true; path: string } | { ok: false; err: string } {
+  if (!input) return { ok: false, err: "Path must be absolute" };
+  if (!input.startsWith("/") && !input.startsWith("~")) {
+    return { ok: false, err: "Path must be absolute (start with / or ~)" };
+  }
+  const expanded = input.startsWith("~") ? input.replace(/^~/, homedir) : input;
+  return { ok: true, path: expanded };
+}
+
+export function validatePeerUrl(url: string): string | null {
+  if (!url) return "URL required";
+  if (!/^https?:\/\//.test(url)) return "URL must start with http:// or https://";
+  try {
+    new URL(url);
+    return null;
+  } catch {
+    return `Invalid URL: ${url}`;
+  }
+}
+
+export function validatePeerName(name: string): string | null {
+  if (!PEER_NAME_RE.test(name)) {
+    return "Name must be 1-31 chars, letters/digits/hyphens only";
+  }
+  return null;
+}
+
+export interface PromptAnswers {
+  node: string;
+  token: string;
+  federate: boolean;
+  peers: { name: string; url: string }[];
+}
+
+const MAX_ATTEMPTS = 3;
+
+async function askUntilValid(
+  ask: AskFn,
+  question: string,
+  defaultVal: string,
+  validate: (v: string) => string | null,
+  writer: (msg: string) => void,
+): Promise<string> {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const answer = await ask(question, defaultVal);
+    const err = validate(answer);
+    if (!err) return answer;
+    writer(`  \x1b[31m✗\x1b[0m ${err}`);
+    if (attempt === MAX_ATTEMPTS) {
+      throw new Error(`Aborted after ${MAX_ATTEMPTS} invalid attempts: ${question}`);
+    }
+  }
+  throw new Error("unreachable");
+}
+
+export async function runPromptLoop(
+  ask: AskFn,
+  defaults: { node: string },
+  homedir: string,
+  writer: (msg: string) => void,
+): Promise<PromptAnswers> {
+  // #680 — ghq root is no longer prompted; it's resolved on demand via `ghq root`.
+  void homedir; // kept in signature for backward-compat (callers still pass it)
+  const node = await askUntilValid(
+    ask,
+    "Node name (this machine's identity in the federation)",
+    defaults.node,
+    validateNodeName,
+    writer,
+  );
+
+  const token = await ask("Claude token (blank = use $CLAUDE_CODE_OAUTH_TOKEN or ~/.claude/credentials)", "");
+  if (!token && !process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    writer(`  \x1b[33m!\x1b[0m no token provided and $CLAUDE_CODE_OAUTH_TOKEN not set — set it before running 'maw wake'`);
+  }
+
+  const federateAnswer = (await ask("Federate with other machines? (y/N)", "N")).toLowerCase();
+  const federate = federateAnswer === "y" || federateAnswer === "yes";
+
+  const peers: { name: string; url: string }[] = [];
+  if (federate) {
+    let idx = 1;
+    while (true) {
+      const url = await ask(`Peer ${idx} URL`, "done");
+      if (!url || url === "done") break;
+      const urlErr = validatePeerUrl(url);
+      if (urlErr) {
+        writer(`  \x1b[31m✗\x1b[0m ${urlErr}`);
+        continue;
+      }
+      const name = await askUntilValid(
+        ask,
+        `Peer ${idx} name (short label)`,
+        `peer-${idx}`,
+        validatePeerName,
+        writer,
+      );
+      peers.push({ name, url });
+      idx++;
+    }
+  }
+
+  return { node, token, federate, peers };
+}

--- a/plugins/view/internal/split-impl.ts
+++ b/plugins/view/internal/split-impl.ts
@@ -1,0 +1,133 @@
+import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
+import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
+import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+
+export interface SplitOpts {
+  /** Split percentage (1-99). Default: 50. */
+  pct?: number;
+  /** Split vertical (top/bottom) instead of horizontal (side-by-side). */
+  vertical?: boolean;
+  /** Split without attaching — leaves a plain shell in the new pane. */
+  noAttach?: boolean;
+  /** Serialize via the pane-creation lock + settle. Opt-in — only matters
+   *  when another in-process caller may be spawning concurrently. */
+  lock?: boolean;
+  /** Settle delay after split when lock=true. Default: 200ms. */
+  settleMs?: number;
+  /** Pane-id / selector to split beside instead of $TMUX_PANE. Break the
+   *  implicit active-pane-drift that caused fractal-split cascade (#545).
+   *  Accepts: "%N" (pane id), "session:window.pane", or "session:window". */
+  anchorPane?: string;
+}
+
+/**
+ * maw split <target> [--pct N] [--vertical] [--no-attach]
+ *
+ * Split the current tmux pane and attach to a target session in the new pane.
+ *
+ * Target resolution:
+ *   - "session:window"  → used as-is
+ *   - "session"         → resolved to session:window[0]
+ *   - bare oracle name  → finds session ending with "-<name>" or name === <name>
+ *
+ * Why this exists: `/bud --split` inlined this pattern, but (a) the nested
+ * `tmux attach-session` silently fails when $TMUX is set, and (b) the logic
+ * is useful beyond bud (worktree, pair-ops, debugging). Extracted here as
+ * one canonical helper — future skills call `maw split` instead of duplicating
+ * the tmux shell-out.
+ */
+export async function cmdSplit(target: string, opts: SplitOpts = {}) {
+  // Canonicalize first — drop trailing `/`, `/.git`, `/.git/` tab-completion artifacts.
+  // Safe for "session:window" form: nothing to strip unless the user adds a literal slash.
+  target = normalizeTarget(target);
+  if (!process.env.TMUX) {
+    throw new Error("maw split requires an active tmux session");
+  }
+
+  if (!target) {
+    console.error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+    console.error("  e.g. maw split yeast");
+    console.error("       maw split mawjs-view --pct 30 --vertical");
+    throw new Error("usage: maw split <target> [--pct N] [--vertical] [--no-attach]");
+  }
+
+  // Validate pct early so bad input never reaches tmux
+  const pct = opts.pct ?? 50;
+  if (!Number.isFinite(pct) || pct < 1 || pct > 99) {
+    throw new Error(`--pct must be 1-99 (got ${pct})`);
+  }
+
+  // Resolve target to session:window if bare name given. Resolution rules
+  // (exact > suffix/prefix fuzzy > ambiguous > none) live in the canonical
+  // matcher — silent wrong-answer is worse than a loud failure.
+  let resolved = target;
+  if (!target.includes(":")) {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) {
+        console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      console.error(`  \x1b[90m  use the full name: maw split <exact-session>\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous`);
+    }
+    if (r.kind === "none") {
+      console.error(`  \x1b[31m✗\x1b[0m session '${target}' not found in fleet`);
+      if (r.hints?.length) {
+        console.error(`  \x1b[90mdid you mean:\x1b[0m`);
+        for (const h of r.hints) {
+          console.error(`  \x1b[90m    • ${h.name}\x1b[0m`);
+        }
+      }
+      console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      throw new Error(`session '${target}' not found in fleet`);
+    }
+
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  // Build tmux split-window command.
+  //
+  // Critical: unset $TMUX in the spawned shell so the inner attach-session
+  // can nest into the target. Without `TMUX=`, tmux refuses nested attach
+  // and the new pane dies immediately (this is the #bud --split silent-fail bug).
+  //
+  // Target the caller's pane (#365 cascade fix): without -t, tmux splits
+  // the currently-active pane — which shifts after the first split, causing
+  // the second `maw bud <name> --split` from the same parent to silently
+  // split the wrong pane (or noop visually). Explicit -t $TMUX_PANE anchors
+  // every split to the caller's origin pane, so buds cascade instead of drifting.
+  // Fallback: if TMUX_PANE isn't set (shouldn't happen — we checked $TMUX above,
+  // and any pane inside tmux has TMUX_PANE set — but defend anyway), omit -t
+  // and accept the pre-fix behavior.
+  // Precedence: opts.anchorPane (explicit, from cmdView) > $TMUX_PANE (caller's
+  // pane) > none. Explicit anchor breaks the active-pane-drift that caused
+  // fractal-split cascade in #545/#546.
+  const direction = opts.vertical ? "-v" : "-h";
+  const innerCmd = opts.noAttach ? "bash" : `TMUX= tmux attach-session -t ${resolved}`;
+  const anchor = opts.anchorPane ?? process.env.TMUX_PANE;
+  const targetFlag = anchor ? `-t '${anchor.replace(/'/g, "'\\''")}' ` : "";
+  const cmd = `tmux split-window ${targetFlag}${direction} -l ${pct}% "${innerCmd}"`;
+
+  try {
+    if (opts.lock) {
+      // Serialize against other in-process pane spawns; settle before release
+      // so tmux has a tick to register the new pane index.
+      const settleMs = opts.settleMs ?? 200;
+      await withPaneLock(async () => {
+        await hostExec(cmd);
+        if (settleMs > 0) await new Promise((r) => setTimeout(r, settleMs));
+      });
+    } else {
+      await hostExec(cmd);
+    }
+    const side = opts.vertical ? "below" : "beside";
+    const action = opts.noAttach ? "empty pane" : resolved;
+    const anchorLabel = opts.anchorPane ? ` (anchored at ${opts.anchorPane})` : "";
+    console.log(`  \x1b[32m✓\x1b[0m split ${side} — ${action} (${pct}%)${anchorLabel}`);
+  } catch (e: any) {
+    throw new Error(`split failed: ${e.message || e}`);
+  }
+}

--- a/plugins/view/plugin.json
+++ b/plugins/view/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "view",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Create or attach to an agent's tmux view.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "view",
+    "aliases": [
+      "create-view",
+      "attach",
+      "a"
+    ],
+    "help": "maw view <agent> [window] [--clean] [--kill] [--split[=<anchor>]] [--wake|--no-wake] — create or attach to an agent's tmux view. --split splits the caller's active pane; --split=<anchor> splits the pane hosting <anchor>'s view (auto-creates if missing). On missing target in a TTY, prompts y/N to wake; --wake skips the prompt and wakes; --no-wake skips the prompt and errors as before.",
+    "flags": {
+      "--clean": "boolean",
+      "--kill": "boolean",
+      "--split": "string",
+      "--wake": "boolean",
+      "--no-wake": "boolean"
+    }
+  },
+  "weight": 10
+}

--- a/plugins/whoami/impl.ts
+++ b/plugins/whoami/impl.ts
@@ -1,0 +1,15 @@
+import { hostExec } from "../../../sdk";
+import { UserError } from "../../../core/util/user-error";
+
+/**
+ * maw whoami — print the current tmux session name on stdout.
+ * Replaces scattered raw `tmux display-message -p '#S'` calls with one
+ * canonical, testable command.
+ */
+export async function cmdWhoami() {
+  if (!process.env.TMUX) {
+    throw new UserError("maw whoami requires an active tmux session — run 'maw wake <oracle>' or attach to tmux first");
+  }
+  const raw = await hostExec(`tmux display-message -p '#S'`);
+  console.log(raw.trim());
+}

--- a/plugins/whoami/index.ts
+++ b/plugins/whoami/index.ts
@@ -1,0 +1,25 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdWhoami } from "./impl";
+
+export const command = { name: "whoami", description: "Print the current tmux session name." };
+
+export default async function handler(_ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log, origError = console.error;
+  console.log = (...a: any[]) => {
+    if (_ctx.writer) _ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (_ctx.writer) _ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    await cmdWhoami();
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog; console.error = origError;
+  }
+}

--- a/plugins/whoami/plugin.json
+++ b/plugins/whoami/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "whoami",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Print the current tmux session name (closes raw `tmux display-message -p '#S'` sweep).",
+  "cli": {
+    "command": "whoami",
+    "help": "maw whoami — print the current tmux session name"
+  },
+  "weight": 10
+}

--- a/plugins/workon/impl.ts
+++ b/plugins/workon/impl.ts
@@ -1,0 +1,80 @@
+import { hostExec } from "../../../sdk";
+import { tmux } from "../../../sdk";
+import { ghqFind } from "../../../core/ghq";
+import { buildCommand } from "../../../config";
+import { findWorktrees } from "../../shared/wake";
+import { resolveWorktreeTarget } from "../../../core/matcher/resolve-target";
+
+async function resolveRepo(repo: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
+  // Support "org/repo" or bare "repo" — always search by last segment
+  const searchTerm = repo.includes("/") ? repo.split("/").pop()! : repo;
+  const repoPath = await ghqFind(`/${searchTerm}$`);
+  if (!repoPath) {
+    throw new Error(`repo not found: ${repo}`);
+  }
+  const repoName = repoPath.split("/").pop()!;
+  const parentDir = repoPath.replace(/\/[^/]+$/, "");
+  return { repoPath, repoName, parentDir };
+}
+
+export async function cmdWorkon(repo: string, task?: string): Promise<void> {
+  const { repoPath, repoName, parentDir } = await resolveRepo(repo);
+
+  let targetPath = repoPath;
+  let windowName = repoName;
+
+  if (task) {
+    const worktrees = await findWorktrees(parentDir, repoName);
+    const resolved = resolveWorktreeTarget(task, worktrees);
+    let match: { path: string; name: string } | null = null;
+    switch (resolved.kind) {
+      case "exact":
+      case "fuzzy":
+        match = resolved.match;
+        break;
+      case "ambiguous":
+        console.error(`\x1b[31m✗\x1b[0m '${task}' is ambiguous — matches ${resolved.candidates.length} worktrees:`);
+        for (const c of resolved.candidates) {
+          console.error(`\x1b[90m    • ${c.name}\x1b[0m`);
+        }
+        console.error(`\x1b[90m  use the full name: maw workon ${repo} <exact-worktree>\x1b[0m`);
+        throw new Error(`'${task}' is ambiguous — matches ${resolved.candidates.length} worktrees`);
+      case "none":
+        match = null;
+        break;
+    }
+
+    if (match) {
+      console.log(`\x1b[33m⚡\x1b[0m reusing worktree: ${match.path}`);
+      targetPath = match.path;
+    } else {
+      const nums = worktrees.map(w => parseInt(w.name) || 0);
+      const nextNum = nums.length > 0 ? Math.max(...nums) + 1 : 1;
+      const wtName = `${nextNum}-${task}`;
+      const wtPath = `${parentDir}/${repoName}.wt-${wtName}`;
+      const branch = `agents/${wtName}`;
+
+      try { await hostExec(`git -C '${repoPath}' branch -D '${branch}' 2>/dev/null`); } catch { /* expected: branch may not exist */ }
+      await hostExec(`git -C '${repoPath}' worktree add '${wtPath}' -b '${branch}'`);
+      console.log(`\x1b[32m+\x1b[0m worktree: ${wtPath} (${branch})`);
+      targetPath = wtPath;
+    }
+    windowName = `${repoName}-${task}`;
+  }
+
+  // Detect current tmux session
+  if (!process.env.TMUX) {
+    throw new Error("not in a tmux session — run inside tmux");
+  }
+  const session = (await hostExec("tmux display-message -p '#{session_name}'").catch(() => "")).trim();
+  if (!session) {
+    throw new Error("could not detect current tmux session");
+  }
+
+  // Create window + start claude
+  await tmux.newWindow(session, windowName, { cwd: targetPath });
+  await new Promise(r => setTimeout(r, 300));
+  await tmux.sendText(`${session}:${windowName}`, buildCommand(windowName));
+
+  console.log(`\x1b[32m✅\x1b[0m workon '${windowName}' in ${session} → ${targetPath}`);
+}

--- a/plugins/workon/index.ts
+++ b/plugins/workon/index.ts
@@ -1,0 +1,34 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdWorkon } from "./impl";
+
+export const command = {
+  name: "workon",
+  description: "Start working on a repo with optional task context.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    if (!args[0]) {
+      throw new Error("usage: maw workon <repo> [task]");
+    }
+    await cmdWorkon(args[0], args[1]);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/workon/plugin.json
+++ b/plugins/workon/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "workon",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Start working on a repo with optional task context.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "workon",
+    "aliases": [
+      "work"
+    ],
+    "help": "maw workon <repo> [task]"
+  },
+  "weight": 50
+}

--- a/plugins/workspace/index.ts
+++ b/plugins/workspace/index.ts
@@ -1,0 +1,112 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { parseFlags } from "../../../cli/parse-args";
+import { cmdWorkspaceCreate, cmdWorkspaceJoin, cmdWorkspaceShare, cmdWorkspaceUnshare, cmdWorkspaceLs, cmdWorkspaceAgents, cmdWorkspaceInvite, cmdWorkspaceLeave, cmdWorkspaceStatus } from "../../shared/workspace";
+
+export const command = {
+  name: ["workspace", "ws"],
+  description: "Multi-node workspace management.",
+};
+
+// ---------------------------------------------------------------------------
+// Pure parsing helpers — exported for golden-master tests
+// ---------------------------------------------------------------------------
+
+/** Parse args for `workspace create <name> [--hub <url>]` */
+export function _parseCreate(args: string[]): { name: string | undefined; hub: string | undefined } {
+  const flags = parseFlags(args.slice(1), { "--hub": String }, 0);
+  return { name: flags._[0] || undefined, hub: flags["--hub"] };
+}
+
+/** Parse args for `workspace join <code> [--hub <url>]` */
+export function _parseJoin(args: string[]): { code: string | undefined; hub: string | undefined } {
+  const flags = parseFlags(args.slice(1), { "--hub": String }, 0);
+  return { code: flags._[0] || undefined, hub: flags["--hub"] };
+}
+
+/** Parse args for `workspace share/unshare [--workspace <id>] [--ws <id>] <agent...>` */
+export function _parseShareAgents(args: string[]): { wsId: string | undefined; agents: string[] } {
+  const flags = parseFlags(args.slice(1), {
+    "--workspace": String,
+    "--ws": "--workspace",
+  }, 0);
+  return { wsId: flags["--workspace"], agents: flags._ };
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const sub = args[0]?.toLowerCase();
+
+    if (sub === "create") {
+      const { name, hub } = _parseCreate(args);
+      if (!name) {
+        logs.push("usage: maw workspace create <name> [--hub <url>]");
+        return { ok: false, error: "name required", output: logs.join("\n") };
+      }
+      await cmdWorkspaceCreate(name, hub);
+    } else if (sub === "join") {
+      const { code, hub } = _parseJoin(args);
+      if (!code) {
+        logs.push("usage: maw workspace join <code> [--hub <url>]");
+        return { ok: false, error: "code required", output: logs.join("\n") };
+      }
+      await cmdWorkspaceJoin(code, hub);
+    } else if (sub === "share") {
+      const { wsId, agents } = _parseShareAgents(args);
+      if (agents.length === 0) {
+        logs.push("usage: maw workspace share <agent...> [--workspace <id>]");
+        return { ok: false, error: "agent required", output: logs.join("\n") };
+      }
+      await cmdWorkspaceShare(agents, wsId);
+    } else if (sub === "unshare") {
+      const { wsId, agents } = _parseShareAgents(args);
+      if (agents.length === 0) {
+        logs.push("usage: maw workspace unshare <agent...> [--workspace <id>]");
+        return { ok: false, error: "agent required", output: logs.join("\n") };
+      }
+      await cmdWorkspaceUnshare(agents, wsId);
+    } else if (sub === "ls" || sub === "list") {
+      await cmdWorkspaceLs();
+    } else if (sub === "agents") {
+      await cmdWorkspaceAgents(args[1]);
+    } else if (sub === "invite") {
+      await cmdWorkspaceInvite(args[1]);
+    } else if (sub === "leave") {
+      await cmdWorkspaceLeave(args[1]);
+    } else if (sub === "status") {
+      await cmdWorkspaceStatus();
+    } else if (!sub) {
+      await cmdWorkspaceLs();
+    } else {
+      logs.push("\x1b[36mmaw workspace\x1b[0m \u2014 Multi-node workspace management\n");
+      logs.push("  maw workspace create <name>          Create workspace on hub");
+      logs.push("  maw workspace join <code>            Join with invite code");
+      logs.push("  maw workspace share <agent...>       Share agents to workspace");
+      logs.push("  maw workspace unshare <agent...>     Remove agents from workspace");
+      logs.push("  maw workspace ls                     List joined workspaces");
+      logs.push("  maw workspace agents [workspace-id]  List all agents in workspace");
+      logs.push("  maw workspace invite [workspace-id]  Show join code");
+      logs.push("  maw workspace leave [workspace-id]   Leave workspace");
+      logs.push("  maw workspace status                 Connection status to hub(s)\n");
+      logs.push("\x1b[90mAlias: maw ws ...\x1b[0m");
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/workspace/plugin.json
+++ b/plugins/workspace/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "workspace",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Multi-node workspace management.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "workspace",
+    "aliases": [
+      "ws"
+    ],
+    "help": "maw workspace <subcommand> [args] — Multi-node workspace management"
+  },
+  "weight": 50
+}

--- a/plugins/zoom/impl.ts
+++ b/plugins/zoom/impl.ts
@@ -1,0 +1,69 @@
+import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
+import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+
+export interface ZoomOpts {
+  /** Pane index within the resolved window. Default: current/first. */
+  pane?: number;
+}
+
+/**
+ * maw zoom <target> [--pane N]
+ *
+ * Toggle zoom state of a pane (full-screen that pane within its window).
+ * Wraps `tmux resize-pane -Z` — idempotent toggle, same key-binding
+ * behavior as prefix + z in interactive tmux.
+ */
+export async function cmdZoom(target: string, opts: ZoomOpts = {}) {
+  if (!target) {
+    throw new Error("usage: maw zoom <target> [--pane N]\n  e.g. maw zoom mawjs\n       maw zoom neo:0 --pane 1");
+  }
+
+  let resolved: string;
+  if (target.includes(":")) {
+    const [rawSession, rest] = target.split(":", 2);
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(rawSession, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${rawSession}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${rawSession}' is ambiguous — matches ${r.candidates.length} sessions`);
+    }
+    if (r.kind === "none") {
+      if (r.hints && r.hints.length > 0) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      }
+      throw new Error(`session '${rawSession}' not found`);
+    }
+    resolved = `${r.match.name}:${rest}`;
+  } else {
+    const sessions = await listSessions();
+    const r = resolveSessionTarget(target, sessions);
+    if (r.kind === "ambiguous") {
+      console.error(`  \x1b[31m✗\x1b[0m '${target}' is ambiguous — matches ${r.candidates.length} sessions:`);
+      for (const s of r.candidates) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      throw new Error(`'${target}' is ambiguous — matches ${r.candidates.length} sessions`);
+    }
+    if (r.kind === "none") {
+      if (r.hints && r.hints.length > 0) {
+        console.error(`  \x1b[90m  did you mean:\x1b[0m`);
+        for (const s of r.hints) console.error(`  \x1b[90m    • ${s.name}\x1b[0m`);
+      } else {
+        console.error(`  \x1b[90m  try: maw ls\x1b[0m`);
+      }
+      throw new Error(`session '${target}' not found`);
+    }
+    resolved = `${r.match.name}:${r.match.windows[0]?.index ?? 0}`;
+  }
+
+  const paneSuffix = opts.pane !== undefined ? `.${opts.pane}` : "";
+  const full = resolved + paneSuffix;
+  const tmux = tmuxCmd();
+
+  try {
+    await hostExec(`${tmux} resize-pane -Z -t '${full}'`);
+    console.log(`  \x1b[32m✓\x1b[0m toggled zoom on ${full}`);
+  } catch (e: any) {
+    throw new Error(`zoom failed: ${e.message || e}`);
+  }
+}

--- a/plugins/zoom/index.ts
+++ b/plugins/zoom/index.ts
@@ -1,0 +1,53 @@
+import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import { cmdZoom } from "./impl";
+import { parseFlags } from "../../../cli/parse-args";
+
+export const command = {
+  name: "zoom",
+  description: "Toggle tmux pane zoom (full-screen).",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    let target: string;
+    let opts: { pane?: number } = {};
+
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(args, { "--pane": Number }, 0);
+
+      target = flags._[0];
+      if (!target || target === "--help" || target === "-h") {
+        return { ok: false, error: "usage: maw zoom <target> [--pane N]" };
+      }
+      if (target.startsWith("-")) {
+        return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw zoom <target>` };
+      }
+      opts = { pane: flags["--pane"] };
+    } else {
+      const body = ctx.args as Record<string, unknown>;
+      if (!body.target) return { ok: false, error: "target is required" };
+      target = body.target as string;
+      opts = { pane: body.pane as number | undefined };
+    }
+
+    await cmdZoom(target, opts);
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/zoom/plugin.json
+++ b/plugins/zoom/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "zoom",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Toggle tmux pane zoom (full-screen) — wraps resize-pane -Z.",
+  "cli": {
+    "command": "zoom",
+    "help": "maw zoom <target> [--pane N]",
+    "flags": {
+      "--pane": "number"
+    }
+  },
+  "api": {
+    "path": "/api/zoom",
+    "methods": [
+      "POST"
+    ]
+  },
+  "weight": 10
+}

--- a/registry.json
+++ b/registry.json
@@ -481,6 +481,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "workspace": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/workspace@v0.1.0-workspace",
+      "sha256": "a789ea64f9215a8db6b9daa499119bcedfda8e90b76a0825fd4e9338de188f2e",
+      "summary": "Multi-node workspace management.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -591,6 +591,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "pr": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/pr@v0.1.0-pr",
+      "sha256": "8fc6804d3817d13852b3c940138c887e01ca35e00a5fef3eeb7d7ec195a91eb1",
+      "summary": "View or manage pull requests.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:19:32Z",
+  "updated": "2026-04-29T02:19:51Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -436,6 +436,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:19:32Z",
+      "tier": "extra"
+    },
+    "bud": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/bud@v0.1.0-bud",
+      "sha256": "ab3dd96d44aced6968445ed9d7831ec9a92bc95c3c1ebb73627d1f24e7217fc9",
+      "summary": "Create a new oracle (bud from parent)",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:19:51Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -393,6 +393,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
+    },
+    "pair": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/pair@v0.1.0-pair",
+      "sha256": "98eb1b96a2654fa1af50d50059528c700aef6f5ad5a521dbd161d7724228cc98",
+      "summary": "Bluetooth-style federation pairing — ephemeral code handshake (#573, facet 3 of #565).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -569,6 +569,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "kill": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/kill@v0.1.0-kill",
+      "sha256": "a1f3101cd6065e1191e880707b4ee08d86ef7f4b33c2176ca5d9409153b9b3b4",
+      "summary": "Kill a tmux session, window, or pane (trusts the user — no --force).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -580,6 +580,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "capture": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/capture@v0.1.0-capture",
+      "sha256": "db636cbd88ca442492eba49c513d08614f9c96cf24aff5e7e94a54cc9c2aa874",
+      "summary": "Capture tmux pane content — visible history or full scrollback.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -426,6 +426,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:19:32Z",
       "tier": "extra"
+    },
+    "view": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/view@v0.1.0-view",
+      "sha256": "a4d46e5120ebc282576de42498397f3c850f5ac8fa642b18b47ffae690426b16",
+      "summary": "Create or attach to an agent's tmux view.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:19:32Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -470,6 +470,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "pulse": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/pulse@v0.1.0-pulse",
+      "sha256": "447a948d73de6b31b920ae7c8db049a2a4243c489f77ec642c918d07346e8b99",
+      "summary": "Task pulse — add, list, and clean up work items.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -712,6 +712,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
+    },
+    "split": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/split@v0.1.0-split",
+      "sha256": "dc5deb7166aba84a0e0754ed3abdbfc6535e9aaf5af41226880ea7906edaf8d9",
+      "summary": "Split current tmux pane and attach to a session (vesicle beside).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -547,6 +547,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "hey-test": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/hey-test@v0.1.0-hey-test",
+      "sha256": "0b325122fe0d08778dbf3fb20860ec48ad94f518b6249b25faf7e05f5e0ff960",
+      "summary": "TBD",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:49:10Z",
+  "updated": "2026-04-29T02:49:11Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -700,6 +700,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
+    },
+    "restart": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/restart@v0.1.0-restart",
+      "sha256": "7b7f84d68499518e54a37cead3a7b3f6459aa2ed5d44134690977de1973b8883",
+      "summary": "Restart the maw server with optional update.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -745,6 +745,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
+    },
+    "talk-to": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/talk-to@v0.1.0-talk-to",
+      "sha256": "786a372c425803c9f4fdd90add6cffa457a3198726023cf8521fdb84cf1459a7",
+      "summary": "Talk to a remote agent on another node.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -349,6 +349,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
+    },
+    "archive": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/archive@v0.1.0-archive",
+      "sha256": "be23b49ce385a3ca87a41a7ee28c4117ba06f6770b74796b816ed65cf91210ed",
+      "summary": "Archive an oracle's tmux session and data.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -602,6 +602,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "send": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/send@v0.1.0-send",
+      "sha256": "78aaf0f2acd056eca532b573a7f7471ee9e53e8e0c1b5ab4bd86bc73e0f72860",
+      "summary": "Type raw text into a tmux pane (no Enter, composable) — dual of send-enter (#757).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -646,6 +646,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "health": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/health@v0.1.0-health",
+      "sha256": "ceeca04da4335ef2a1062f2e0e7a64c6d3f9dfc15e9814cee5b2ae859c62bf89",
+      "summary": "System health check — tmux, maw server, disk, memory, pm2, peers.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -690,6 +690,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "send-enter": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/send-enter@v0.1.0-send-enter",
+      "sha256": "025e520fde0026421f673d1e96afc7767bea0c6b769e73f54207f9003c770e9c",
+      "summary": "Send Enter key to a maw target — manually submit pending input on stuck panes (#728).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:49:09Z",
+  "updated": "2026-04-29T02:49:10Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -623,6 +623,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
+    },
+    "take": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/take@v0.1.0-take",
+      "sha256": "937d3050ef22c67b7885e73dada20282471671442b70fcc0913a0e696bee2ab2",
+      "summary": "Move a tmux window from one oracle session to another (vesicle transport).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:18:09Z",
+  "updated": "2026-04-29T02:19:32Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -414,6 +414,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:09Z",
+      "tier": "extra"
+    },
+    "doctor": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/doctor@v0.1.0-doctor",
+      "sha256": "553360a12eb9f03c1479df5084b0ec1ce8f14078888319008fd5b8a717109d56",
+      "summary": "Diagnostic checks — verifies maw install health and auto-heals when possible (#531).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:19:32Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:19:51Z",
+  "updated": "2026-04-29T02:49:07Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -447,6 +447,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:19:51Z",
+      "tier": "extra"
+    },
+    "on": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/on@v0.1.0-on",
+      "sha256": "bab28c6b1a20b590016b7f7cf04d062111469da603d803deffde4303ee4c3e70",
+      "summary": "Create event triggers for oracle lifecycle events.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:07Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T01:40:28Z",
+  "updated": "2026-04-29T02:18:08Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -337,6 +337,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:40:28Z",
+      "tier": "extra"
+    },
+    "about": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/about@v0.1.0-about",
+      "sha256": "e8f754f83d37574360356b0b4ec6b21a8a6f11a055b03d4534cebb11e5f2cd5a",
+      "summary": "Show information about an oracle (session, repo, windows).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -525,6 +525,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "artifact-manager": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/artifact-manager@v0.1.0-artifact-manager",
+      "sha256": "e67c84d1a7fb017a665a730f44e951344333c13dd34e4cbf5a3a1e0a1ce79c94",
+      "summary": "Task artifact lifecycle — ls, get, write, attach, init. Pure TypeScript, no WASM.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -514,6 +514,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "consent": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/consent@v0.1.0-consent",
+      "sha256": "f9b68b6bb52b74bf508ce036fcf7d87e8a9abd6eb76654f44b68d589438bd2c5",
+      "summary": "PIN-consent for cross-oracle actions (#644 Phase 1 — gates `maw hey` when MAW_CONSENT=1).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -734,6 +734,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
+    },
+    "tag": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/tag@v0.1.0-tag",
+      "sha256": "e4e019b08bd2c40cad239836d6f195e5ded0bcb16cf7f98150870114e02ef4a3",
+      "summary": "Set pane metadata: title, custom options. Enables deterministic routing by agent name.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -613,6 +613,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "run": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/run@v0.1.0-run",
+      "sha256": "c249fd922d4cca7fc3078f2b4612533be669a5c0c81431a4e6a04c37d7581eca",
+      "summary": "Type text into a tmux pane and submit with Enter — idiomatic for shells (#757).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:18:08Z",
+  "updated": "2026-04-29T02:18:09Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -403,6 +403,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
+    },
+    "tab": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/tab@v0.1.0-tab",
+      "sha256": "fa1cb5b76e700b03750c198f71af6a52bc65e349582827995e6c66175376ceef",
+      "summary": "Manage tmux tabs.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:09Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -360,6 +360,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
+    },
+    "cleanup": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/cleanup@v0.1.0-cleanup",
+      "sha256": "88b83b29d037f067a5591c88a3ea31f9acf5817e25c29c1700f3f28a02b2bfac",
+      "summary": "Cleanup zombie agent panes.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -371,6 +371,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
+    },
+    "done": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/done@v0.1.0-done",
+      "sha256": "b27124336937bf46bc30d7bd80611d78956157975b3d5f7c708e3ca4a8772f75",
+      "summary": "Clean up a finished worktree window: rrr, git save, kill, remove worktree.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -657,6 +657,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "overview": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/overview@v0.1.0-overview",
+      "sha256": "377d37b339325b4d5acceb8e1b14b4c0d08cf5ea203ec9af85ab8fc95cd42577",
+      "summary": "Show fleet overview / war room dashboard.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T01:40:04Z",
+  "updated": "2026-04-29T01:40:28Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -326,6 +326,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:40:04Z",
+      "tier": "extra"
+    },
+    "whoami": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/whoami@v0.1.0-whoami",
+      "sha256": "a08543916e503a691c139cd469d21b9f02c9245ba34bd06ed73cd9c054fff20a",
+      "summary": "Print the current tmux session name (closes raw `tmux display-message -p '#S'` sweep).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T01:40:28Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -382,6 +382,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:18:08Z",
       "tier": "extra"
+    },
+    "init": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/init@v0.1.0-init",
+      "sha256": "39fc62510425f3b83a76ebfdda983866c6449be9e4fd4b62abf7c8c01cae3a57",
+      "summary": "First-run wizard — configure ~/.config/maw/maw.config.json",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:18:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:49:08Z",
+  "updated": "2026-04-29T02:49:09Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -535,6 +535,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
+    },
+    "ping": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/ping@v0.1.0-ping",
+      "sha256": "14c1e89c9765e00ed0eeb4e34d2a172e783b3de8de6b39cc4496fdbf582f75e0",
+      "summary": "Ping peer nodes to check connectivity and auth status.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -723,6 +723,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
+    },
+    "contacts": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/contacts@v0.1.0-contacts",
+      "sha256": "07d9153d378eb4150ac3b4a1d836177980473b764f2a233f46d1ed37aa5c8da2",
+      "summary": "Manage oracle contacts — add, remove, list",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -492,6 +492,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "workon": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/workon@v0.1.0-workon",
+      "sha256": "e404553ff41eeea3652784b286aa55645cbace499dd74072a8be0070560a9426",
+      "summary": "Start working on a repo with optional task context.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-04-29T02:49:07Z",
+  "updated": "2026-04-29T02:49:08Z",
   "plugins": {
     "bg": {
       "version": "0.1.2",
@@ -458,6 +458,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:07Z",
+      "tier": "extra"
+    },
+    "signals": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/signals@v0.1.0-signals",
+      "sha256": "081531bc13afcd51b8ada7105d5db7be157e57137737ff7a9571231477dcd4a6",
+      "summary": "List bud signals written to ψ/memory/signals/",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
     }
   }

--- a/registry.json
+++ b/registry.json
@@ -679,6 +679,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "avengers": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/avengers@v0.1.0-avengers",
+      "sha256": "3068b86454fad08e547464a93b7259d3b7e8d23b1c3709a9147c6da74251972b",
+      "summary": "Manage the Avengers multi-agent team.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -558,6 +558,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:09Z",
       "tier": "extra"
+    },
+    "check": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/check@v0.1.0-check",
+      "sha256": "538bb55a38a5407cb5cf3c2971d619c62517e61ff8de13eb668961dc06025301",
+      "summary": "Audit installed prep tools (ghq, gh, git, tmux, bun, uv, uvx)",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:09Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -635,6 +635,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "panes": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/panes@v0.1.0-panes",
+      "sha256": "cd98d6bb4fdfd22286e85c66fae96cf7918878565e39930babe525c2eecce1d3",
+      "summary": "List tmux panes with metadata (index, size, command, title).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -668,6 +668,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:10Z",
       "tier": "extra"
+    },
+    "profile": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/profile@v0.1.0-profile",
+      "sha256": "c60d51a1ece5824d506055e61de2b3302a42a2ea279dec436c5cd82d1615b283",
+      "summary": "Profile primitive — named plugin bundles (Phase 1 of #640 / #888).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:10Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -503,6 +503,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
       "tier": "extra"
+    },
+    "zoom": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/zoom@v0.1.0-zoom",
+      "sha256": "2f09671b78a674083887b36bf3cddcc29a0d7bd01d7b21fff7880aece5852c50",
+      "summary": "Toggle tmux pane zoom (full-screen) — wraps resize-pane -Z.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
     }
   }
 }

--- a/registry.json
+++ b/registry.json
@@ -756,6 +756,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
+    },
+    "locate": {
+      "version": "0.1.0",
+      "source": "monorepo:plugins/locate@v0.1.0-locate",
+      "sha256": "e7744467dbb6e32a45a0a1bc968caaa3bd0452f4022862df4872a1ee85aebde0",
+      "summary": "Locate an oracle — repo path, session, fleet config, federation node. Diagnostic, no side effects.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-04-29T02:49:11Z",
+      "tier": "extra"
     }
   }
 }


### PR DESCRIPTION
## Summary

Bulk extraction by phase2-extract team — 29 newly extracted plugins.

Unblocked by morning's PRs:
- #919 — SDK widen (re-export core/util, config, cli/parse-args, worktrees, core/ghq, core/matcher, core/consent, lib/profile-loader, lib/schemas, lib/artifacts, core/util/terminal)
- #921 — helpers vendored to src/lib/
- #922 — cross-plugin imports vendored to <plugin>/internal/

## Plugins (29)

on, signals, pulse, workspace, workon, zoom, consent, artifact-manager, ping, hey-test, check, kill, capture, pr, send, run, take, panes, health, overview, profile, avengers, send-enter, restart, split, contacts, tag, talk-to, locate

Each plugin has a `v0.1.0-<plugin>` tag at the pin commit.

## Verification

- All preflight A/B/C/D/E checks ✓ per /tmp/migrate-plugin.sh
- Per-plugin sha256 + tag table: /tmp/phase2-extract-progress.md
- Full extraction log: /tmp/phase2-extract-master.log
- 17 plugins (whoami + 10 DEFER + 6 inbound-dep) skipped with "already-extracted"; 0 failed

## Test plan

- [x] migrate-plugin.sh preflight passed for all 29
- [x] Working tree clean post-extraction
- [x] All tags pushed to origin

🤖 Generated with [Claude Code](https://claude.com/claude-code)