### PR TITLE
feat(incubate): thin router — fire /incubate skill via send-text (#14)

### DIFF
--- a/plugins/incubate/impl.ts
+++ b/plugins/incubate/impl.ts
@@ -1,46 +1,79 @@
 /**
- * maw incubate — stub implementation (#522).
+ * incubate — fire `/incubate` skill into an oracle's Claude TUI.
  *
- * Migration scaffold for Oracle skill /incubate. Real flow (ghq clone/create,
- * origin symlink into ψ/incubate/<owner>/<repo>/origin, .origins manifest,
- * .claude/INCUBATED_BY breadcrumb, hub file, and the --flash / --contribute /
- * --status / --offload workflow modes) is tracked as follow-up work.
+ * Composition:
+ *   1. Resolve target oracle (from --oracle flag or inferred from cwd).
+ *   2. Build the slash-command line: `/incubate <source> [mode flags]`.
+ *   3. Send via cmdSendText so the skill runs inside the oracle's session.
  *
- * Until that lands, this stub:
- *   - Accepts <repo> + mode (default | flash | contribute | status | offload)
- *   - Returns a well-shaped stub message with the selected mode
- *   - Points users at the Oracle skill for actual incubation runs
+ * The plugin is a THIN ROUTER. The `/incubate` skill at
+ * ~/.claude/skills/incubate/SKILL.md does the actual work:
+ *   - ghq clone of source
+ *   - symlink into ψ/incubate/<owner>/<repo>/origin
+ *   - update .origins manifest
+ *   - create hub file REPO.md
+ *   - mode-specific behavior (--flash / --contribute / --status / --offload)
  *
- * The function is pure (no I/O, no process spawning) so it's safe to unit
- * test and safe to wire into the CLI ahead of the real impl.
+ * This decouples CLI contract from skill implementation — skill can evolve
+ * without breaking plugin's public surface.
+ *
+ * Sister of `awaken` (which fires `/awaken`) and `send-text` (the underlying
+ * send primitive).
  */
+import { cmdSendText } from "../send-text/impl";
+import { listSessions, resolveTarget } from "maw-js/sdk";
+import { loadConfig } from "maw-js/config";
+import { existsSync } from "fs";
+import { join } from "path";
 
 export type IncubateMode = "default" | "flash" | "contribute" | "status" | "offload";
 
 export interface IncubateOptions {
-  repo: string;
-  mode: IncubateMode;
+  /** Source repo (org/repo, URL, or slug). Required unless mode is "status" or --init. */
+  source?: string;
+  /** Target oracle to fire skill into. Default: inferred from cwd. */
+  oracle?: string;
+  /** Mode passed to the skill. */
+  mode?: IncubateMode;
+  /** Restore all origins from .origins manifest. */
+  init?: boolean;
+  /** Custom trigger override (replaces auto-built `/incubate <args>`). */
+  trigger?: string;
+  /** Skip firing the skill (dispatch only, debug). */
+  noTrigger?: boolean;
+  /** Don't actually send — just print what would be sent. */
+  dryRun?: boolean;
 }
 
+const SKILL = "/incubate";
+
 /**
- * Return a stub message for `maw incubate`. Will be replaced by the real
- * ghq + symlink + workflow flow once the migration PR ships.
+ * Build the slash-command line from options. Pure function — testable.
+ *
+ *   { source: "org/foo" }                       → "/incubate org/foo"
+ *   { source: "org/foo", mode: "flash" }        → "/incubate org/foo --flash"
+ *   { mode: "status" }                          → "/incubate --status"
+ *   { init: true }                              → "/incubate --init"
+ *   { trigger: "/incubate-custom" }             → "/incubate-custom"  (override)
  */
-export async function cmdIncubate(repo: string, mode: IncubateMode = "default"): Promise<string> {
-  const target = repo || "(none)";
-  const lines = [
-    `incubate: ${mode} mode on "${target}" — not yet implemented in core plugin; use Oracle skill /incubate for full behavior.`,
-    `  planned: ghq clone/create → symlink ψ/incubate/<owner>/<repo>/origin → hub file + .origins manifest`,
-    `  track:   https://github.com/Soul-Brews-Studio/maw-js/issues/522`,
-  ];
-  const message = lines.join("\n");
-  console.log(message);
-  return message;
+export function buildSkillCommand(opts: IncubateOptions): string {
+  if (opts.trigger) return opts.trigger;
+
+  const parts: string[] = [SKILL];
+  if (opts.source) parts.push(opts.source);
+
+  if (opts.mode === "flash") parts.push("--flash");
+  else if (opts.mode === "contribute") parts.push("--contribute");
+  else if (opts.mode === "status") parts.push("--status");
+  else if (opts.mode === "offload") parts.push("--offload");
+
+  if (opts.init) parts.push("--init");
+
+  return parts.join(" ");
 }
 
 /**
- * Resolve mode from flag booleans. Exposed for tests and for future CLI
- * wiring that may accept a single `--mode` string alternative.
+ * Resolve mode from flag booleans. Mutually exclusive.
  */
 export function resolveMode(
   flash: boolean,
@@ -49,10 +82,80 @@ export function resolveMode(
   offload: boolean,
 ): IncubateMode {
   const count = [flash, contribute, status, offload].filter(Boolean).length;
-  if (count > 1) throw new Error("--flash, --contribute, --status, --offload are mutually exclusive");
+  if (count > 1) {
+    throw new Error("--flash, --contribute, --status, --offload are mutually exclusive");
+  }
   if (flash) return "flash";
   if (contribute) return "contribute";
   if (status) return "status";
   if (offload) return "offload";
   return "default";
+}
+
+/**
+ * Infer the current oracle from cwd. Walks up to find a CLAUDE.md + ψ/ pair
+ * (oracle root signature). Returns the basename (which matches the fleet
+ * stem when the oracle was created via `maw bud`).
+ *
+ * Returns null if no oracle root found above cwd.
+ */
+export function inferCurrentOracle(cwd: string = process.cwd()): string | null {
+  let dir = cwd;
+  while (dir && dir !== "/") {
+    if (existsSync(join(dir, "CLAUDE.md")) && existsSync(join(dir, "ψ"))) {
+      // Strip "-oracle" suffix if present, mirror fleet stem convention.
+      const base = dir.split("/").pop() || "";
+      return base.replace(/-oracle$/, "");
+    }
+    dir = dir.split("/").slice(0, -1).join("/");
+  }
+  return null;
+}
+
+export async function cmdIncubate(opts: IncubateOptions): Promise<void> {
+  // Validate input
+  if (opts.mode !== "status" && !opts.init && !opts.source) {
+    throw new Error('usage: maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init]');
+  }
+
+  // Resolve target oracle
+  const target = opts.oracle ?? inferCurrentOracle();
+  if (!target) {
+    throw new Error(
+      'could not infer current oracle from cwd — run from inside an oracle repo or pass --oracle <name>',
+    );
+  }
+
+  // Verify the oracle resolves to a live target before sending
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(target, config, sessions);
+  if (!result || result.type === "error") {
+    const hint = result?.type === "error" && result.hint ? ` — ${result.hint}` : "";
+    throw new Error(`could not resolve oracle "${target}"${hint} — try: maw wake ${target}`);
+  }
+
+  // Build the skill command
+  const cmd = buildSkillCommand(opts);
+
+  if (opts.dryRun) {
+    console.log(`\x1b[33m[dry-run]\x1b[0m would send to \x1b[36m${target}\x1b[0m: ${cmd}`);
+    return;
+  }
+
+  if (opts.noTrigger) {
+    console.log(`\x1b[90m○\x1b[0m --no-trigger: would have sent to ${target}: ${cmd}`);
+    return;
+  }
+
+  // Fire the skill via send-text
+  console.log(`\x1b[36m🔔\x1b[0m firing \x1b[33m${cmd}\x1b[0m → ${target}`);
+  try {
+    await cmdSendText({ target, text: cmd });
+    console.log(`\x1b[32m✓\x1b[0m skill dispatched`);
+  } catch (e: any) {
+    console.log(`\x1b[33m⚠\x1b[0m send-text failed: ${e?.message || e}`);
+    console.log(`\x1b[90m  try manually: maw send-text ${target} '${cmd}'\x1b[0m`);
+    throw e;
+  }
 }

--- a/plugins/incubate/incubate.test.ts
+++ b/plugins/incubate/incubate.test.ts
@@ -1,0 +1,351 @@
+/**
+ * incubate — thin-router tests for `maw incubate`.
+ *
+ * 3 layers:
+ *   1. CLI test  — buildSkillCommand + resolveMode + handler arg parsing
+ *   2. Call test — cmdIncubate composition (with stubbed send-text + sdk)
+ *   3. Smoke test — full handler dispatch via dry-run
+ */
+
+import { test, expect, mock } from "bun:test";
+import {
+  buildSkillCommand,
+  resolveMode,
+  inferCurrentOracle,
+} from "./impl";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. CLI tests — pure helpers (no IO)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("buildSkillCommand: bare source", () => {
+  expect(buildSkillCommand({ source: "Soul-Brews-Studio/foo" })).toBe(
+    "/incubate Soul-Brews-Studio/foo",
+  );
+});
+
+test("buildSkillCommand: source + flash", () => {
+  expect(
+    buildSkillCommand({ source: "org/foo", mode: "flash" }),
+  ).toBe("/incubate org/foo --flash");
+});
+
+test("buildSkillCommand: source + contribute", () => {
+  expect(
+    buildSkillCommand({ source: "org/foo", mode: "contribute" }),
+  ).toBe("/incubate org/foo --contribute");
+});
+
+test("buildSkillCommand: status alone (no source needed)", () => {
+  expect(buildSkillCommand({ mode: "status" })).toBe("/incubate --status");
+});
+
+test("buildSkillCommand: offload + source", () => {
+  expect(
+    buildSkillCommand({ source: "org/foo", mode: "offload" }),
+  ).toBe("/incubate org/foo --offload");
+});
+
+test("buildSkillCommand: init alone", () => {
+  expect(buildSkillCommand({ init: true })).toBe("/incubate --init");
+});
+
+test("buildSkillCommand: trigger override wins (custom)", () => {
+  expect(
+    buildSkillCommand({ source: "org/foo", trigger: "/incubate-mine" }),
+  ).toBe("/incubate-mine");
+});
+
+test("resolveMode: no flags → default", () => {
+  expect(resolveMode(false, false, false, false)).toBe("default");
+});
+
+test("resolveMode: --flash", () => {
+  expect(resolveMode(true, false, false, false)).toBe("flash");
+});
+
+test("resolveMode: --status", () => {
+  expect(resolveMode(false, false, true, false)).toBe("status");
+});
+
+test("resolveMode: throws on multiple modes", () => {
+  expect(() => resolveMode(true, true, false, false)).toThrow(
+    /mutually exclusive/,
+  );
+  expect(() => resolveMode(true, false, true, false)).toThrow(
+    /mutually exclusive/,
+  );
+  expect(() => resolveMode(false, true, true, true)).toThrow(
+    /mutually exclusive/,
+  );
+});
+
+test("inferCurrentOracle: returns null for /tmp", () => {
+  // /tmp doesn't have CLAUDE.md or ψ
+  expect(inferCurrentOracle("/tmp")).toBeNull();
+});
+
+test("inferCurrentOracle: detects mawjs-oracle from its own cwd", () => {
+  // Walking up from a known oracle subdir should land on the oracle
+  const oracle = inferCurrentOracle(
+    "/Users/nat/Code/github.com/Soul-Brews-Studio/mawjs-oracle/scripts",
+  );
+  expect(oracle).toBe("mawjs");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Call tests — cmdIncubate composes with stubbed send-text + sdk
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setupHappyPathMocks() {
+  const calls = {
+    sendText: [] as Array<{ target: string; text: string }>,
+  };
+
+  mock.module("../send-text/impl", () => ({
+    cmdSendText: async (opts: { target: string; text: string }) => {
+      calls.sendText.push(opts);
+    },
+  }));
+
+  mock.module("maw-js/sdk", () => ({
+    listSessions: async () => [{ name: "01-foo", windows: [{ name: "foo" }] }],
+    resolveTarget: () => ({ type: "local", target: "01-foo:foo" }),
+  }));
+
+  mock.module("maw-js/config", () => ({ loadConfig: () => ({}) }));
+
+  return calls;
+}
+
+test("call: cmdIncubate fires /incubate with source + explicit oracle", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    source: "org/foo",
+    oracle: "mawjs",
+  });
+
+  expect(calls.sendText.length).toBe(1);
+  expect(calls.sendText[0].target).toBe("mawjs");
+  expect(calls.sendText[0].text).toBe("/incubate org/foo");
+  mock.restore();
+});
+
+test("call: cmdIncubate with --flash mode passes through", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    source: "org/foo",
+    oracle: "mawjs",
+    mode: "flash",
+  });
+
+  expect(calls.sendText[0].text).toBe("/incubate org/foo --flash");
+  mock.restore();
+});
+
+test("call: cmdIncubate --status without source works", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    oracle: "mawjs",
+    mode: "status",
+  });
+
+  expect(calls.sendText[0].text).toBe("/incubate --status");
+  mock.restore();
+});
+
+test("call: cmdIncubate --init without source works", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    oracle: "mawjs",
+    init: true,
+  });
+
+  expect(calls.sendText[0].text).toBe("/incubate --init");
+  mock.restore();
+});
+
+test("call: cmdIncubate --no-trigger does NOT send", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    source: "org/foo",
+    oracle: "mawjs",
+    noTrigger: true,
+  });
+
+  expect(calls.sendText.length).toBe(0);
+  mock.restore();
+});
+
+test("call: cmdIncubate --dry-run does NOT send", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    source: "org/foo",
+    oracle: "mawjs",
+    dryRun: true,
+  });
+
+  expect(calls.sendText.length).toBe(0);
+  mock.restore();
+});
+
+test("call: missing source + non-status mode throws usage", async () => {
+  setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+  await expect(
+    cmdIncubate({ oracle: "mawjs", mode: "default" }),
+  ).rejects.toThrow(/usage/);
+  mock.restore();
+});
+
+test("call: unresolvable oracle throws", async () => {
+  mock.module("../send-text/impl", () => ({
+    cmdSendText: async () => {},
+  }));
+  mock.module("maw-js/sdk", () => ({
+    listSessions: async () => [],
+    resolveTarget: () => null,
+  }));
+  mock.module("maw-js/config", () => ({ loadConfig: () => ({}) }));
+
+  const { cmdIncubate } = await import("./impl");
+  await expect(
+    cmdIncubate({ source: "org/foo", oracle: "ghost-oracle" }),
+  ).rejects.toThrow(/could not resolve oracle/);
+  mock.restore();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Smoke test — full handler dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setupHandlerMocks() {
+  const calls = setupHappyPathMocks();
+  mock.module("maw-js/cli/parse-args", () => ({
+    parseFlags: (args: string[], schema: any, _positional: number) => {
+      const out: any = { _: [] };
+      for (let i = 0; i < args.length; i++) {
+        const a = args[i];
+        if (a.startsWith("--")) {
+          const ty = schema[a];
+          if (ty === Boolean) out[a] = true;
+          else if (ty === Number) out[a] = Number(args[++i]);
+          else out[a] = args[++i];
+        } else {
+          out._.push(a);
+        }
+      }
+      return out;
+    },
+  }));
+  return calls;
+}
+
+test("smoke: handler CLI dispatch with source + --oracle", async () => {
+  const calls = setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["org/foo", "--oracle", "mawjs"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(true);
+  expect(calls.sendText[0].text).toBe("/incubate org/foo");
+  expect(calls.sendText[0].target).toBe("mawjs");
+  mock.restore();
+});
+
+test("smoke: handler CLI --flash passes through", async () => {
+  const calls = setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["org/foo", "--oracle", "mawjs", "--flash"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(true);
+  expect(calls.sendText[0].text).toBe("/incubate org/foo --flash");
+  mock.restore();
+});
+
+test("smoke: handler CLI --status with no source", async () => {
+  const calls = setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["--oracle", "mawjs", "--status"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(true);
+  expect(calls.sendText[0].text).toBe("/incubate --status");
+  mock.restore();
+});
+
+test("smoke: handler rejects mutually exclusive modes", async () => {
+  setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["org/foo", "--oracle", "mawjs", "--flash", "--contribute"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/mutually exclusive/);
+  mock.restore();
+});
+
+test("smoke: handler rejects flag-shaped source", async () => {
+  setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["-bad", "--oracle", "mawjs"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/looks like a flag/);
+  mock.restore();
+});
+
+test("smoke: API dispatch", async () => {
+  const calls = setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "api",
+    args: { source: "org/api-test", oracle: "mawjs", mode: "flash" },
+  } as any);
+
+  expect(result.ok).toBe(true);
+  expect(calls.sendText[0].text).toBe("/incubate org/api-test --flash");
+  mock.restore();
+});
+
+test("smoke: API rejects invalid mode", async () => {
+  setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "api",
+    args: { source: "org/foo", oracle: "mawjs", mode: "garbage" },
+  } as any);
+
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/invalid mode/);
+  mock.restore();
+});

