### PR TITLE
fix(inbox): WHEN column shows '—' for missing timestamps + absolute date for old items (#1142)

### DIFF
--- a/plugins/inbox/impl.ts
+++ b/plugins/inbox/impl.ts
@@ -75,13 +75,37 @@ function slugify(text: string): string {
   return text.trim().split(/\s+/).slice(0, 5).join("-").toLowerCase().replace(/[^a-z0-9-]/g, "").slice(0, 40);
 }
 
-function relativeTime(date: Date): string {
-  const mins = Math.floor((Date.now() - date.getTime()) / 60000);
+/**
+ * Format a date as human-readable relative age (or absolute date for old/invalid).
+ *
+ * Defensive against the epoch-zero fallback in `loadInboxMessages` (where a
+ * missing/malformed `timestamp:` frontmatter coerces to `new Date(0)` and
+ * produces "20578d ago" — the #1142 bug shape).
+ *
+ * Contract:
+ *   NaN / epoch-zero / non-positive  → "—"  (unknown/missing)
+ *   future-dated (clock skew)        → "future"
+ *   < 1 minute                       → "just now"
+ *   < 60 minutes                     → "Nm ago"
+ *   < 24 hours                       → "Nh ago"
+ *   < 30 days                        → "Nd ago"
+ *   ≥ 30 days                        → "YYYY-MM-DD" (absolute)
+ *
+ * Exported for tests; the WHEN column in `cmdInboxLs` is the production caller.
+ */
+export function relativeTime(date: Date): string {
+  const t = date.getTime();
+  if (!isFinite(t) || t <= 0) return "—";
+  const diffMs = Date.now() - t;
+  if (diffMs < 0) return "future";
+  const mins = Math.floor(diffMs / 60000);
   if (mins < 1) return "just now";
   if (mins < 60) return `${mins}m ago`;
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
-  return `${Math.floor(hrs / 24)}d ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return date.toISOString().slice(0, 10); // YYYY-MM-DD for older items
 }
 
 export function writeInboxFile(inboxDir: string, from: string, to: string, body: string): string {

--- a/plugins/inbox/relative-time.test.ts
+++ b/plugins/inbox/relative-time.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Tests for relativeTime — the inbox WHEN column formatter.
+ *
+ * Regression for #1142: `new Date(0)` epoch-zero fallback in loadInboxMessages
+ * produced "20578d ago" (~56 years) when frontmatter.timestamp was missing.
+ * The fix makes relativeTime defensive against NaN, epoch-zero, future-dated,
+ * and >30-day cases.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { relativeTime } from "./impl";
+
+// Pin "now" so the relative outputs are deterministic.
+const NOW = new Date("2026-05-05T08:00:00.000Z").getTime();
+const origDateNow = Date.now;
+
+beforeAll(() => { Date.now = () => NOW; });
+afterAll(() => { Date.now = origDateNow; });
+
+describe("relativeTime — defensive cases (#1142 regression)", () => {
+  test("epoch zero → '—' (the bug from #1142)", () => {
+    expect(relativeTime(new Date(0))).toBe("—");
+  });
+
+  test("NaN date → '—'", () => {
+    expect(relativeTime(new Date("not-a-date"))).toBe("—");
+  });
+
+  test("future-dated (clock skew) → 'future'", () => {
+    expect(relativeTime(new Date(NOW + 60_000))).toBe("future");
+  });
+
+  test("just-now (< 1 min) → 'just now'", () => {
+    expect(relativeTime(new Date(NOW - 30_000))).toBe("just now");
+  });
+
+  test("minutes (< 60m) → 'Nm ago'", () => {
+    expect(relativeTime(new Date(NOW - 5 * 60_000))).toBe("5m ago");
+  });
+
+  test("hours (< 24h) → 'Nh ago'", () => {
+    expect(relativeTime(new Date(NOW - 3 * 60 * 60_000))).toBe("3h ago");
+  });
+
+  test("days (< 30d) → 'Nd ago'", () => {
+    expect(relativeTime(new Date(NOW - 5 * 24 * 60 * 60_000))).toBe("5d ago");
+  });
+
+  test("≥ 30 days → absolute YYYY-MM-DD", () => {
+    const d = new Date("2025-12-15T10:30:00.000Z");
+    expect(relativeTime(d)).toBe("2025-12-15");
+  });
+
+  test("exactly 30 days → still relative is wrong; renders absolute", () => {
+    const d = new Date(NOW - 30 * 24 * 60 * 60_000);
+    // 30d → render absolute (per the contract; 365d cap was suggested in #1142
+    // body but evaluators agreed 30d is more useful — older items get exact date)
+    expect(relativeTime(d)).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});


### PR DESCRIPTION
## Closes

#1142

## Bug

Every inbox entry shows \`20578d ago\` (~56 years). Filed by discord-oracle. Root cause: \`loadInboxMessages\` falls back to \`new Date(0)\` (epoch-zero) when \`frontmatter.timestamp\` is missing or malformed. The original \`relativeTime\` then computed \`now - epoch_0\` → 20578 days → "Nd ago" string.

## Fix

Defensive contract on \`relativeTime\`:

| Input | Output |
|---|---|
| NaN / epoch-zero / non-positive | \`—\` |
| Future-dated (clock skew) | \`future\` |
| < 1 minute | \`just now\` |
| < 60 minutes | \`Nm ago\` |
| < 24 hours | \`Nh ago\` |
| < 30 days | \`Nd ago\` |
| ≥ 30 days | \`YYYY-MM-DD\` (absolute) |

The 30-day cutoff means old archived inbox items show their actual date (useful) instead of \`237d ago\` (useless). New + recent items still show the relative age users expect. Cap was empirically chosen — issue body suggested 365d, but 30 lines up better with the 4 existing buckets and avoids the eyestrain of "237d ago" for items closer to a year old.

## Tests

9 cases in \`plugins/inbox/relative-time.test.ts\` (Date.now() pinned for determinism):
- epoch-zero (regression)
- NaN
- future
- just-now / minutes / hours / days
- ≥30d absolute boundary

\`relativeTime\` is now exported for testability (was private). Pure function, no side effects.

## Discovery

Backlog audit (3-lens /team-agents) on 2026-05-05 — risk evaluator flagged: *"epoch-zero fallback, daily-use surface — when timestamps lie, attention misroutes"*. Triage evaluator ranked it cheap+high-impact. Both right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)