### PR TITLE
feat(bud): fleet-as-truth smart-default org resolution

### DIFF
--- a/plugins/bud/impl.ts
+++ b/plugins/bud/impl.ts
@@ -9,6 +9,7 @@ import { initVault, generateClaudeMd, configureFleet, writeBirthNote } from "./b
 import { finalizeBud } from "./bud-wake";
 import { writeSignal } from "maw-js/core/fleet/leaf";
 import { validateNickname, writeNickname, setCachedNickname } from "maw-js/core/fleet/nicknames";
+import { resolveOrg, formatOrgSource, type OrgResolution } from "./smart-default-org";
 import { join } from "path";
 
 export interface BudOpts {
@@ -40,10 +41,18 @@ export interface BudOpts {
  *
  * Yeast budding — any oracle can spawn a new oracle.
  *
- * Target org resolution (first wins):
+ * Target org resolution (first wins) — see ./smart-default-org.ts for impl:
  *   1. --org <org>                    — per-invocation override (#235)
- *   2. config.githubOrg               — per-machine default from config
- *   3. "Soul-Brews-Studio"            — hard-coded fallback
+ *   2. MAW_BUD_OWNER env              — per-shell override
+ *   3. config.githubOrg               — per-machine default from config
+ *   4. fleet most-recent (FTS-tier)   — smart default from local fleet history
+ *   5. gh api user (vector cold-start) — once per fresh machine when fleet empty
+ *   6. "Soul-Brews-Studio"            — ultimate fallback
+ *
+ * The fleet→gh→default chain is the FTS+vector retrieval pattern (mirrored
+ * from arra-oracle-v3): fast structural match first, slow authoritative
+ * fallback when needed. Future Phase 3 upgrades to parallel-merge with a
+ * confidence bonus — see follow-up issue.
  *
  * Note: --repo is an INCUBATION flag (seeds the bud from an existing local
  * project's ψ/), NOT a target-org override. Use --org to target a different
@@ -87,7 +96,16 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
 
   const config = loadConfig();
   const reposRoot = join(getGhqRoot(), "github.com");
-  const org = opts.org || config.githubOrg || "Soul-Brews-Studio";
+
+  // Resolve target org via the FTS+vector precedence chain (smart-default-org.ts).
+  // Echo line happens just before `gh repo create` in bud-repo.ts so the user
+  // can catch a wrong default before the destructive step.
+  const orgResolution: OrgResolution = await resolveOrg({
+    flag: opts.org,
+    env: process.env.MAW_BUD_OWNER,
+    config: config.githubOrg,
+  });
+  const org = orgResolution.org;
 
   // Resolve parent oracle (skip for --root)
   let parentName: string | null = opts.from || null;
@@ -142,6 +160,19 @@ export async function cmdBud(name: string, opts: BudOpts = {}) {
     }
     console.log();
     return;
+  }
+
+  // Echo the resolved org + source BEFORE the destructive `gh repo create`
+  // call, so the user can catch a wrong default (sticky-default trap) and
+  // ^C before any network side-effects fire. All 3 v3 evaluators converged
+  // on this as the essential mitigation against the recency-only ranking
+  // failure mode (e.g., personal-fork side-quest after months in
+  // Soul-Brews-Studio leaves fleet pointing at the wrong org until
+  // explicitly bud back).
+  console.log(`  \x1b[36m●\x1b[0m bud: creating ${budRepoSlug}`);
+  console.log(`     \x1b[90msource: ${formatOrgSource(orgResolution)}\x1b[0m`);
+  if (orgResolution.source === "fleet" || orgResolution.source === "gh" || orgResolution.source === "default") {
+    console.log(`     \x1b[90moverride: --org <name> or MAW_BUD_OWNER=<name>\x1b[0m`);
   }
 
   // 1. Create oracle repo — returns the ACTUAL clone path per ghq (#630).

--- a/plugins/bud/smart-default-org.test.ts
+++ b/plugins/bud/smart-default-org.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for fleet-as-truth smart-default org resolution.
+ *
+ * Pure dependency injection — pass mock `loadFleetFn` and `execFn` directly.
+ * No `mock.module` calls, so this test file doesn't pollute Bun's
+ * process-global module cache or interact with neighboring test files.
+ */
+import { describe, test, expect } from "bun:test";
+import {
+  smartDefaultOrgFromFleet,
+  fetchGhDefaultLogin,
+  resolveOrg,
+  formatOrgSource,
+} from "./smart-default-org";
+
+describe("smartDefaultOrgFromFleet — fleet (FTS) tier", () => {
+  test("returns null on empty fleet", () => {
+    expect(smartDefaultOrgFromFleet(() => [])).toBeNull();
+  });
+
+  test("returns most-recent budded_at org", () => {
+    const fleet = [
+      { name: "01-old", windows: [{ name: "old", repo: "Old-Org/old-oracle" }], budded_at: "2026-01-01T00:00:00Z" },
+      { name: "26-new", windows: [{ name: "new", repo: "New-Org/new-oracle" }], budded_at: "2026-05-04T00:00:00Z" },
+      { name: "12-mid", windows: [{ name: "mid", repo: "Mid-Org/mid-oracle" }], budded_at: "2026-03-15T00:00:00Z" },
+    ] as any;
+    const result = smartDefaultOrgFromFleet(() => fleet);
+    expect(result?.org).toBe("New-Org");
+    expect(result?.oracle).toBe("new");
+    expect(result?.date).toBe("2026-05-04");
+  });
+
+  test("falls back to numeric prefix when budded_at missing", () => {
+    const fleet = [
+      { name: "05-foo", windows: [{ name: "foo", repo: "Foo-Org/foo-oracle" }] },
+      { name: "20-bar", windows: [{ name: "bar", repo: "Bar-Org/bar-oracle" }] },
+    ] as any;
+    expect(smartDefaultOrgFromFleet(() => fleet)?.org).toBe("Bar-Org");
+  });
+
+  test("skips entries with malformed repo field (defensive #1133)", () => {
+    const fleet = [
+      { name: "01-bad", windows: [{ name: "bad" }] },
+      { name: "02-also-bad", windows: [{ name: "also-bad", repo: "no-slash-here" }] },
+      { name: "03-good", windows: [{ name: "good", repo: "Good/good-oracle" }], budded_at: "2026-04-01T00:00:00Z" },
+    ] as any;
+    expect(smartDefaultOrgFromFleet(() => fleet)?.org).toBe("Good");
+  });
+
+  test("handles entries with empty windows array", () => {
+    const fleet = [
+      { name: "weird", windows: [] },
+      { name: "01-good", windows: [{ name: "good", repo: "Good/good-oracle" }], budded_at: "2026-04-01T00:00:00Z" },
+    ] as any;
+    expect(smartDefaultOrgFromFleet(() => fleet)?.org).toBe("Good");
+  });
+});
+
+describe("fetchGhDefaultLogin — gh (vector) cold-start", () => {
+  test("returns trimmed login on success", async () => {
+    const exec = async (cmd: string) => cmd.includes("gh api user") ? "nazt\n" : "";
+    expect(await fetchGhDefaultLogin(exec)).toBe("nazt");
+  });
+
+  test("returns null on hostExec error (gh missing/unauthed)", async () => {
+    const exec = async () => { throw new Error("gh: command not found"); };
+    expect(await fetchGhDefaultLogin(exec)).toBeNull();
+  });
+
+  test("returns null on empty output (gh succeeded but no login)", async () => {
+    const exec = async () => "\n";
+    expect(await fetchGhDefaultLogin(exec)).toBeNull();
+  });
+});
+
+describe("resolveOrg — full precedence chain", () => {
+  const fleet = [{ name: "01-x", windows: [{ name: "x", repo: "Fleet-Org/x" }], budded_at: "2026-05-01" }] as any;
+
+  test("--org flag wins over everything", async () => {
+    const r = await resolveOrg(
+      { flag: "Flag-Org", env: "Env-Org", config: "Config-Org" },
+      { loadFleetFn: () => fleet, execFn: async () => "gh-user\n" },
+    );
+    expect(r.org).toBe("Flag-Org");
+    expect(r.source).toBe("flag");
+  });
+
+  test("env wins over config + fleet when no flag", async () => {
+    const r = await resolveOrg(
+      { env: "Env-Org", config: "Config-Org" },
+      { loadFleetFn: () => fleet },
+    );
+    expect(r.org).toBe("Env-Org");
+    expect(r.source).toBe("env");
+  });
+
+  test("config wins over fleet when no flag/env", async () => {
+    const r = await resolveOrg(
+      { config: "Config-Org" },
+      { loadFleetFn: () => fleet },
+    );
+    expect(r.org).toBe("Config-Org");
+    expect(r.source).toBe("config");
+  });
+
+  test("fleet (FTS) wins over gh + default when populated", async () => {
+    const r = await resolveOrg(
+      {},
+      { loadFleetFn: () => fleet, execFn: async () => "gh-user\n" },
+    );
+    expect(r.org).toBe("Fleet-Org");
+    expect(r.source).toBe("fleet");
+    expect(r.detail).toContain("most recent: x");
+  });
+
+  test("gh (vector) wins over default on empty fleet", async () => {
+    const r = await resolveOrg(
+      {},
+      { loadFleetFn: () => [], execFn: async () => "nazt\n" },
+    );
+    expect(r.org).toBe("nazt");
+    expect(r.source).toBe("gh");
+  });
+
+  test("default fallback when both fleet empty AND gh fails", async () => {
+    const r = await resolveOrg(
+      {},
+      {
+        loadFleetFn: () => [],
+        execFn: async () => { throw new Error("gh: not authed"); },
+      },
+    );
+    expect(r.org).toBe("Soul-Brews-Studio");
+    expect(r.source).toBe("default");
+  });
+});
+
+describe("formatOrgSource — echo line label", () => {
+  test("flag → '--org flag'", () => {
+    expect(formatOrgSource({ org: "X", source: "flag" })).toBe("--org flag");
+  });
+
+  test("fleet with detail → 'fleet (most recent: foo, 2026-05-01)'", () => {
+    expect(formatOrgSource({ org: "X", source: "fleet", detail: "most recent: foo, 2026-05-01" }))
+      .toBe("fleet (most recent: foo, 2026-05-01)");
+  });
+
+  test("gh with detail → 'gh user (cold start — no fleet entries)'", () => {
+    expect(formatOrgSource({ org: "X", source: "gh", detail: "cold start — no fleet entries" }))
+      .toBe("gh user (cold start — no fleet entries)");
+  });
+
+  test("default → 'hardcoded default (Soul-Brews-Studio)'", () => {
+    expect(formatOrgSource({ org: "Soul-Brews-Studio", source: "default" }))
+      .toBe("hardcoded default (Soul-Brews-Studio)");
+  });
+});

--- a/plugins/bud/smart-default-org.ts
+++ b/plugins/bud/smart-default-org.ts
@@ -1,0 +1,165 @@
+/**
+ * Fleet-as-truth smart-default org resolution for `maw bud`.
+ *
+ * Architectural framing (FTS+vector retrieval pattern, mirrored from
+ * arra-oracle-v3):
+ *
+ *   FTS-tier (fast, structural, always fresh) — local fleet entries at
+ *     `~/.config/maw/fleet/*.json`. Each entry's `windows[0].repo` field
+ *     is `<org>/<oracle-name>`; `budded_at` records creation time.
+ *     Reading the fleet is a sub-millisecond local FS scan, hardened by
+ *     the #1133 defensive filter, and "always fresh" by construction
+ *     (written-on-write by maw itself).
+ *
+ *   Vector-tier (slow, authoritative, occasionally stale) — `gh api user`
+ *     network call. Returns the user's GitHub login regardless of fleet
+ *     state. Used only as cold-start fallback when fleet is empty (truly
+ *     fresh machine, no oracles yet).
+ *
+ * The combination rule today is FALLBACK (FTS-first, vector-on-empty),
+ * not parallel-merge. Future Phase 3 (when usage triggers warrant)
+ * upgrades to arra-oracle-v3's parallel + selective-merge with hybrid
+ * confidence bonus — see follow-up issue.
+ *
+ * Known limitation (sticky-default trap): recency-only ranking can keep
+ * suggesting the org of a recent side-quest oracle until the user buds
+ * back into their primary org. `--org <name>` is the escape hatch and
+ * the echo line surfaces the source so the user can catch wrong defaults
+ * before `gh repo create` fires.
+ */
+
+import { hostExec } from "maw-js/sdk";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
+
+export type OrgSource = "flag" | "env" | "config" | "fleet" | "gh" | "default";
+
+export interface OrgResolution {
+  /** The resolved GitHub org name (will be the namespace for the new repo). */
+  org: string;
+  /** Where the value came from — surfaced in the echo line for cross-check. */
+  source: OrgSource;
+  /** Optional human-readable detail (e.g., "most recent: discord-oracle, 2026-05-03"). */
+  detail?: string;
+}
+
+/**
+ * Walk the local fleet and return the org from the most recently budded
+ * oracle. Returns null if no fleet entry has a parseable `windows[0].repo`.
+ *
+ * Tiebreaker: when `budded_at` is missing or equal, the numeric prefix
+ * on the fleet filename (e.g., `26-sbs.json`) breaks ties — higher prefix
+ * = later creation.
+ *
+ * Tests inject their own `loadFleetFn` to avoid touching the real
+ * `~/.config/maw/fleet/` and to sidestep Bun's process-global mock.module
+ * cache pollution (see smart-default-org.test.ts header).
+ */
+export function smartDefaultOrgFromFleet(
+  loadFleetFn: typeof loadFleet = loadFleet,
+): { org: string; oracle: string; date: string } | null {
+  const fleet = loadFleetFn();
+  const candidates = fleet
+    .map(s => {
+      const repo = s.windows?.[0]?.repo;
+      if (!repo || typeof repo !== "string" || !repo.includes("/")) return null;
+      const org = repo.split("/")[0];
+      if (!org) return null;
+      const oracle = s.windows?.[0]?.name || s.name;
+      const ts = s.budded_at ? new Date(s.budded_at).getTime() : 0;
+      const numPrefix = (() => {
+        const m = /^(\d+)-/.exec(s.name || "");
+        return m ? parseInt(m[1] ?? "0", 10) : 0;
+      })();
+      return { org, oracle, ts, numPrefix, date: s.budded_at?.slice(0, 10) ?? "" };
+    })
+    .filter((c): c is NonNullable<typeof c> => c !== null);
+
+  if (candidates.length === 0) return null;
+
+  candidates.sort((a, b) => (b.ts - a.ts) || (b.numPrefix - a.numPrefix));
+  const winner = candidates[0]!;
+  return { org: winner.org, oracle: winner.oracle, date: winner.date };
+}
+
+/**
+ * Cold-start fallback — ask `gh` who the user is. Used only when fleet
+ * is empty (no oracles ever). One `gh api user` call, ~100-300ms once
+ * per fresh machine. Returns null on any failure (gh missing, unauthed,
+ * offline) so the caller can fall through to the hardcoded default.
+ *
+ * `execFn` is injectable for tests; defaults to the real `hostExec`.
+ */
+export async function fetchGhDefaultLogin(
+  execFn: typeof hostExec = hostExec,
+): Promise<string | null> {
+  try {
+    const out = await execFn("gh api user --jq .login 2>/dev/null");
+    const login = out.trim();
+    return login || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface ResolveOrgOpts {
+  /** Explicit `--org <name>` flag value (highest priority). */
+  flag?: string;
+  /** `MAW_BUD_OWNER` env var snapshot — caller passes process.env.MAW_BUD_OWNER. */
+  env?: string;
+  /** `config.githubOrg` from maw config. */
+  config?: string;
+}
+
+export interface ResolveOrgDeps {
+  /** Override the fleet loader (tests). Defaults to real `loadFleet`. */
+  loadFleetFn?: typeof loadFleet;
+  /** Override the gh exec (tests). Defaults to real `hostExec`. */
+  execFn?: typeof hostExec;
+}
+
+/**
+ * Full precedence chain for bud's org resolution:
+ *
+ *   1. --org <name>                     (explicit flag wins)
+ *   2. MAW_BUD_OWNER env                (per-shell override)
+ *   3. config.githubOrg                 (per-machine config)
+ *   4. fleet most-recent (FTS)          (smart default — NEW)
+ *   5. gh api user (vector cold-start)  (NEW — fires once per fresh machine)
+ *   6. "Soul-Brews-Studio"              (ultimate fallback)
+ */
+export async function resolveOrg(
+  opts: ResolveOrgOpts,
+  deps: ResolveOrgDeps = {},
+): Promise<OrgResolution> {
+  if (opts.flag) return { org: opts.flag, source: "flag" };
+  if (opts.env) return { org: opts.env, source: "env" };
+  if (opts.config) return { org: opts.config, source: "config" };
+
+  const fleetPick = smartDefaultOrgFromFleet(deps.loadFleetFn);
+  if (fleetPick) {
+    const detail = fleetPick.date
+      ? `most recent: ${fleetPick.oracle}, ${fleetPick.date}`
+      : `most recent: ${fleetPick.oracle}`;
+    return { org: fleetPick.org, source: "fleet", detail };
+  }
+
+  const ghLogin = await fetchGhDefaultLogin(deps.execFn);
+  if (ghLogin) {
+    return { org: ghLogin, source: "gh", detail: "cold start — no fleet entries" };
+  }
+
+  return { org: "Soul-Brews-Studio", source: "default" };
+}
+
+/** Format the source for the user-facing echo line. */
+export function formatOrgSource(res: OrgResolution): string {
+  const tail = res.detail ? ` (${res.detail})` : "";
+  switch (res.source) {
+    case "flag":    return "--org flag";
+    case "env":     return "MAW_BUD_OWNER env";
+    case "config":  return "config.githubOrg";
+    case "fleet":   return `fleet${tail}`;
+    case "gh":      return `gh user${tail}`;
+    case "default": return "hardcoded default (Soul-Brews-Studio)";
+  }
+}


### PR DESCRIPTION
## What

Phase 2 of the bud smart-default-org work. Adds fleet-based org resolution to `maw bud`.

Replaces:
```typescript
const org = opts.org || config.githubOrg || "Soul-Brews-Studio";
```

With a 6-step FTS+vector precedence chain (`smart-default-org.ts`):
```typescript
1. opts.org                       // --org flag
2. process.env.MAW_BUD_OWNER      // per-shell override (NEW)
3. config.githubOrg               // per-machine config
4. fleet most-recent (FTS-tier)   // smart default (NEW)
5. gh api user (vector cold)      // first oracle fallback (NEW)
6. "Soul-Brews-Studio"            // ultimate fallback
```

## Architectural framing

Mirrors arra-oracle-v3's `combineSearchResults` pattern (`handlers.ts:286-315`):

| Tier | Bud's smart-default | arra-oracle-v3 analog |
|---|---|---|
| **FTS** (fast structural) | Local fleet `~/.config/maw/fleet/*.json` | SQLite FTS5 |
| **Vector** (slow authoritative) | `gh api user --jq .login` | ChromaDB |
| **Combination today** | Fallback (FTS-first, vector-on-empty) | Parallel + merge with +0.1 hybrid bonus |

The fallback combination is the *make-it-work-first* version. Future Phase 3 graduates to parallel-merge with a confidence bonus to invalidate stale fleet entries (sticky-default trap) — filed as separate follow-up.

## Echo line for sticky-default trap mitigation

All 3 v3 evaluators flagged that recency-only ranking can keep suggesting an old side-quest org. Mitigation: print the resolved org + source BEFORE `gh repo create` so the user can ^C:

```
bud: creating Soul-Brews-Studio/foo-oracle
     source: fleet (most recent: discord-oracle, 2026-05-03)
     override: --org <name> or MAW_BUD_OWNER=<name>
```

## Implementation note — dependency injection > mock.module

`smartDefaultOrgFromFleet`, `fetchGhDefaultLogin`, and `resolveOrg` accept their dependencies (`loadFleetFn`, `execFn`) as optional parameters with sensible defaults. Tests pass mocks directly without using `mock.module`, which avoids Bun's process-global cache pollution that broke neighboring tests in earlier iterations.

## Tests

- **New**: `plugins/bud/smart-default-org.test.ts` — 18 cases (5 fleet + 3 gh + 6 precedence + 4 echo formatting). All pass.
- **Existing pre-existing failures** in `bud-repo.test.ts` (#630 path mismatch, unrelated to this PR) — same 11 fail on main before/after. Verified.

```
73 pass on this branch
55 pass on main
== +18 net new passing tests
```

## Pairs with

[Soul-Brews-Studio/maw-js#1143](https://github.com/Soul-Brews-Studio/maw-js/pull/1143) — Phase 1 extract `fetchAllowedOrgs` helper. **Phase 1 already merged**; this PR doesn't depend on it directly today, but a future Phase 3 (arra-pattern hybrid) will share the helper for the cached vector tier.

## Plan

`mawjs-oracle/ψ/plans/2026-05-05_0735_bud-smart-default-v2-fleet-as-truth.md`

Three rounds of /team-agents (option-scoring → risk-mitigation → v3-grounded-by-arra-dig) converged on this design.

## Out of scope (deferred Phase 3)

Filed as separate issue (link in next comment): hybrid parallel-merge with +0.1 confidence bonus, freshness-aware cache for the vector tier, multi-host (`github.com` + GHE) `--host` plumbing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)