--- a/plugins/incubate/index.ts
+++ b/plugins/incubate/index.ts
@@ -1,29 +1,16 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { cmdIncubate, resolveMode } from "./impl";
+import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "incubate",
-  description: "Scaffold (stub): clone or create repos for active development.",
+  description: "Fire /incubate skill into an oracle's Claude TUI — thin router.",
 };
 
-/**
- * maw incubate — core plugin scaffold (#522).
- *
- * This is a migration scaffold for the Oracle skill `/incubate`. The full
- * implementation (ghq clone/create, origin symlink, .origins manifest,
- * INCUBATED_BY breadcrumb, hub file, --flash/--contribute/--status/--offload
- * workflow modes) lives in ~/.claude/skills/incubate/SKILL.md and ships in a
- * follow-up PR.
- *
- * Today the plugin only:
- *   - registers the CLI verb + flags
- *   - validates positional args + flag shape
- *   - returns a stub message pointing users at the Oracle skill
- *
- * See issue #522 for the follow-up implementation tracker.
- */
-export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
-  const { cmdIncubate } = await import("./impl");
+const USAGE =
+  "usage: maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init] [--no-trigger] [--trigger <text>] [--dry-run]";
 
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
   const origLog = console.log;
   const origError = console.error;
@@ -37,44 +24,83 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
 
   try {
-    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(
+        args,
+        {
+          "--oracle": String,
+          "--trigger": String,
+          "--no-trigger": Boolean,
+          "--flash": Boolean,
+          "--contribute": Boolean,
+          "--status": Boolean,
+          "--offload": Boolean,
+          "--init": Boolean,
+          "--dry-run": Boolean,
+        },
+        0,
+      );
 
-    const flash = args.includes("--flash");
-    const contribute = args.includes("--contribute");
-    const status = args.includes("--status");
-    const offload = args.includes("--offload");
+      let mode;
+      try {
+        mode = resolveMode(
+          !!flags["--flash"],
+          !!flags["--contribute"],
+          !!flags["--status"],
+          !!flags["--offload"],
+        );
+      } catch (e: any) {
+        return { ok: false, error: e.message };
+      }
 
-    const modes = [flash, contribute, status, offload].filter(Boolean).length;
-    if (modes > 1) {
-      return {
-        ok: false,
-        error: "maw incubate: --flash, --contribute, --status, --offload are mutually exclusive",
-      };
+      const source = flags._[0];
+      // --status and --init don't need a source positional
+      const needsSource = mode !== "status" && !flags["--init"];
+      if (needsSource && !source) {
+        return { ok: false, error: USAGE };
+      }
+      if (source && source.startsWith("-")) {
+        return {
+          ok: false,
+          error: `"${source}" looks like a flag, not a source repo.\n  ${USAGE}`,
+        };
+      }
+
+      await cmdIncubate({
+        source,
+        oracle: flags["--oracle"],
+        mode,
+        init: flags["--init"],
+        trigger: flags["--trigger"],
+        noTrigger: flags["--no-trigger"],
+        dryRun: flags["--dry-run"],
+      });
+    } else if (ctx.source === "api") {
+      const body = ctx.args as Record<string, unknown>;
+      const source = body.source as string | undefined;
+      const mode = (body.mode as string | undefined) ?? "default";
+      if (!["default", "flash", "contribute", "status", "offload"].includes(mode)) {
+        return { ok: false, error: `invalid mode: ${mode}` };
+      }
+      await cmdIncubate({
+        source,
+        oracle: body.oracle as string | undefined,
+        mode: mode as any,
+        init: body.init as boolean | undefined,
+        trigger: body.trigger as string | undefined,
+        noTrigger: body.noTrigger as boolean | undefined,
+        dryRun: body.dryRun as boolean | undefined,
+      });
     }
 
-    const known = new Set(["--flash", "--contribute", "--status", "--offload"]);
-    const positional = args.filter(a => !a.startsWith("--"));
-    const unknown = args.filter(a => a.startsWith("--") && !known.has(a));
-    if (unknown.length > 0) {
-      return {
-        ok: false,
-        error: `maw incubate: unknown flag(s) ${unknown.join(", ")} (accepts --flash, --contribute, --status, --offload)`,
-      };
-    }
-
-    const mode = flash ? "flash" : contribute ? "contribute" : status ? "status" : offload ? "offload" : "default";
-
-    if (mode !== "status" && !positional[0]) {
-      return {
-        ok: false,
-        error: "usage: maw incubate <repo> [--flash|--contribute|--status|--offload]",
-      };
-    }
-
-    const result = await cmdIncubate(positional[0] ?? "", mode);
-    return { ok: true, output: logs.join("\n") || result };
+    return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
-    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+    return {
+      ok: false,
+      error: logs.join("\n") || e.message,
+      output: logs.join("\n") || undefined,
+    };
   } finally {
     console.log = origLog;
     console.error = origError;

--- a/plugins/incubate/plugin.json
+++ b/plugins/incubate/plugin.json
@@ -1,19 +1,24 @@
 {
   "name": "incubate",
-  "version": "0.1.0-alpha.0",
+  "version": "1.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Scaffold (stub): clone or create repos for active development — the right hand of /learn. Full impl lives in the Oracle /incubate skill — core plugin is a dispatcher shape only.",
+  "description": "Fire /incubate skill into an oracle's Claude TUI — thin router. Skill does the actual ghq clone, ψ/incubate symlink, .origins manifest, hub file, and mode workflow.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "incubate",
-    "help": "maw incubate <repo> [--flash|--contribute|--status|--offload] — scaffold stub (impl pending, see Oracle skill /incubate)",
+    "help": "maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init] [--no-trigger] [--trigger <text>]\n       Fire `/incubate <source>` into an oracle's Claude TUI. The skill clones via ghq, symlinks into ψ/incubate/, manages .origins + hub files.\n       Default oracle: inferred from cwd (must be inside an oracle's repo). Override with --oracle.\n       Mode flags pass straight through to the skill.\n       Use --status to query existing incubations (no source arg required).\n       Use --init to restore all origins from .origins manifest.",
     "flags": {
+      "--oracle": "string",
+      "--trigger": "string",
+      "--no-trigger": "boolean",
       "--flash": "boolean",
       "--contribute": "boolean",
       "--status": "boolean",
-      "--offload": "boolean"
+      "--offload": "boolean",
+      "--init": "boolean",
+      "--dry-run": "boolean"
     }
   },
-  "weight": 50
+  "weight": 0
 }


