### PR TITLE
fix: migrate 306 relative imports to maw-js subpath exports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,545 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "maw-plugin-registry",
+      "dependencies": {
+        "maw-js": "file:../maw-js",
+      },
+    },
+  },
+  "packages": {
+    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/compat-data": ["@babel/compat-data@7.29.3", "", {}, "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg=="],
+
+    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
+
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
+
+    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.2", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.29.0" } }, "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw=="],
+
+    "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
+
+    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
+
+    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
+
+    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
+
+    "@dimforge/rapier3d-compat": ["@dimforge/rapier3d-compat@0.12.0", "", {}, "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow=="],
+
+    "@elysiajs/cors": ["@elysiajs/cors@1.4.2", "", { "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-FTCcbH35brTLigF1W7BYySRZomgI/dBEMK9BgK9RP9Nez7zmpGh4koL/Yr1BFv8nYz7CfhRvcM8d/c+XnwMaVQ=="],
+
+    "@elysiajs/swagger": ["@elysiajs/swagger@1.3.1", "", { "dependencies": { "@scalar/themes": "^0.9.52", "@scalar/types": "^0.0.12", "openapi-types": "^12.1.3", "pathe": "^1.1.2" }, "peerDependencies": { "elysia": ">= 1.3.0" } }, "sha512-LcbLHa0zE6FJKWPWKsIC/f+62wbDv3aXydqcNPVPyqNcaUgwvCajIi+5kHEU6GO3oXUCpzKaMsb3gsjt8sLzFQ=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@monaco-editor/loader": ["@monaco-editor/loader@1.7.0", "", { "dependencies": { "state-local": "^1.0.6" } }, "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA=="],
+
+    "@monaco-editor/react": ["@monaco-editor/react@4.7.0", "", { "dependencies": { "@monaco-editor/loader": "^1.5.0" }, "peerDependencies": { "monaco-editor": ">= 0.25.0 < 1", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA=="],
+
+    "@resvg/resvg-js": ["@resvg/resvg-js@2.6.2", "", { "optionalDependencies": { "@resvg/resvg-js-android-arm-eabi": "2.6.2", "@resvg/resvg-js-android-arm64": "2.6.2", "@resvg/resvg-js-darwin-arm64": "2.6.2", "@resvg/resvg-js-darwin-x64": "2.6.2", "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2", "@resvg/resvg-js-linux-arm64-gnu": "2.6.2", "@resvg/resvg-js-linux-arm64-musl": "2.6.2", "@resvg/resvg-js-linux-x64-gnu": "2.6.2", "@resvg/resvg-js-linux-x64-musl": "2.6.2", "@resvg/resvg-js-win32-arm64-msvc": "2.6.2", "@resvg/resvg-js-win32-ia32-msvc": "2.6.2", "@resvg/resvg-js-win32-x64-msvc": "2.6.2" } }, "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q=="],
+
+    "@resvg/resvg-js-android-arm-eabi": ["@resvg/resvg-js-android-arm-eabi@2.6.2", "", { "os": "android", "cpu": "arm" }, "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA=="],
+
+    "@resvg/resvg-js-android-arm64": ["@resvg/resvg-js-android-arm64@2.6.2", "", { "os": "android", "cpu": "arm64" }, "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ=="],
+
+    "@resvg/resvg-js-darwin-arm64": ["@resvg/resvg-js-darwin-arm64@2.6.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A=="],
+
+    "@resvg/resvg-js-darwin-x64": ["@resvg/resvg-js-darwin-x64@2.6.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw=="],
+
+    "@resvg/resvg-js-linux-arm-gnueabihf": ["@resvg/resvg-js-linux-arm-gnueabihf@2.6.2", "", { "os": "linux", "cpu": "arm" }, "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw=="],
+
+    "@resvg/resvg-js-linux-arm64-gnu": ["@resvg/resvg-js-linux-arm64-gnu@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg=="],
+
+    "@resvg/resvg-js-linux-arm64-musl": ["@resvg/resvg-js-linux-arm64-musl@2.6.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg=="],
+
+    "@resvg/resvg-js-linux-x64-gnu": ["@resvg/resvg-js-linux-x64-gnu@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw=="],
+
+    "@resvg/resvg-js-linux-x64-musl": ["@resvg/resvg-js-linux-x64-musl@2.6.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ=="],
+
+    "@resvg/resvg-js-win32-arm64-msvc": ["@resvg/resvg-js-win32-arm64-msvc@2.6.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ=="],
+
+    "@resvg/resvg-js-win32-ia32-msvc": ["@resvg/resvg-js-win32-ia32-msvc@2.6.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w=="],
+
+    "@resvg/resvg-js-win32-x64-msvc": ["@resvg/resvg-js-win32-x64-msvc@2.6.2", "", { "os": "win32", "cpu": "x64" }, "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.60.2", "", { "os": "android", "cpu": "arm64" }, "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.60.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.60.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.60.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.60.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.60.2", "", { "os": "linux", "cpu": "arm" }, "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.60.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.60.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.60.2", "", { "os": "linux", "cpu": "none" }, "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.60.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.60.2", "", { "os": "linux", "cpu": "x64" }, "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.60.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.60.2", "", { "os": "none", "cpu": "arm64" }, "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.60.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.60.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
+
+    "@scalar/openapi-types": ["@scalar/openapi-types@0.1.1", "", {}, "sha512-NMy3QNk6ytcCoPUGJH0t4NNr36OWXgZhA3ormr3TvhX1NDgoF95wFyodGVH8xiHeUyn2/FxtETm8UBLbB5xEmg=="],
+
+    "@scalar/themes": ["@scalar/themes@0.9.86", "", { "dependencies": { "@scalar/types": "0.1.7" } }, "sha512-QUHo9g5oSWi+0Lm1vJY9TaMZRau8LHg+vte7q5BVTBnu6NuQfigCaN+ouQ73FqIVd96TwMO6Db+dilK1B+9row=="],
+
+    "@scalar/types": ["@scalar/types@0.0.12", "", { "dependencies": { "@scalar/openapi-types": "0.1.1", "@unhead/schema": "^1.9.5" } }, "sha512-XYZ36lSEx87i4gDqopQlGCOkdIITHHEvgkuJFrXFATQs9zHARop0PN0g4RZYWj+ZpCUclOcaOjbCt8JGe22mnQ=="],
+
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.2.4", "", { "os": "android", "cpu": "arm64" }, "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.2.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.2.4", "", { "dependencies": { "@emnapi/core": "^1.8.1", "@emnapi/runtime": "^1.8.1", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.1.1", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw=="],
+
+    "@tailwindcss/vite": ["@tailwindcss/vite@4.2.4", "", { "dependencies": { "@tailwindcss/node": "4.2.4", "@tailwindcss/oxide": "4.2.4", "tailwindcss": "4.2.4" }, "peerDependencies": { "vite": "^5.2.0 || ^6 || ^7 || ^8" } }, "sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw=="],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
+    "@tweenjs/tween.js": ["@tweenjs/tween.js@23.1.3", "", {}, "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA=="],
+
+    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
+
+    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
+
+    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
+
+    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/readable-stream": ["@types/readable-stream@4.0.23", "", { "dependencies": { "@types/node": "*" } }, "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig=="],
+
+    "@types/stats.js": ["@types/stats.js@0.17.4", "", {}, "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA=="],
+
+    "@types/three": ["@types/three@0.184.0", "", { "dependencies": { "@dimforge/rapier3d-compat": "~0.12.0", "@tweenjs/tween.js": "~23.1.3", "@types/stats.js": "*", "@types/webxr": ">=0.5.17", "fflate": "~0.8.2", "meshoptimizer": "~1.1.1" } }, "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA=="],
+
+    "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/webxr": ["@types/webxr@0.5.24", "", {}, "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@unhead/schema": ["@unhead/schema@1.11.20", "", { "dependencies": { "hookable": "^5.5.3", "zhead": "^2.2.4" } }, "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA=="],
+
+    "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/xterm": ["@xterm/xterm@5.5.0", "", {}, "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.25", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA=="],
+
+    "bl": ["bl@6.1.6", "", { "dependencies": { "@types/readable-stream": "^4.0.0", "buffer": "^6.0.3", "inherits": "^2.0.4", "readable-stream": "^4.2.0" } }, "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg=="],
+
+    "broker-factory": ["broker-factory@3.1.14", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1", "worker-factory": "^7.0.49" } }, "sha512-L45k5HMbPIrMid0nTOZ/UPXG/c0aRuQKVrSDFIb1zOkvfiyHgYmIjc3cSiN1KwQIvRDOtKE0tfb3I9EZ3CmpQQ=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
+
+    "commist": ["commist@3.2.0", "", {}, "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw=="],
+
+    "concat-stream": ["concat-stream@2.0.0", "", { "dependencies": { "buffer-from": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.0.2", "typedarray": "^0.0.6" } }, "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dompurify": ["dompurify@3.2.7", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw=="],
+
+    "electron-to-chromium": ["electron-to-chromium@1.5.348", "", {}, "sha512-QC2X59nRlycQQMc4ZXjSVBX+tSgJfgRtcrYHbIZLgOV2dCvefoQGegLR7lLXKgpPpSuVmJU19LMzGrSa2C7k3Q=="],
+
+    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
+
+    "fast-unique-numbers": ["fast-unique-numbers@9.0.27", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1" } }, "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+
+    "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "help-me": ["help-me@5.0.0", "", {}, "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg=="],
+
+    "hono": ["hono@4.12.16", "", {}, "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg=="],
+
+    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "js-sdsl": ["js-sdsl@4.3.0", "", {}, "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@14.0.0", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="],
+
+    "maw-js": ["maw-js@file:../maw-js", { "dependencies": { "@elysiajs/cors": "^1.4.1", "@elysiajs/swagger": "^1.3.1", "@monaco-editor/react": "^4.7.0", "@sinclair/typebox": "^0.34.49", "@xterm/addon-fit": "^0.11.0", "@xterm/xterm": "^5.5.0", "arg": "^5.0.2", "elysia": "^1.4.28", "hono": "^4.12.5", "mqtt": "^5.15.1", "react": "^19.0.0", "react-dom": "^19.0.0", "three": "^0.184.0", "typescript": "^6.0.3", "zustand": "^5.0.11" }, "devDependencies": { "@resvg/resvg-js": "^2.6.2", "@tailwindcss/vite": "^4.2.1", "@types/bun": "^1.3.11", "@types/react": "^19.0.0", "@types/react-dom": "^19.0.0", "@types/three": "^0.184.0", "@vitejs/plugin-react": "^4.3.0", "tailwindcss": "^4.2.1", "vite": "^6.0.0" }, "bin": { "maw": "./src/cli.ts" } }],
+
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
+    "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
+
+    "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
+
+    "mqtt": ["mqtt@5.15.1", "", { "dependencies": { "@types/readable-stream": "^4.0.21", "@types/ws": "^8.18.1", "commist": "^3.2.0", "concat-stream": "^2.0.0", "debug": "^4.4.1", "help-me": "^5.0.0", "lru-cache": "^10.4.3", "minimist": "^1.2.8", "mqtt-packet": "^9.0.2", "number-allocator": "^1.0.14", "readable-stream": "^4.7.0", "rfdc": "^1.4.1", "socks": "^2.8.6", "split2": "^4.2.0", "worker-timers": "^8.0.23", "ws": "^8.18.3" }, "bin": { "mqtt_pub": "build/bin/pub.js", "mqtt_sub": "build/bin/sub.js", "mqtt": "build/bin/mqtt.js" } }, "sha512-V1WnkGuJh3ec9QXzy5Iylw8OOBK+Xu1WhxcQ9mMpLThG+/JZIMV1PgLNRgIiqXhZnvnVLsuyxHl5A/3bHHbcAA=="],
+
+    "mqtt-packet": ["mqtt-packet@9.0.2", "", { "dependencies": { "bl": "^6.0.8", "debug": "^4.3.4", "process-nextick-args": "^2.0.1" } }, "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+
+    "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
+
+    "number-allocator": ["number-allocator@1.0.14", "", { "dependencies": { "debug": "^4.3.1", "js-sdsl": "4.3.0" } }, "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "postcss": ["postcss@8.5.13", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "process-nextick-args": ["process-nextick-args@2.0.1", "", {}, "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="],
+
+    "react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
+
+    "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
+
+    "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.8", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "state-local": ["state-local@1.0.7", "", {}, "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
+    "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "three": ["three@0.184.0", "", {}, "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
+    "typedarray": ["typedarray@0.0.6", "", {}, "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vite": ["vite@6.4.2", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ=="],
+
+    "worker-factory": ["worker-factory@7.0.49", "", { "dependencies": { "@babel/runtime": "^7.29.2", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1" } }, "sha512-lW7tpgy6aUv2dFsQhv1yv+XFzdkCf/leoKRTGMPVK5/die6RrUjqgJHJf556qO+ZfytNG6wPXc17E8zzsOLUDw=="],
+
+    "worker-timers": ["worker-timers@8.0.31", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1", "worker-timers-broker": "^8.0.16", "worker-timers-worker": "^9.0.14" } }, "sha512-ngkq5S6JuZyztom8tDgBzorLo9byhBMko/sXfgiUD945AuzKGg1GCgDMCC3NaYkicLpGKXutONM36wEX8UbBCA=="],
+
+    "worker-timers-broker": ["worker-timers-broker@8.0.16", "", { "dependencies": { "@babel/runtime": "^7.29.2", "broker-factory": "^3.1.14", "fast-unique-numbers": "^9.0.27", "tslib": "^2.8.1", "worker-timers-worker": "^9.0.14" } }, "sha512-JyP3AvUGyPGbBGW7XiUewm2+0pN/aYo1QpVf5kdXAfkDZcN3p7NbWrG6XnyDEpDIvfHk/+LCnOW/NsuiU9riYA=="],
+
+    "worker-timers-worker": ["worker-timers-worker@9.0.14", "", { "dependencies": { "@babel/runtime": "^7.29.2", "tslib": "^2.8.1", "worker-factory": "^7.0.49" } }, "sha512-/qF06C60sXmSLfUl7WglvrDIbspmPOM8UrG63Dnn4bi2x4/DfqHS/+dxF5B+MdHnYO5tVuZYLHdAodrKdabTIg=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
+    "zhead": ["zhead@2.2.4", "", {}, "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "@scalar/themes/@scalar/types": ["@scalar/types@0.1.7", "", { "dependencies": { "@scalar/openapi-types": "0.2.0", "@unhead/schema": "^1.11.11", "nanoid": "^5.1.5", "type-fest": "^4.20.0", "zod": "^3.23.8" } }, "sha512-irIDYzTQG2KLvFbuTI8k2Pz/R4JR+zUUSykVTbEMatkzMmVFnn1VzNSMlODbadycwZunbnL2tA27AXed9URVjw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "concat-stream/readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
+    "@scalar/themes/@scalar/types/@scalar/openapi-types": ["@scalar/openapi-types@0.2.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-waiKk12cRCqyUCWTOX0K1WEVX46+hVUK+zRPzAahDJ7G0TApvbNkuy5wx7aoUyEk++HHde0XuQnshXnt8jsddA=="],
+
+    "@scalar/themes/@scalar/types/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "maw-plugin-registry",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "maw-js": "file:../maw-js"
+  }
+}

--- a/plugins/about/about.test.ts
+++ b/plugins/about/about.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/about/index.ts
+++ b/plugins/about/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdOracleAbout } from "./internal/impl-about";
 
 export const command = {

--- a/plugins/about/internal/impl-about.ts
+++ b/plugins/about/internal/impl-about.ts
@@ -1,9 +1,9 @@
-import { listSessions, capture, FLEET_DIR } from "../../../../sdk";
-import { findWorktrees, detectSession } from "../../../shared/wake";
+import { listSessions, capture, FLEET_DIR } from "maw-js/sdk";
+import { findWorktrees, detectSession } from "maw-js/commands/shared/wake";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { resolveOracleSafe } from "./impl-helpers";
-import { UserError } from "../../../../core/util/user-error";
+import { UserError } from "maw-js/core/util/user-error";
 
 export async function cmdOracleAbout(oracle: string) {
   const name = oracle.toLowerCase();

--- a/plugins/about/internal/impl-helpers.ts
+++ b/plugins/about/internal/impl-helpers.ts
@@ -1,5 +1,5 @@
-import { listSessions, FLEET_DIR, type OracleEntry } from "../../../../sdk";
-import { ghqFind } from "../../../../core/ghq";
+import { listSessions, FLEET_DIR, type OracleEntry } from "maw-js/sdk";
+import { ghqFind } from "maw-js/core/ghq";
 import { readdirSync, readFileSync } from "fs";
 import { join } from "path";
 

--- a/plugins/archive/impl.ts
+++ b/plugins/archive/impl.ts
@@ -1,8 +1,8 @@
-import { hostExec } from "../../../sdk";
-import { getGhqRoot } from "../../../config/ghq-root";
-import { loadFleetEntries } from "../../shared/fleet-load";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import { cmdSoulSync } from "./internal/soul-sync-impl";
-import { FLEET_DIR } from "../../../sdk";
+import { FLEET_DIR } from "maw-js/sdk";
 import { join } from "path";
 import { existsSync, renameSync } from "fs";
 

--- a/plugins/archive/index.ts
+++ b/plugins/archive/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdArchive } from "./impl";
 
 export const command = {

--- a/plugins/archive/internal/resolve.ts
+++ b/plugins/archive/internal/resolve.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "../../../../core/ghq";
-import { getGhqRoot } from "../../../../config/ghq-root";
-import { loadFleet } from "../../../shared/fleet-load";
+import { ghqFind } from "maw-js/core/ghq";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/plugins/archive/internal/soul-sync-impl.ts
+++ b/plugins/archive/internal/soul-sync-impl.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "../../../../sdk";
-import { getGhqRoot } from "../../../../config/ghq-root";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/plugins/archive/internal/sync-helpers.ts
+++ b/plugins/archive/internal/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "../../../shared/fleet-load";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/plugins/artifact-manager/index.ts
+++ b/plugins/artifact-manager/index.ts
@@ -20,7 +20,7 @@ import {
   listArtifacts,
   getArtifact,
   artifactDir,
-} from "../../../lib/artifacts";
+} from "maw-js/lib/artifacts";
 import { readFileSync } from "fs";
 import { basename } from "path";
 

--- a/plugins/assign/impl.ts
+++ b/plugins/assign/impl.ts
@@ -1,5 +1,5 @@
-import { hostExec } from "../../../sdk";
-import { cmdWake, fetchIssuePrompt } from "../../shared/wake";
+import { hostExec } from "maw-js/sdk";
+import { cmdWake, fetchIssuePrompt } from "maw-js/commands/shared/wake";
 
 function parseIssueUrl(url: string): { org: string; repo: string; issueNum: number } {
   const m = url.match(/github\.com[:/]([^/]+)\/([^/]+)\/issues\/(\d+)/);

--- a/plugins/assign/index.ts
+++ b/plugins/assign/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdAssign } from "./impl";
 
 export const command = {

--- a/plugins/avengers/avengers.test.ts
+++ b/plugins/avengers/avengers.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import handler, { command } from "./index";
 
 describe("avengers plugin — smoke", () => {

--- a/plugins/avengers/impl.ts
+++ b/plugins/avengers/impl.ts
@@ -2,7 +2,7 @@
  * maw avengers — rate limit monitor integration with ARRA-01/avengers.
  */
 
-import { loadConfig } from "../../../config";
+import { loadConfig } from "maw-js/config";
 
 function getAvengersUrl(): string | null {
   return (loadConfig() as any).avengers || null;

--- a/plugins/avengers/index.ts
+++ b/plugins/avengers/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "avengers",

--- a/plugins/broadcast/impl.ts
+++ b/plugins/broadcast/impl.ts
@@ -1,4 +1,4 @@
-import { tmux } from "../../../sdk";
+import { tmux } from "maw-js/sdk";
 
 /**
  * maw broadcast <message> — send to ALL Claude windows across ALL sessions

--- a/plugins/broadcast/index.ts
+++ b/plugins/broadcast/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdBroadcast } from "./impl";
 
 export const command = { name: "broadcast", description: "Broadcast a message to all agents." };

--- a/plugins/bud/bud-init.ts
+++ b/plugins/bud/bud-init.ts
@@ -1,7 +1,7 @@
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "fs";
-import { loadFleetEntries } from "../../shared/fleet-load";
-import { FLEET_DIR } from "../../../sdk";
+import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
+import { FLEET_DIR } from "maw-js/sdk";
 
 /** Step 2: Create ψ/ vault directory structure. Returns the psiDir path. */
 export function initVault(budRepoPath: string): string {

--- a/plugins/bud/bud-repo.ts
+++ b/plugins/bud/bud-repo.ts
@@ -1,4 +1,4 @@
-import { hostExec } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
 import { existsSync } from "fs";
 
 /**

--- a/plugins/bud/bud-wake.ts
+++ b/plugins/bud/bud-wake.ts
@@ -1,9 +1,9 @@
-import { hostExec } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
 import { cmdSoulSync } from "./internal/soul-sync-impl";
-import { cmdWake } from "../../shared/wake";
-import { loadFleetEntries } from "../../shared/fleet-load";
-import { FLEET_DIR } from "../../../sdk";
-import { getGhqRoot } from "../../../config/ghq-root";
+import { cmdWake } from "maw-js/commands/shared/wake";
+import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
+import { FLEET_DIR } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { join } from "path";
 import { existsSync, readFileSync, writeFileSync } from "fs";
 

--- a/plugins/bud/bud.test.ts
+++ b/plugins/bud/bud.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock, beforeAll, afterAll, beforeEach, afterEach 
 import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 // Capture real modules BEFORE any mock.module rewrites the cache.
 // Namespace imports are live bindings, so we copy function references into
@@ -12,8 +12,8 @@ import * as rawImpl from "./impl";
 import * as rawBudRepo from "./bud-repo";
 import * as rawBudWake from "./bud-wake";
 import * as rawBudInit from "./bud-init";
-import * as rawConfig from "../../../config";
-import * as rawGhqRoot from "../../../config/ghq-root";
+import * as rawConfig from "maw-js/config";
+import * as rawGhqRoot from "maw-js/config/ghq-root";
 
 const realCmdBud = rawImpl.cmdBud;
 const realEnsureBudRepo = rawBudRepo.ensureBudRepo;

--- a/plugins/bud/from-repo-fleet.ts
+++ b/plugins/bud/from-repo-fleet.ts
@@ -11,7 +11,7 @@
 import { existsSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import { basename, join } from "path";
 import { execFileSync } from "child_process";
-import { FLEET_DIR } from "../../../core/paths";
+import { FLEET_DIR } from "maw-js/core/paths";
 
 /** Parsed `org/repo` slug from a remote URL. */
 export interface RepoSlug {

--- a/plugins/bud/from-repo-git.ts
+++ b/plugins/bud/from-repo-git.ts
@@ -10,7 +10,7 @@
 import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { hostExec } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
 
 /** Single-quote escape for bash. Safe for unknown input (URLs, paths, branches). */
 function sh(s: string): string {

--- a/plugins/bud/from-repo-seed.ts
+++ b/plugins/bud/from-repo-seed.ts
@@ -13,8 +13,8 @@
 
 import { cpSync, copyFileSync, existsSync, mkdirSync, statSync } from "fs";
 import { join } from "path";
-import { loadConfig } from "../../../config";
-import { getGhqRoot } from "../../../config/ghq-root";
+import { loadConfig } from "maw-js/config";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { peersPath } from "./internal/peers-store";
 
 type Log = (msg: string) => void;

--- a/plugins/bud/from-repo.test.ts
+++ b/plugins/bud/from-repo.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import { planFromRepoInjection, looksLikeUrl, cmdBudFromRepo } from "./from-repo";
 import { applyFromRepoInjection, oracleMarkerBegin } from "./from-repo-exec";
 

--- a/plugins/bud/impl.ts
+++ b/plugins/bud/impl.ts
@@ -1,14 +1,14 @@
-import { loadConfig } from "../../../config";
-import { getGhqRoot } from "../../../config/ghq-root";
-import { parseWakeTarget, ensureCloned } from "../../shared/wake-target";
-import { normalizeTarget } from "../../../core/matcher/normalize-target";
-import { assertValidOracleName } from "../../../core/fleet/validate";
-import { hostExec } from "../../../sdk";
+import { loadConfig } from "maw-js/config";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { parseWakeTarget, ensureCloned } from "maw-js/commands/shared/wake-target";
+import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
+import { assertValidOracleName } from "maw-js/core/fleet/validate";
+import { hostExec } from "maw-js/sdk";
 import { ensureBudRepo } from "./bud-repo";
 import { initVault, generateClaudeMd, configureFleet, writeBirthNote } from "./bud-init";
 import { finalizeBud } from "./bud-wake";
-import { writeSignal } from "../../../core/fleet/leaf";
-import { validateNickname, writeNickname, setCachedNickname } from "../../../core/fleet/nicknames";
+import { writeSignal } from "maw-js/core/fleet/leaf";
+import { validateNickname, writeNickname, setCachedNickname } from "maw-js/core/fleet/nicknames";
 import { join } from "path";
 
 export interface BudOpts {

--- a/plugins/bud/index.ts
+++ b/plugins/bud/index.ts
@@ -1,7 +1,7 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdBud } from "./impl";
 import { cmdBudFromRepo, looksLikeUrl } from "./from-repo";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "bud",

--- a/plugins/bud/internal/resolve.ts
+++ b/plugins/bud/internal/resolve.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "../../../../core/ghq";
-import { getGhqRoot } from "../../../../config/ghq-root";
-import { loadFleet } from "../../../shared/fleet-load";
+import { ghqFind } from "maw-js/core/ghq";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/plugins/bud/internal/soul-sync-impl.ts
+++ b/plugins/bud/internal/soul-sync-impl.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "../../../../sdk";
-import { getGhqRoot } from "../../../../config/ghq-root";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/plugins/bud/internal/split-impl.ts
+++ b/plugins/bud/internal/split-impl.ts
@@ -1,6 +1,6 @@
-import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
-import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
-import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+import { listSessions, hostExec, withPaneLock } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 
 export interface SplitOpts {
   /** Split percentage (1-99). Default: 50. */

--- a/plugins/bud/internal/sync-helpers.ts
+++ b/plugins/bud/internal/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "../../../shared/fleet-load";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/plugins/capture/impl.ts
+++ b/plugins/capture/impl.ts
@@ -1,5 +1,5 @@
-import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 
 export interface CaptureOpts {
   /** Pane index within the resolved window. Default: current/first. */

--- a/plugins/capture/index.ts
+++ b/plugins/capture/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdCapture } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "capture",

--- a/plugins/check/impl.ts
+++ b/plugins/check/impl.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "child_process";
-import { tlink } from "../../../core/util/terminal";
+import { tlink } from "maw-js/core/util/terminal";
 
 export interface ToolStatus {
   name: string;

--- a/plugins/check/index.ts
+++ b/plugins/check/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdCheck } from "./impl";
 
 export const command = {

--- a/plugins/cleanup/index.ts
+++ b/plugins/cleanup/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdCleanupZombies } from "./internal/team-cleanup-zombies";
 
 export const command = {

--- a/plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -1,8 +1,8 @@
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
-import { tmux } from "../../../../sdk";
-import type { TmuxPane } from "../../../../sdk";
-import { loadFleetEntries } from "../../../shared/fleet-load";
+import { tmux } from "maw-js/sdk";
+import type { TmuxPane } from "maw-js/sdk";
+import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import { TEAMS_DIR, loadTeam } from "./team-helpers";
 
 // ─── maw cleanup --zombie-agents ───

--- a/plugins/completions/impl.ts
+++ b/plugins/completions/impl.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync } from "fs";
 import { join, dirname } from "path";
-import { FLEET_DIR } from "../../../sdk";
+import { FLEET_DIR } from "maw-js/sdk";
 
 // Auto-discover commands from src/commands/*.ts
 // No manual list — add a file, it shows up in completions

--- a/plugins/completions/index.ts
+++ b/plugins/completions/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "completions",

--- a/plugins/consent/index.ts
+++ b/plugins/consent/index.ts
@@ -9,12 +9,12 @@
  *   maw consent untrust <peer> [action]  revoke trust entry
  *   maw consent list-trust               show all trust entries
  */
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import {
   listPending, listTrust, recordTrust, removeTrust,
   approveConsent, rejectConsent, type ConsentAction,
-} from "../../../core/consent";
-import { loadConfig } from "../../../config";
+} from "maw-js/core/consent";
+import { loadConfig } from "maw-js/config";
 
 const VALID_ACTIONS: ConsentAction[] = ["hey", "team-invite", "plugin-install"];
 

--- a/plugins/contacts/contacts.test.ts
+++ b/plugins/contacts/contacts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 // Mock the contacts commands
 mock.module("./impl", () => ({

--- a/plugins/contacts/impl.ts
+++ b/plugins/contacts/impl.ts
@@ -1,8 +1,8 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { loadConfig } from "../../../config";
-import { parseFlags } from "../../../cli/parse-args";
+import { loadConfig } from "maw-js/config";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 interface Contact {
   maw?: string;

--- a/plugins/contacts/index.ts
+++ b/plugins/contacts/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdContactsLs, cmdContactsAdd, cmdContactsRm } from "./impl";
 
 export const command = {

--- a/plugins/costs/costs.test.ts
+++ b/plugins/costs/costs.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/costs/impl.ts
+++ b/plugins/costs/impl.ts
@@ -1,6 +1,6 @@
-import { loadConfig } from "../../../config";
-import { UserError } from "../../../core/util/user-error";
-import { sparkline } from "../../../lib/sparkline";
+import { loadConfig } from "maw-js/config";
+import { UserError } from "maw-js/core/util/user-error";
+import { sparkline } from "maw-js/lib/sparkline";
 
 type CostAgent = {
   name: string;

--- a/plugins/costs/index.ts
+++ b/plugins/costs/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
 import { cmdCosts, cmdCostsDaily } from "./impl";
 
 export const command = {

--- a/plugins/demo/impl.ts
+++ b/plugins/demo/impl.ts
@@ -1,4 +1,4 @@
-import { hostExec } from "../../../core/transport/ssh";
+import { hostExec } from "maw-js/core/transport/ssh";
 
 // ---------------------------------------------------------------------------
 // Types

--- a/plugins/demo/index.ts
+++ b/plugins/demo/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdDemo } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "demo",

--- a/plugins/doctor/cross-source-detect.ts
+++ b/plugins/doctor/cross-source-detect.ts
@@ -30,7 +30,7 @@
  * `--allow-drift` for normal mid-migration states, defeating the purpose.
  */
 
-import type { OracleManifestEntry } from "../../../lib/oracle-manifest";
+import type { OracleManifestEntry } from "maw-js/lib/oracle-manifest";
 
 /** One inconsistency flagged across the 5 registries for a single oracle. */
 export interface CrossSourceGap {

--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -4,9 +4,9 @@ import { homedir } from "os";
 import { join, dirname, resolve } from "path";
 import { loadPeers } from "./internal/peers-store";
 import { findDuplicateIdentities, formatDuplicate } from "./internal/duplicate-detect";
-import { loadConfig } from "../../../config";
-import { C } from "../../shared/fleet-doctor-fixer";
-import { loadManifestCached, invalidateManifest } from "../../../lib/oracle-manifest";
+import { loadConfig } from "maw-js/config";
+import { C } from "maw-js/commands/shared/fleet-doctor-fixer";
+import { loadManifestCached, invalidateManifest } from "maw-js/lib/oracle-manifest";
 import { findGaps, summarizeGaps } from "./cross-source-detect";
 
 export interface DoctorResult {

--- a/plugins/doctor/index.ts
+++ b/plugins/doctor/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdDoctor } from "./impl";
 
 export const command = {

--- a/plugins/done/done-autosave.ts
+++ b/plugins/done/done-autosave.ts
@@ -1,5 +1,5 @@
-import { hostExec } from "../../../sdk";
-import { tmux } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
 import { appendFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";

--- a/plugins/done/done-worktree.ts
+++ b/plugins/done/done-worktree.ts
@@ -1,5 +1,5 @@
-import { hostExec } from "../../../sdk";
-import { FLEET_DIR } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
+import { FLEET_DIR } from "maw-js/sdk";
 import { readdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 

--- a/plugins/done/done.test.ts
+++ b/plugins/done/done.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/done/impl.ts
+++ b/plugins/done/impl.ts
@@ -1,10 +1,10 @@
 import { join } from "path";
-import { listSessions } from "../../../sdk";
-import { getGhqRoot } from "../../../config/ghq-root";
-import { FLEET_DIR } from "../../../sdk";
-import { takeSnapshot } from "../../../sdk";
-import { tmux } from "../../../sdk";
-import { normalizeTarget } from "../../../core/matcher/normalize-target";
+import { listSessions } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { FLEET_DIR } from "maw-js/sdk";
+import { takeSnapshot } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
+import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 import { signalParentInbox, autoSave } from "./done-autosave";
 import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig } from "./done-worktree";
 

--- a/plugins/done/index.ts
+++ b/plugins/done/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdDone } from "./impl";
 
 export const command = {

--- a/plugins/done/internal/resolve.ts
+++ b/plugins/done/internal/resolve.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "../../../../core/ghq";
-import { getGhqRoot } from "../../../../config/ghq-root";
-import { loadFleet } from "../../../shared/fleet-load";
+import { ghqFind } from "maw-js/core/ghq";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/plugins/done/internal/reunion-impl.ts
+++ b/plugins/done/internal/reunion-impl.ts
@@ -1,4 +1,4 @@
-import { listSessions, hostExec } from "../../../../sdk";
+import { listSessions, hostExec } from "maw-js/sdk";
 import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 

--- a/plugins/done/internal/soul-sync-impl.ts
+++ b/plugins/done/internal/soul-sync-impl.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "../../../../sdk";
-import { getGhqRoot } from "../../../../config/ghq-root";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/plugins/done/internal/sync-helpers.ts
+++ b/plugins/done/internal/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "../../../shared/fleet-load";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/plugins/federation/federation.test.ts
+++ b/plugins/federation/federation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import handler, { command } from "./index";
 
 describe("federation plugin — smoke", () => {

--- a/plugins/federation/index.ts
+++ b/plugins/federation/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "federation",

--- a/plugins/find/find.test.ts
+++ b/plugins/find/find.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import handler, { command } from "./index";
 
 describe("find plugin — smoke", () => {

--- a/plugins/find/impl.ts
+++ b/plugins/find/impl.ts
@@ -1,6 +1,6 @@
-import { hostExec } from "../../../sdk";
-import { getGhqRoot } from "../../../config/ghq-root";
-import { loadFleet } from "../../shared/fleet-load";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 import { join } from "path";
 import { existsSync, readdirSync } from "fs";
 

--- a/plugins/find/index.ts
+++ b/plugins/find/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdFind } from "./impl";
 
 export const command = {

--- a/plugins/health/health.test.ts
+++ b/plugins/health/health.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/health/impl.ts
+++ b/plugins/health/impl.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
-import { loadConfig, cfgTimeout } from "../../../config";
-import { curlFetch } from "../../../sdk";
-import { tmux } from "../../../sdk";
+import { loadConfig, cfgTimeout } from "maw-js/config";
+import { curlFetch } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
 
 export async function cmdHealth() {
   const checks: { name: string; status: string; detail: string }[] = [];

--- a/plugins/health/index.ts
+++ b/plugins/health/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdHealth } from "./impl";
 
 export const command = {

--- a/plugins/hey-test/hey-plugin.test.ts
+++ b/plugins/hey-test/hey-plugin.test.ts
@@ -54,7 +54,7 @@ mock.module("../../../core/fleet/worktrees", () => ({ scanWorktrees: async () =>
 mock.module("../../../core/transport/curl-fetch", () => ({ curlFetch: async () => ({ ok: false, data: {} }) }));
 mock.module("../../../commands/shared/wake", () => ({ resolveFleetSession: () => undefined }));
 
-import { cmdSend } from "../../../commands/shared/comm";
+import { cmdSend } from "maw-js/commands/shared/comm";
 
 describe("maw hey plugin:<name> routing", () => {
   let exitCode: number | undefined;

--- a/plugins/inbox/impl.ts
+++ b/plugins/inbox/impl.ts
@@ -1,13 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "fs";
 import { join } from "path";
-import { loadConfig } from "../../../config";
+import { loadConfig } from "maw-js/config";
 import {
   deletePending,
   loadPending,
   loadPendingById,
   updatePending,
   type PendingMessage,
-} from "../../shared/queue-store";
+} from "maw-js/commands/shared/queue-store";
 
 // Re-export queue-store helpers so callers can import from one place.
 export {
@@ -20,8 +20,8 @@ export {
   pendingPath,
   isExpired,
   TTL_MS,
-} from "../../shared/queue-store";
-export type { PendingMessage } from "../../shared/queue-store";
+} from "maw-js/commands/shared/queue-store";
+export type { PendingMessage } from "maw-js/commands/shared/queue-store";
 
 // File naming: YYYY-MM-DD_HH-MM_<from>_<slug>.md
 // Frontmatter: from / to / timestamp / read

--- a/plugins/inbox/index.ts
+++ b/plugins/inbox/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import {
   cmdInboxLs,
   cmdInboxMarkRead,

--- a/plugins/incubate/index.ts
+++ b/plugins/incubate/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "incubate",

--- a/plugins/init/impl.ts
+++ b/plugins/init/impl.ts
@@ -1,6 +1,6 @@
 import { homedir, hostname } from "os";
 import { existsSync, readdirSync } from "fs";
-import { CONFIG_FILE, FLEET_DIR } from "../../../core/paths";
+import { CONFIG_FILE, FLEET_DIR } from "maw-js/core/paths";
 import { runPromptLoop, ttyAsk, type AskFn } from "./prompts";
 import { parseNonInteractive } from "./non-interactive";
 import {

--- a/plugins/init/index.ts
+++ b/plugins/init/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdInit } from "./impl";
 
 export const command = {

--- a/plugins/init/internal/install-extraction.ts
+++ b/plugins/init/internal/install-extraction.ts
@@ -2,12 +2,12 @@
  * install-impl seam: tarball extraction, URL download, artifact hash verify.
  */
 
-import type { PluginManifest } from "../../../../plugin/types";
+import type { PluginManifest } from "maw-js/plugin/types";
 import { spawnSync } from "child_process";
 import { existsSync, mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { basename, join } from "path";
-import { hashFile } from "../../../../plugin/registry";
+import { hashFile } from "maw-js/plugin/registry";
 
 const MAX_DOWNLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
 

--- a/plugins/init/internal/install-manifest-helpers.ts
+++ b/plugins/init/internal/install-manifest-helpers.ts
@@ -2,11 +2,11 @@
  * install-impl seam: manifest reading + success printing helpers.
  */
 
-import type { PluginManifest } from "../../../../plugin/types";
+import type { PluginManifest } from "maw-js/plugin/types";
 import { existsSync, readFileSync, readdirSync, statSync } from "fs";
 import { join } from "path";
-import { parseManifest } from "../../../../plugin/manifest";
-import { runtimeSdkVersion } from "../../../../plugin/registry";
+import { parseManifest } from "maw-js/plugin/manifest";
+import { runtimeSdkVersion } from "maw-js/plugin/registry";
 
 /**
  * #864 — Resolve the plugin root inside an extracted staging dir.

--- a/plugins/init/internal/plugin-lock.ts
+++ b/plugins/init/internal/plugin-lock.ts
@@ -13,7 +13,7 @@
 import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { hashFile } from "../../../../plugin/registry";
+import { hashFile } from "maw-js/plugin/registry";
 import { readManifest } from "./install-manifest-helpers";
 import { extractTarball } from "./install-extraction";
 import { mkdtempSync, rmSync } from "fs";

--- a/plugins/init/non-interactive.ts
+++ b/plugins/init/non-interactive.ts
@@ -1,4 +1,4 @@
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 import { validateNodeName, validatePeerUrl, validatePeerName, validateGhqRoot } from "./prompts";
 
 export interface NonInteractiveOpts {

--- a/plugins/init/write-config.ts
+++ b/plugins/init/write-config.ts
@@ -1,6 +1,6 @@
 import { copyFileSync, existsSync, mkdirSync, writeFileSync } from "fs";
 import { dirname } from "path";
-import type { MawConfig } from "../../../config/types";
+import type { MawConfig } from "maw-js/config/types";
 
 /** Atomically write JSON config; throws EEXIST if `wx` flag and file exists. */
 export function writeConfigAtomic(filePath: string, config: Partial<MawConfig>, overwrite: boolean): void {

--- a/plugins/kill/impl.ts
+++ b/plugins/kill/impl.ts
@@ -1,5 +1,5 @@
-import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 
 export interface KillOpts {
   /** Pane index — narrows kill to a specific pane of the resolved window. */

--- a/plugins/kill/index.ts
+++ b/plugins/kill/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdKill } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "kill",

--- a/plugins/learn/index.ts
+++ b/plugins/learn/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "learn",

--- a/plugins/locate/impl.ts
+++ b/plugins/locate/impl.ts
@@ -13,11 +13,11 @@
 
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "../../../core/ghq";
-import { listSessions, FLEET_DIR } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
-import { UserError } from "../../../core/util/user-error";
+import { ghqFind } from "maw-js/core/ghq";
+import { listSessions, FLEET_DIR } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { UserError } from "maw-js/core/util/user-error";
 
 export interface LocateOpts {
   path?: boolean;

--- a/plugins/locate/index.ts
+++ b/plugins/locate/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdLocate } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "locate",

--- a/plugins/locate/locate.test.ts
+++ b/plugins/locate/locate.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, test, expect } from "bun:test";
 import handler, { command } from "./index";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 function makeCtx(args: string[]): InvokeContext {
   return {

--- a/plugins/ls/index.ts
+++ b/plugins/ls/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdList } from "../../shared/comm";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdList } from "maw-js/commands/shared/comm";
 
 export const command = { name: "ls", description: "List all agents and their status." };
 

--- a/plugins/mega/impl.ts
+++ b/plugins/mega/impl.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { tmux } from "../../../sdk";
+import { tmux } from "maw-js/sdk";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
 const TASKS_DIR = join(homedir(), ".claude/tasks");

--- a/plugins/mega/index.ts
+++ b/plugins/mega/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdMegaStatus, cmdMegaStop } from "./impl";
 
 export const command = {

--- a/plugins/mega/mega.test.ts
+++ b/plugins/mega/mega.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import handler, { command } from "./index";
 
 describe("mega plugin — smoke", () => {

--- a/plugins/on/index.ts
+++ b/plugins/on/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "on",

--- a/plugins/overview/impl.ts
+++ b/plugins/overview/impl.ts
@@ -1,7 +1,7 @@
-import { listSessions, hostExec } from "../../../sdk";
-import { tmux } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import type { Session } from "../../../sdk";
+import { listSessions, hostExec } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import type { Session } from "maw-js/sdk";
 
 export interface OverviewTarget {
   session: string;

--- a/plugins/overview/index.ts
+++ b/plugins/overview/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdOverview } from "./impl";
 
 export const command = {

--- a/plugins/pair/impl.ts
+++ b/plugins/pair/impl.ts
@@ -4,7 +4,7 @@
  * Both paths end with cmdAdd() so peers.json has reciprocal aliases.
  */
 
-import { loadConfig } from "../../../config";
+import { loadConfig } from "maw-js/config";
 import { cmdAdd } from "./internal/peers-impl";
 import { postHandshake, warnIfPlainHttp } from "./handshake";
 import { normalize, isValidShape, redact } from "./codes";

--- a/plugins/pair/index.ts
+++ b/plugins/pair/index.ts
@@ -5,7 +5,7 @@
  *   maw pair generate [--expires <sec>]   — recipient: mint code, listen
  *   maw pair <url> <code>                 — initiator: post to remote server
  */
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "pair",

--- a/plugins/panes/impl.ts
+++ b/plugins/panes/impl.ts
@@ -1,5 +1,5 @@
-import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 
 export interface PanesOpts {
   /** Include a PID column (for /proc inspection / ghost detection). */

--- a/plugins/panes/index.ts
+++ b/plugins/panes/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdPanes } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "panes",

--- a/plugins/peek/index.ts
+++ b/plugins/peek/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdPeek } from "../../shared/comm";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdPeek } from "maw-js/commands/shared/comm";
 
 export const command = { name: "peek", description: "Peek at an agent's latest output." };
 

--- a/plugins/peers/index.ts
+++ b/plugins/peers/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "peers",

--- a/plugins/ping/impl.ts
+++ b/plugins/ping/impl.ts
@@ -1,5 +1,5 @@
-import { loadConfig, cfgTimeout } from "../../../config";
-import { curlFetch } from "../../../sdk";
+import { loadConfig, cfgTimeout } from "maw-js/config";
+import { curlFetch } from "maw-js/sdk";
 
 export async function cmdPing(node?: string) {
   const config = loadConfig();

--- a/plugins/ping/index.ts
+++ b/plugins/ping/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdPing } from "./impl";
 
 export const command = {

--- a/plugins/ping/ping.test.ts
+++ b/plugins/ping/ping.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 const { mockConfigModule } = await import("../../../../test/helpers/mock-config");

--- a/plugins/pr/impl.ts
+++ b/plugins/pr/impl.ts
@@ -1,4 +1,4 @@
-import { Tmux } from "../../../core/transport/tmux";
+import { Tmux } from "maw-js/core/transport/tmux";
 
 function branchToTitle(branch: string): string {
   // Strip prefix like "agents/" or "feature/"

--- a/plugins/pr/index.ts
+++ b/plugins/pr/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdPr } from "./impl";
 
 export const command = {

--- a/plugins/pr/pr.test.ts
+++ b/plugins/pr/pr.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 import handler, { command } from "./index";
 
 describe("pr plugin — smoke", () => {

--- a/plugins/profile/impl.ts
+++ b/plugins/profile/impl.ts
@@ -16,8 +16,8 @@ import {
   loadAllProfiles,
   loadProfile,
   setActiveProfile,
-} from "../../../lib/profile-loader";
-import type { TProfile } from "../../../lib/schemas";
+} from "maw-js/lib/profile-loader";
+import type { TProfile } from "maw-js/lib/schemas";
 
 export function cmdList(): TProfile[] {
   return loadAllProfiles();

--- a/plugins/profile/index.ts
+++ b/plugins/profile/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "profile",

--- a/plugins/project/index.ts
+++ b/plugins/project/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "project",

--- a/plugins/pulse/index.ts
+++ b/plugins/pulse/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "pulse",

--- a/plugins/restart/impl.ts
+++ b/plugins/restart/impl.ts
@@ -10,11 +10,11 @@
  *   4. Wake fleet (maw wake all)
  */
 
-import { listSessions } from "../../../sdk";
-import { Tmux } from "../../../sdk";
-import { cmdSleep, cmdWakeAll } from "../../shared/fleet";
+import { listSessions } from "maw-js/sdk";
+import { Tmux } from "maw-js/sdk";
+import { cmdSleep, cmdWakeAll } from "maw-js/commands/shared/fleet";
 import { execSync } from "child_process";
-import { ghqFindSync } from "../../../core/ghq";
+import { ghqFindSync } from "maw-js/core/ghq";
 
 const HELP_TEXT = [
   "usage: maw restart [--no-update] [--ref <git-ref>]",

--- a/plugins/restart/index.ts
+++ b/plugins/restart/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdRestart } from "./impl";
 
 /** Dual-dispatcher ctx: old plugin/registry.ts passes InvokeContext;

--- a/plugins/resume/impl.ts
+++ b/plugins/resume/impl.ts
@@ -15,7 +15,7 @@ import { mkdirSync, readFileSync, readdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
-import { tmux } from "../../../sdk";
+import { tmux } from "maw-js/sdk";
 
 const PARKED_DIR = join(homedir(), ".config/maw/parked");
 

--- a/plugins/resume/index.ts
+++ b/plugins/resume/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "resume",

--- a/plugins/reunion/impl.ts
+++ b/plugins/reunion/impl.ts
@@ -1,4 +1,4 @@
-import { listSessions, hostExec } from "../../../sdk";
+import { listSessions, hostExec } from "maw-js/sdk";
 import { existsSync, readdirSync, copyFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 

--- a/plugins/reunion/index.ts
+++ b/plugins/reunion/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdReunion } from "./impl";
 
 export const command = {

--- a/plugins/run/impl.ts
+++ b/plugins/run/impl.ts
@@ -12,9 +12,9 @@
  *   maw run <target> "<cmd>"
  */
 
-import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import { resolveOraclePane } from "../../shared/comm-send";
+import { listSessions, resolveTarget, Tmux, curlFetch } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
 
 export interface RunOpts {
   target: string;

--- a/plugins/run/index.ts
+++ b/plugins/run/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdRun, parseRunArgs } from "./impl";
 
 export const command = {

--- a/plugins/scope/impl.ts
+++ b/plugins/scope/impl.ts
@@ -22,7 +22,7 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import type { TScope } from "../../../lib/schemas";
+import type { TScope } from "maw-js/lib/schemas";
 
 // Scope name validation — same alphabet as peers aliases. Slug-safe so the
 // name can double as a filename without escaping.

--- a/plugins/scope/index.ts
+++ b/plugins/scope/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "scope",

--- a/plugins/send-enter/impl.ts
+++ b/plugins/send-enter/impl.ts
@@ -12,9 +12,9 @@
  *   maw send-enter <target> --N 3    # send N Enters
  */
 
-import { listSessions, resolveTarget, tmux } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import { resolveOraclePane } from "../../shared/comm-send";
+import { listSessions, resolveTarget, tmux } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
 
 export interface SendEnterOpts {
   target: string;

--- a/plugins/send-enter/index.ts
+++ b/plugins/send-enter/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdSendEnter, parseSendEnterArgs } from "./impl";
 
 export const command = {

--- a/plugins/send/impl.ts
+++ b/plugins/send/impl.ts
@@ -13,9 +13,9 @@
  *   maw send <target> "<text>"
  */
 
-import { listSessions, resolveTarget, Tmux, curlFetch } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import { resolveOraclePane } from "../../shared/comm-send";
+import { listSessions, resolveTarget, Tmux, curlFetch } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
 
 export interface SendOpts {
   target: string;

--- a/plugins/send/index.ts
+++ b/plugins/send/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdSend, parseSendArgs } from "./impl";
 
 export const command = {

--- a/plugins/signals/index.ts
+++ b/plugins/signals/index.ts
@@ -1,7 +1,7 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
-import { scanSignals } from "../../shared/scan-signals";
-import type { ScannedSignal } from "../../shared/scan-signals";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { scanSignals } from "maw-js/commands/shared/scan-signals";
+import type { ScannedSignal } from "maw-js/commands/shared/scan-signals";
 
 export const command = {
   name: "signals",

--- a/plugins/sleep/impl.ts
+++ b/plugins/sleep/impl.ts
@@ -1,10 +1,10 @@
-import { tmux } from "../../../sdk";
-import { detectSession } from "../../shared/wake";
-import { saveTabOrder } from "../../../sdk";
+import { tmux } from "maw-js/sdk";
+import { detectSession } from "maw-js/commands/shared/wake";
+import { saveTabOrder } from "maw-js/sdk";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
-import { takeSnapshot } from "../../../sdk";
+import { takeSnapshot } from "maw-js/sdk";
 
 /**
  * maw sleep <oracle> [window]

--- a/plugins/sleep/index.ts
+++ b/plugins/sleep/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdSleepOne } from "./impl";
 
 export const command = {

--- a/plugins/sleep/sleep.test.ts
+++ b/plugins/sleep/sleep.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/soul-sync/impl.ts
+++ b/plugins/soul-sync/impl.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "fs";
 import { join, basename } from "path";
-import { hostExec } from "../../../sdk";
-import { getGhqRoot } from "../../../config/ghq-root";
+import { hostExec } from "maw-js/sdk";
+import { getGhqRoot } from "maw-js/config/ghq-root";
 import { findPeers, findProjectsForOracle, syncOracleVaults, syncProjectVault, reportProjectResult, type SoulSyncResult, type ProjectSyncResult } from "./sync-helpers";
 import { resolveOraclePath, resolveProjectSlug, findOracleForProject } from "./resolve";
 

--- a/plugins/soul-sync/index.ts
+++ b/plugins/soul-sync/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "soul-sync",

--- a/plugins/soul-sync/resolve.ts
+++ b/plugins/soul-sync/resolve.ts
@@ -1,8 +1,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
-import { ghqFind } from "../../../core/ghq";
-import { getGhqRoot } from "../../../config/ghq-root";
-import { loadFleet } from "../../shared/fleet-load";
+import { ghqFind } from "maw-js/core/ghq";
+import { getGhqRoot } from "maw-js/config/ghq-root";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 /**
  * Resolve ghq path for an oracle name.

--- a/plugins/soul-sync/sync-helpers.ts
+++ b/plugins/soul-sync/sync-helpers.ts
@@ -1,6 +1,6 @@
 import { existsSync, readdirSync, copyFileSync, mkdirSync, appendFileSync } from "fs";
 import { join } from "path";
-import { loadFleet } from "../../shared/fleet-load";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
 
 const SYNC_DIRS = ["memory/learnings", "memory/retrospectives", "memory/traces", "memory/collaborations"];
 

--- a/plugins/split/impl.ts
+++ b/plugins/split/impl.ts
@@ -1,6 +1,6 @@
-import { listSessions, hostExec, withPaneLock } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
-import { normalizeTarget } from "../../../core/matcher/normalize-target";
+import { listSessions, hostExec, withPaneLock } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 
 export interface SplitOpts {
   /** Split percentage (1-99). Default: 50. */

--- a/plugins/split/index.ts
+++ b/plugins/split/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdSplit } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "split",

--- a/plugins/stop/index.ts
+++ b/plugins/stop/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { cmdSleep } from "../../shared/fleet";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdSleep } from "maw-js/commands/shared/fleet";
 
 export const command = {
   name: ["stop", "rest"],

--- a/plugins/stop/stop.test.ts
+++ b/plugins/stop/stop.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/swarm/index.ts
+++ b/plugins/swarm/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "swarm",

--- a/plugins/tab/impl.ts
+++ b/plugins/tab/impl.ts
@@ -1,6 +1,6 @@
-import { hostExec } from "../../../sdk";
-import { tmux, tmuxCmd } from "../../../sdk";
-import { cmdPeek, cmdSend } from "../../shared/comm";
+import { hostExec } from "maw-js/sdk";
+import { tmux, tmuxCmd } from "maw-js/sdk";
+import { cmdPeek, cmdSend } from "maw-js/commands/shared/comm";
 import { cmdTalkTo } from "./internal/talk-to-impl";
 
 /**

--- a/plugins/tab/index.ts
+++ b/plugins/tab/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "tab",

--- a/plugins/tab/internal/talk-to-impl.ts
+++ b/plugins/tab/internal/talk-to-impl.ts
@@ -1,7 +1,7 @@
-import { loadConfig } from "../../../../config";
-import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../../sdk";
-import { runHook } from "../../../../sdk";
-import { resolveOraclePane } from "../../../shared/comm-send";
+import { loadConfig } from "maw-js/config";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "maw-js/sdk";
+import { runHook } from "maw-js/sdk";
+import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir, hostname } from "os";
 import { join } from "path";

--- a/plugins/tag/impl.ts
+++ b/plugins/tag/impl.ts
@@ -1,5 +1,5 @@
-import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 
 export interface TagOpts {
   /** Pane index within the target window (default: active pane of the window). */

--- a/plugins/tag/index.ts
+++ b/plugins/tag/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdTag } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "tag",

--- a/plugins/take/impl.ts
+++ b/plugins/take/impl.ts
@@ -1,6 +1,6 @@
-import { listSessions, hostExec } from "../../../sdk";
-import { tmux } from "../../../sdk";
-import { buildCommandInDir } from "../../../config";
+import { listSessions, hostExec } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
+import { buildCommandInDir } from "maw-js/config";
 
 /**
  * maw take <source-session>:<window> [target-session]

--- a/plugins/take/index.ts
+++ b/plugins/take/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdTake } from "./impl";
 
 export const command = {

--- a/plugins/take/take.test.ts
+++ b/plugins/take/take.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 const root = join(import.meta.dir, "../../..");
 

--- a/plugins/talk-to/impl.ts
+++ b/plugins/talk-to/impl.ts
@@ -1,7 +1,7 @@
-import { loadConfig } from "../../../config";
-import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "../../../sdk";
-import { runHook } from "../../../sdk";
-import { resolveOraclePane } from "../../shared/comm-send";
+import { loadConfig } from "maw-js/config";
+import { listSessions, sendKeys, getPaneCommand, resolveTarget } from "maw-js/sdk";
+import { runHook } from "maw-js/sdk";
+import { resolveOraclePane } from "maw-js/commands/shared/comm-send";
 import { appendFile, mkdir } from "fs/promises";
 import { homedir, hostname } from "os";
 import { join } from "path";

--- a/plugins/talk-to/index.ts
+++ b/plugins/talk-to/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdTalkTo } from "./impl";
 
 export const command = { name: "talk-to", description: "Talk to a remote agent on another node." };

--- a/plugins/team/impl.ts
+++ b/plugins/team/impl.ts
@@ -1,6 +1,6 @@
 import { readdirSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { tmux } from "../../../sdk";
+import { tmux } from "maw-js/sdk";
 import { TEAMS_DIR, loadTeam, resolvePsi } from "./team-helpers";
 import { findZombiePanes } from "./team-cleanup-zombies";
 

--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -6,7 +6,7 @@ import {
   cmdTeamShutdown, cmdTeamList, cmdTeamCreate, cmdTeamSpawn,
   cmdTeamSend, cmdTeamResume, cmdTeamLives,
 } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "team",

--- a/plugins/team/oracle-members.ts
+++ b/plugins/team/oracle-members.ts
@@ -14,7 +14,7 @@
  */
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { CONFIG_DIR } from "../../../core/paths";
+import { CONFIG_DIR } from "maw-js/core/paths";
 
 // ─── Types ───
 

--- a/plugins/team/team-cleanup-zombies.ts
+++ b/plugins/team/team-cleanup-zombies.ts
@@ -1,8 +1,8 @@
 import { readdirSync, existsSync } from "fs";
 import { join } from "path";
-import { tmux } from "../../../sdk";
-import type { TmuxPane } from "../../../sdk";
-import { loadFleetEntries } from "../../shared/fleet-load";
+import { tmux } from "maw-js/sdk";
+import type { TmuxPane } from "maw-js/sdk";
+import { loadFleetEntries } from "maw-js/commands/shared/fleet-load";
 import { TEAMS_DIR, loadTeam } from "./team-helpers";
 
 // ─── maw cleanup --zombie-agents ───

--- a/plugins/team/team-invite.ts
+++ b/plugins/team/team-invite.ts
@@ -24,8 +24,8 @@
  */
 import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
-import { loadConfig } from "../../../config";
-import { isTrusted, requestConsent } from "../../../core/consent";
+import { loadConfig } from "maw-js/config";
+import { isTrusted, requestConsent } from "maw-js/core/consent";
 import { resolvePsi } from "./team-helpers";
 
 export interface TeamInviteOptions {

--- a/plugins/team/team-lifecycle.ts
+++ b/plugins/team/team-lifecycle.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, writeFileSync, existsSync, mkdirSync, copyFileSync } from "fs";
 import { join } from "path";
-import { tmux } from "../../../sdk";
-import { assertValidOracleName } from "../../../core/fleet/validate";
+import { tmux } from "maw-js/sdk";
+import { assertValidOracleName } from "maw-js/core/fleet/validate";
 import { TEAMS_DIR, loadTeam, resolvePsi, writeShutdownRequest, cleanupTeamDir, type TeamConfig, type TeamMember } from "./team-helpers";
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));

--- a/plugins/team/team-status.ts
+++ b/plugins/team/team-status.ts
@@ -1,7 +1,7 @@
 import { existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { hostExec } from "../../../sdk";
+import { hostExec } from "maw-js/sdk";
 import { cmdTeamTaskList, type MawTask } from "./task-ops";
 import { loadTeam } from "./impl";
 

--- a/plugins/triggers/index.ts
+++ b/plugins/triggers/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "triggers",

--- a/plugins/trust/index.ts
+++ b/plugins/trust/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "trust",

--- a/plugins/ui/impl-helpers.ts
+++ b/plugins/ui/impl-helpers.ts
@@ -8,8 +8,8 @@
 import { existsSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { loadConfig } from "../../../config";
-import { ghqFindSync } from "../../../core/ghq";
+import { loadConfig } from "maw-js/config";
+import { ghqFindSync } from "maw-js/core/ghq";
 
 // ---- Constants -----------------------------------------------------------
 

--- a/plugins/ui/impl-render.ts
+++ b/plugins/ui/impl-render.ts
@@ -14,7 +14,7 @@ import {
   justHost,
   buildTunnelCommand,
 } from "./impl-helpers";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 /**
  * Render the full output that `maw ui` prints, given the parsed options.

--- a/plugins/ui/index.ts
+++ b/plugins/ui/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "ui",

--- a/plugins/view/impl.ts
+++ b/plugins/view/impl.ts
@@ -1,8 +1,8 @@
-import { listSessions } from "../../../sdk";
-import { Tmux, tmuxCmd, resolveSocket } from "../../../sdk";
-import { loadConfig } from "../../../config";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
-import { logAnomaly } from "../../../core/fleet/audit";
+import { listSessions } from "maw-js/sdk";
+import { Tmux, tmuxCmd, resolveSocket } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { logAnomaly } from "maw-js/core/fleet/audit";
 import { execFileSync } from "child_process";
 import { ttyAsk } from "./internal/prompts";
 

--- a/plugins/view/index.ts
+++ b/plugins/view/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 
 export const command = {
   name: "view",

--- a/plugins/view/internal/split-impl.ts
+++ b/plugins/view/internal/split-impl.ts
@@ -1,6 +1,6 @@
-import { listSessions, hostExec, withPaneLock } from "../../../../sdk";
-import { resolveSessionTarget } from "../../../../core/matcher/resolve-target";
-import { normalizeTarget } from "../../../../core/matcher/normalize-target";
+import { listSessions, hostExec, withPaneLock } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
+import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 
 export interface SplitOpts {
   /** Split percentage (1-99). Default: 50. */

--- a/plugins/wake/index.ts
+++ b/plugins/wake/index.ts
@@ -1,5 +1,5 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "wake",

--- a/plugins/wake/wake.test.ts
+++ b/plugins/wake/wake.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { join } from "path";
-import type { InvokeContext } from "../../../plugin/types";
+import type { InvokeContext } from "maw-js/plugin/types";
 
 let lastWakeCall: { oracle: string; opts: any } | null = null;
 let lastWakeAllCall: { opts: any } | null = null;

--- a/plugins/whoami/impl.ts
+++ b/plugins/whoami/impl.ts
@@ -1,5 +1,5 @@
-import { hostExec } from "../../../sdk";
-import { UserError } from "../../../core/util/user-error";
+import { hostExec } from "maw-js/sdk";
+import { UserError } from "maw-js/core/util/user-error";
 
 /**
  * maw whoami — print the current tmux session name on stdout.

--- a/plugins/whoami/index.ts
+++ b/plugins/whoami/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdWhoami } from "./impl";
 
 export const command = { name: "whoami", description: "Print the current tmux session name." };

--- a/plugins/workon/impl.ts
+++ b/plugins/workon/impl.ts
@@ -1,9 +1,9 @@
-import { hostExec } from "../../../sdk";
-import { tmux } from "../../../sdk";
-import { ghqFind } from "../../../core/ghq";
-import { buildCommand } from "../../../config";
-import { findWorktrees } from "../../shared/wake";
-import { resolveWorktreeTarget } from "../../../core/matcher/resolve-target";
+import { hostExec } from "maw-js/sdk";
+import { tmux } from "maw-js/sdk";
+import { ghqFind } from "maw-js/core/ghq";
+import { buildCommand } from "maw-js/config";
+import { findWorktrees } from "maw-js/commands/shared/wake";
+import { resolveWorktreeTarget } from "maw-js/core/matcher/resolve-target";
 
 async function resolveRepo(repo: string): Promise<{ repoPath: string; repoName: string; parentDir: string }> {
   // Support "org/repo" or bare "repo" — always search by last segment

--- a/plugins/workon/index.ts
+++ b/plugins/workon/index.ts
@@ -1,4 +1,4 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdWorkon } from "./impl";
 
 export const command = {

--- a/plugins/workspace/index.ts
+++ b/plugins/workspace/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
-import { parseFlags } from "../../../cli/parse-args";
-import { cmdWorkspaceCreate, cmdWorkspaceJoin, cmdWorkspaceShare, cmdWorkspaceUnshare, cmdWorkspaceLs, cmdWorkspaceAgents, cmdWorkspaceInvite, cmdWorkspaceLeave, cmdWorkspaceStatus } from "../../shared/workspace";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { cmdWorkspaceCreate, cmdWorkspaceJoin, cmdWorkspaceShare, cmdWorkspaceUnshare, cmdWorkspaceLs, cmdWorkspaceAgents, cmdWorkspaceInvite, cmdWorkspaceLeave, cmdWorkspaceStatus } from "maw-js/commands/shared/workspace";
 
 export const command = {
   name: ["workspace", "ws"],

--- a/plugins/zoom/impl.ts
+++ b/plugins/zoom/impl.ts
@@ -1,5 +1,5 @@
-import { listSessions, hostExec, tmuxCmd } from "../../../sdk";
-import { resolveSessionTarget } from "../../../core/matcher/resolve-target";
+import { listSessions, hostExec, tmuxCmd } from "maw-js/sdk";
+import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 
 export interface ZoomOpts {
   /** Pane index within the resolved window. Default: current/first. */

--- a/plugins/zoom/index.ts
+++ b/plugins/zoom/index.ts
@@ -1,6 +1,6 @@
-import type { InvokeContext, InvokeResult } from "../../../plugin/types";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdZoom } from "./impl";
-import { parseFlags } from "../../../cli/parse-args";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "zoom",

--- a/scripts/lint-imports.sh
+++ b/scripts/lint-imports.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# lint-imports.sh — detect relative imports that escape the plugin directory
+#
+# Registry plugins must import maw-js internals via subpath exports:
+#   import { cmdList } from "maw-js/commands/shared/comm"   ✓
+#   import { cmdList } from "../../shared/comm"              ✗
+#
+# Why: relative paths only resolve when the plugin lives inside the maw-js
+# source tree. Once extracted to the registry, those paths break at runtime.
+#
+# Usage:
+#   bash scripts/lint-imports.sh          # check all plugins
+#   bash scripts/lint-imports.sh --fix    # show what to replace (no auto-fix)
+
+set -euo pipefail
+
+REGISTRY_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PLUGINS_DIR="$REGISTRY_DIR/plugins"
+
+# Match imports like: from "../../shared/..." or from "../../../plugin/..."
+# These are relative paths that escape the plugin's own directory.
+PATTERN='from ["'"'"']\.\./\.\.'
+
+VIOLATIONS=$(grep -rn "$PATTERN" "$PLUGINS_DIR" --include='*.ts' 2>/dev/null || true)
+
+if [ -z "$VIOLATIONS" ]; then
+  echo "✓ no escaping relative imports found"
+  exit 0
+fi
+
+COUNT=$(echo "$VIOLATIONS" | wc -l | tr -d ' ')
+echo ""
+echo "✗ found $COUNT relative imports that escape the plugin directory"
+echo ""
+echo "  These imports only resolve inside the maw-js source tree."
+echo "  Use subpath exports instead:"
+echo ""
+echo "    ../../shared/comm         → maw-js/commands/shared/comm"
+echo "    ../../../plugin/types     → maw-js/plugin/types"
+echo "    ../../../cli/parse-args   → maw-js/cli/parse-args"
+echo "    ../../../sdk              → maw-js/sdk"
+echo "    ../../../config           → (add to maw-js exports if needed)"
+echo ""
+
+echo "$VIOLATIONS" | while IFS= read -r line; do
+  # Strip the registry dir prefix for readability
+  echo "  ${line#$REGISTRY_DIR/}"
+done
+
+echo ""
+echo "  Available maw-js subpath exports:"
+node -e "const p=require('$REGISTRY_DIR/node_modules/maw-js/package.json'); Object.keys(p.exports||{}).forEach(k=>console.log('    '+k))" 2>/dev/null || true
+echo ""
+
+exit 1


### PR DESCRIPTION
## Summary

- Replaced all 306 escaping relative imports across 169 plugin files with `maw-js/...` subpath exports
- Added `package.json` with `file:../maw-js` dependency so imports resolve
- Added `scripts/lint-imports.sh` to catch regressions

Before: `from "../../shared/comm"` (breaks outside maw-js source tree)
After: `from "maw-js/commands/shared/comm"` (resolves via subpath exports)

Companion PR: Soul-Brews-Studio/maw-js#1070 (adds 30 subpath exports)

## Test plan

- [x] `scripts/lint-imports.sh` — 0 violations
- [x] `maw ls` works after rebuild
- [x] `maw oracle ls --json` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)