### PR TITLE
fix: migrate 28 dynamic imports to subpath exports

### DIFF
--- a/plugins/bud/bud-wake.ts
+++ b/plugins/bud/bud-wake.ts
@@ -80,7 +80,7 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   // #835 — consult unified shouldAutoWake helper. bud's policy is "always
   // wake" — a freshly-cloned bud has no session yet and the whole point of
   // bud is to spawn one. The helper makes that explicit and auditable.
-  const { shouldAutoWake } = await import("../../shared/should-auto-wake");
+  const { shouldAutoWake } = await import("maw-js/commands/shared/should-auto-wake");
   const decision = shouldAutoWake(name, { site: "bud" });
   if (!decision.wake) {
     // Defensive — site=bud never returns wake=false today. Preserve the
@@ -93,14 +93,14 @@ export async function finalizeBud(ctx: BudFinalizeCtx): Promise<void> {
   // which would match any same-named repo in any org (stale-clone bug).
   const wakeOpts: any = { noAttach: true, repoPath: budRepoPath };
   if (opts.issue) {
-    const { fetchIssuePrompt } = await import("../../shared/wake");
+    const { fetchIssuePrompt } = await import("maw-js/commands/shared/wake");
     wakeOpts.prompt = await fetchIssuePrompt(opts.issue, `${org}/${budRepoName}`);
     wakeOpts.task = `issue-${opts.issue}`;
   }
   if (opts.repo) {
     // Clone the target repo via ghq (resolve-first, no worktree).
     // Previously set wakeOpts.incubate which auto-created a worktree — see #271.
-    const { ensureCloned } = await import("../../shared/wake-target");
+    const { ensureCloned } = await import("maw-js/commands/shared/wake-target");
     await ensureCloned(opts.repo);
   }
   try {

--- a/plugins/federation/index.ts
+++ b/plugins/federation/index.ts
@@ -24,17 +24,17 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     if (!sub || sub === "status" || sub === "ls") {
       if (args.includes("--verify")) {
-        const { cmdFederationStatusVerify } = await import("../../shared/federation");
+        const { cmdFederationStatusVerify } = await import("maw-js/commands/shared/federation");
         const res = await cmdFederationStatusVerify();
         if (!res.ok) {
           return { ok: false, error: "one or more pairs are non-healthy", output: logs.join("\n") || undefined };
         }
       } else {
-        const { cmdFederationStatus } = await import("../../shared/federation");
+        const { cmdFederationStatus } = await import("maw-js/commands/shared/federation");
         await cmdFederationStatus();
       }
     } else if (sub === "sync") {
-      const { cmdFederationSync } = await import("../../shared/federation-sync");
+      const { cmdFederationSync } = await import("maw-js/commands/shared/federation-sync");
       await cmdFederationSync({
         dryRun: args.includes("--dry-run"),
         check: args.includes("--check"),

--- a/plugins/inbox/impl.ts
+++ b/plugins/inbox/impl.ts
@@ -268,7 +268,7 @@ export async function cmdApprove(idOrPrefix: string): Promise<PendingMessage> {
   // Re-issue the send. Use the original query string when present (preserves
   // node prefix routing); fall back to target name otherwise.
   const query = updated.query ?? updated.target;
-  const { cmdSend } = await import("../../shared/comm-send");
+  const { cmdSend } = await import("maw-js/commands/shared/comm-send");
   // Pass `force=true` plus a sentinel to bypass ACL on the second pass:
   // the human approval IS the gate — re-checking here would loop forever.
   process.env.MAW_ACL_BYPASS = "1";

--- a/plugins/on/index.ts
+++ b/plugins/on/index.ts
@@ -6,7 +6,7 @@ export const command = {
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const { loadConfig, saveConfig } = await import("../../../config");
+  const { loadConfig, saveConfig } = await import("maw-js/config");
 
   const logs: string[] = [];
   const origLog = console.log;

--- a/plugins/pulse/index.ts
+++ b/plugins/pulse/index.ts
@@ -42,14 +42,14 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           error: 'usage: maw pulse add "task title" --oracle <name> [--wt <repo>]',
         };
       }
-      const { cmdPulseAdd } = await import("../../shared/pulse");
+      const { cmdPulseAdd } = await import("maw-js/commands/shared/pulse");
       await cmdPulseAdd(title, pulseOpts);
     } else if (subcmd === "ls" || subcmd === "list") {
       const sync = args.includes("--sync");
-      const { cmdPulseLs } = await import("../../shared/pulse");
+      const { cmdPulseLs } = await import("maw-js/commands/shared/pulse");
       await cmdPulseLs({ sync });
     } else if (subcmd === "cleanup" || subcmd === "clean") {
-      const { scanWorktrees, cleanupWorktree } = await import("../../../worktrees");
+      const { scanWorktrees, cleanupWorktree } = await import("maw-js/worktrees");
       const worktrees = await scanWorktrees();
       const stale = worktrees.filter(wt => wt.status !== "active");
       if (!stale.length) {

--- a/plugins/swarm/index.ts
+++ b/plugins/swarm/index.ts
@@ -67,7 +67,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       nextAgentColor, colorAnsi, stylePaneBorder, enableBorderStatus,
       applyTeamLayout, applyTiledLayout, getWindowTarget,
     } = await import("../tmux/layout-manager");
-    const { hostExec, withPaneLock } = await import("../../../sdk");
+    const { hostExec, withPaneLock } = await import("maw-js/sdk");
     const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import("fs");
     const { join } = await import("path");
     const { homedir } = await import("os");

--- a/plugins/team/team-lifecycle.ts
+++ b/plugins/team/team-lifecycle.ts
@@ -253,7 +253,7 @@ export async function cmdTeamSpawn(
       return;
     }
     try {
-      const { hostExec } = await import("../../../sdk");
+      const { hostExec } = await import("maw-js/sdk");
       const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       await hostExec(`tmux split-window -h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
       console.log();

--- a/plugins/triggers/index.ts
+++ b/plugins/triggers/index.ts
@@ -6,7 +6,7 @@ export const command = {
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const { cmdTriggers } = await import("../../shared/triggers");
+  const { cmdTriggers } = await import("maw-js/commands/shared/triggers");
 
   const logs: string[] = [];
   const origLog = console.log;

--- a/plugins/view/impl.ts
+++ b/plugins/view/impl.ts
@@ -111,8 +111,8 @@ export async function cmdView(
     let autoWake = extraOpts.wake;
     if (!autoWake && !extraOpts.noWake) {
       try {
-        const { resolveFleetSession } = await import("../../shared/wake-resolve");
-        const { shouldAutoWake } = await import("../../shared/should-auto-wake");
+        const { resolveFleetSession } = await import("maw-js/commands/shared/wake-resolve");
+        const { shouldAutoWake } = await import("maw-js/commands/shared/should-auto-wake");
         const isFleetKnown = Boolean(resolveFleetSession(agent));
         const decision = shouldAutoWake(agent, {
           site: "view",
@@ -150,7 +150,7 @@ export async function cmdView(
         const wakeImpl =
           extraOpts.wakeImpl ??
           (async (target: string) => {
-            const { cmdWake } = await import("../../shared/wake-cmd");
+            const { cmdWake } = await import("maw-js/commands/shared/wake-cmd");
             await cmdWake(target, { attach: true });
           });
         console.log(`\x1b[36m⚡\x1b[0m waking '${agent}'...`);

--- a/plugins/wake/index.ts
+++ b/plugins/wake/index.ts
@@ -8,10 +8,10 @@ export const command = {
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   // Dynamic imports — clean, one await, mockable
-  const { cmdWake } = await import("../../shared/wake");
-  const { cmdWakeAll } = await import("../../shared/fleet");
-  const { parseWakeTarget, ensureCloned } = await import("../../shared/wake-target");
-  const { fetchGitHubPrompt } = await import("../../shared/wake-resolve");
+  const { cmdWake } = await import("maw-js/commands/shared/wake");
+  const { cmdWakeAll } = await import("maw-js/commands/shared/fleet");
+  const { parseWakeTarget, ensureCloned } = await import("maw-js/commands/shared/wake-target");
+  const { fetchGitHubPrompt } = await import("maw-js/commands/shared/wake-resolve");
 
   const logs: string[] = [];
   const origLog = console.log;


### PR DESCRIPTION
Second pass — dynamic import() paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)