### PR DESCRIPTION
Closes #14. Retires the #522 stub.

## Summary

Replaces the stub plugin with a real **thin router**: `maw incubate <source>` fires the `/incubate` skill into an oracle's Claude TUI via `send-text`. The skill does the actual work (ghq clone, ψ/incubate symlink, .origins manifest, hub file, mode-specific behavior).

## Why thin

@nazt's insight on issue #14 (the spec revision):
> "we just call skill /incubate — this is more simple? bcoz cli skills can be changed we have maw send-text?"

Plugin = stable CLI contract. Skill = implementation. Decouple. ~30-50 LOC vs ~200.

## Composition

```typescript
async function cmdIncubate(opts) {
  const target = opts.oracle ?? inferCurrentOracle();   // 1. resolve target
  const cmd = buildSkillCommand(opts);                  // 2. build /incubate args
  await cmdSendText({ target, text: cmd });             // 3. dispatch
}
```

Mirrors `awaken` exactly. Same testing template. Same shape.

## CLI

```bash
maw incubate <source> [--oracle <name>]
                     [--flash | --contribute | --status | --offload | --init]
                     [--dry-run] [--no-trigger] [--trigger <text>]
```

| Flag | Routes to skill as |
|------|---------------------|
| (default) | `/incubate <source>` |
| `--flash` | `/incubate <source> --flash` |
| `--contribute` | `/incubate <source> --contribute` |
| `--status` | `/incubate --status` (no source needed) |
| `--offload` | `/incubate <source> --offload` |
| `--init` | `/incubate --init` (no source needed) |
| `--dry-run` | preview only, doesn't send |
| `--no-trigger` | skip the send (debug) |
| `--trigger <custom>` | override entire slash command |

