### PR TITLE
feat(registry): packages map — standard / federation / dev / extras

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -768,5 +768,97 @@
       "addedAt": "2026-04-29T02:49:11Z",
       "tier": "extra"
     }
+  },
+  "packages": {
+    "standard": {
+      "summary": "Default install — common workflow plugins for daily use.",
+      "plugins": [
+        "init",
+        "ls",
+        "peek",
+        "stop",
+        "done",
+        "kill",
+        "find",
+        "locate",
+        "tag",
+        "send",
+        "run",
+        "view",
+        "on",
+        "take"
+      ]
+    },
+    "federation": {
+      "summary": "Multi-oracle features — peer discovery, trust, consent, broadcast.",
+      "plugins": [
+        "peers",
+        "trust",
+        "consent",
+        "pair",
+        "reunion",
+        "broadcast",
+        "cross-team-queue",
+        "workspace",
+        "talk-to",
+        "contacts"
+      ]
+    },
+    "dev": {
+      "summary": "Diagnostics + debug tooling.",
+      "plugins": [
+        "doctor",
+        "panes",
+        "ping",
+        "signals",
+        "scope",
+        "completions",
+        "whoami",
+        "restart",
+        "sleep",
+        "archive",
+        "check",
+        "health"
+      ]
+    },
+    "extras": {
+      "summary": "Optional community plugins — install à la carte or as a bundle.",
+      "plugins": [
+        "about",
+        "artifact-manager",
+        "assign",
+        "avengers",
+        "bg",
+        "bud",
+        "capture",
+        "cleanup",
+        "costs",
+        "demo",
+        "hey-test",
+        "inbox",
+        "incubate",
+        "learn",
+        "mega",
+        "overview",
+        "park",
+        "pr",
+        "profile",
+        "project",
+        "pulse",
+        "rename",
+        "resume",
+        "send-enter",
+        "shellenv",
+        "soul-sync",
+        "split",
+        "tab",
+        "team",
+        "triggers",
+        "ui",
+        "wake",
+        "workon",
+        "zoom"
+      ]
+    }
   }
 }

--- a/schema/registry.json
+++ b/schema/registry.json
@@ -30,6 +30,18 @@
       "additionalProperties": {
         "$ref": "#/$defs/entry"
       }
+    },
+    "packages": {
+      "type": "object",
+      "description": "Curated bundles of plugins. `maw plugin install <package>` resolves and installs all referenced plugins. Each `plugins` entry must be a key in the top-level `plugins` map (cross-validated by tooling, not schema).",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9-]*$",
+        "minLength": 2,
+        "maxLength": 32
+      },
+      "additionalProperties": {
+        "$ref": "#/$defs/package"
+      }
     }
   },
   "$defs": {
@@ -79,6 +91,29 @@
         "tier": {
           "type": "string",
           "description": "Optional classification tag — e.g. 'extra', 'standard', 'federation', 'dev'."
+        }
+      }
+    },
+    "package": {
+      "type": "object",
+      "required": ["summary", "plugins"],
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 4,
+          "maxLength": 200,
+          "description": "One-line description of what this bundle is for."
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9-]*$"
+          },
+          "minItems": 1,
+          "uniqueItems": true,
+          "description": "Plugin names to install when this package is requested."
         }
       }
     }


### PR DESCRIPTION
## Summary

Adds a `packages` map to `registry.json` so users can install curated bundles instead of picking plugins one-by-one. Mirrors the proposal in [maw-js#939](https://github.com/Soul-Brews-Studio/maw-js/issues/939) body.

## Bundles

| Package | Count | Purpose |
|---------|-------|---------|
| **standard** | 14 | Default install — common workflow plugins for daily use |
| **federation** | 10 | Multi-oracle: peer discovery, trust, consent, broadcast, talk-to |
| **dev** | 12 | Diagnostics + debug (doctor, panes, ping, signals, etc.) |
| **extras** | 34 | Optional community plugins |

All 70 plugins are in exactly one package (perfect bijection — `extras` covers everything not opinionated about).

## Schema

- New top-level `packages` (open property names)
- New `$defs/package` requiring `summary` + `plugins[]` array

```json
"packages": {
  "standard": {
    "summary": "...",
    "plugins": ["init", "ls", "peek", "stop", "done", ...]
  }
}
```

## Resolver impact (out of scope here)

Once this lands, `maw-js` install command needs a small extension:

```
maw plugin install <name>
  ↓
  if registry.plugins[name]: install single plugin (current behavior)
  if registry.packages[name]: expand to plugins[] and install each
```

That's a separate maw-js PR.

## Verified

- Local schema validation: VALID
- Bijection check: all 70 plugins covered, no orphans, no missing references

## Out of scope

- maw-js resolver wiring (separate PR)
- Per-plugin `tier` field still tracked separately (tier is per-plugin classification; package is a cross-cutting bundle)