## Default oracle inference

When `--oracle` not given, walks up `cwd` looking for `CLAUDE.md` + `ψ/` pair (oracle root signature) and strips `-oracle` suffix to get the fleet stem.

```bash
# inside ~/Code/.../mawjs-oracle/scripts/
$ maw incubate Soul-Brews-Studio/test-repo --dry-run
→ would send to mawjs: /incubate Soul-Brews-Studio/test-repo
```

## Tests (28/28 passing)

Mirrors `awaken` and `send-text` PR #13's 3-tier pattern:

```
CLI tests   12  buildSkillCommand variants, resolveMode, inferCurrentOracle
call tests   8  composition with stubbed send-text + sdk; dry-run / no-trigger / status / init
smoke tests  8  handler dispatch CLI/API; mutually-exclusive guard; flag-shaped source guard
```

## Test plan

- [x] `bun test plugins/incubate/` → 28/28 green
- [x] `maw incubate` (no args) → usage line
- [x] `maw incubate org/foo --oracle mawjs --dry-run` → correct slash command
- [x] All 4 modes dry-run (flash / contribute / status / offload) verified
- [x] `--init` standalone works
- [x] `--flash --contribute` rejected (mutually exclusive)
- [x] `inferCurrentOracle` returns `"mawjs"` when cwd is inside `mawjs-oracle/`
- [ ] Real end-to-end smoke: `maw incubate <real-source>` and verify skill executes (recommended before merge — operator approval needed since real ghq clone)

## Out of scope

- Skill-side improvements (issue tracking lifecycle, archived-repo detection, etc.) — plugin doesn't need to know
- Multi-source incubation in one call — `maw incubate` is 1 source per call (call N times)
- Renaming `--no-trigger` for consistency with awaken — could happen separately

## Decision history

Original spec (issue body) had a 9-step composition: clone, symlink, manifest, hub file, fleet config — plugin doing the skill's work. Revised after @nazt's spec-revision comment to this thin-router shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)