### PR TITLE
feat(incubate)!: bud + wake + /incubate <source> in NEW oracle (rewrite v2.0)

### DIFF
--- a/plugins/incubate/impl.ts
+++ b/plugins/incubate/impl.ts
@@ -1,161 +1,149 @@
 /**
- * incubate — fire `/incubate` skill into an oracle's Claude TUI.
+ * incubate — bud + wake + fire `/incubate <source>` in the new oracle.
  *
- * Composition:
- *   1. Resolve target oracle (from --oracle flag or inferred from cwd).
- *   2. Build the slash-command line: `/incubate <source> [mode flags]`.
- *   3. Send via cmdSendText so the skill runs inside the oracle's session.
+ * Composition (mirror of `awaken`, but for source-wrapping rather than birth):
+ *   1. Derive oracle stem from source (`org/foo` → `foo`).
+ *   2. cmdBud(stem, { repo: source, ...opts }) — creates the new
+ *      `<stem>-oracle` repo, ψ vault, fleet entry, and wakes it
+ *      (cmdBud calls cmdWake internally with noAttach: true).
+ *   3. cmdSendText({ target: stem, text: "/incubate <source>" }) — fires
+ *      the `/incubate` skill into the NEW oracle's TUI; the skill clones
+ *      via ghq, symlinks into the NEW oracle's ψ/incubate/, manages
+ *      .origins + hub file inside the new oracle.
  *
- * The plugin is a THIN ROUTER. The `/incubate` skill at
- * ~/.claude/skills/incubate/SKILL.md does the actual work:
- *   - ghq clone of source
- *   - symlink into ψ/incubate/<owner>/<repo>/origin
- *   - update .origins manifest
- *   - create hub file REPO.md
- *   - mode-specific behavior (--flash / --contribute / --status / --offload)
+ * Result: a dedicated oracle with the source repo as its primary focus.
  *
- * This decouples CLI contract from skill implementation — skill can evolve
- * without breaking plugin's public surface.
+ * Verb family completed:
+ *   bud      — creates new oracle (blank or seeded)
+ *   awaken   — bud + wake + /awaken (one-shot birth)
+ *   incubate — bud + wake + /incubate <source> (one-shot wrap)
  *
- * Sister of `awaken` (which fires `/awaken`) and `send-text` (the underlying
- * send primitive).
+ * For "add a source to the CURRENT oracle's ψ/incubate" workflow, use
+ * the `/incubate <source>` skill directly inside an oracle's TUI — that's
+ * the multi-source-per-oracle pattern that existed before this plugin.
  */
+import { cmdBud, type BudOpts } from "../bud/impl";
 import { cmdSendText } from "../send-text/impl";
 import { listSessions, resolveTarget } from "maw-js/sdk";
 import { loadConfig } from "maw-js/config";
-import { existsSync } from "fs";
-import { join } from "path";
 
-export type IncubateMode = "default" | "flash" | "contribute" | "status" | "offload";
+export type IncubateMode = "default" | "flash" | "contribute";
 
-export interface IncubateOptions {
-  /** Source repo (org/repo, URL, or slug). Required unless mode is "status" or --init. */
-  source?: string;
-  /** Target oracle to fire skill into. Default: inferred from cwd. */
-  oracle?: string;
-  /** Mode passed to the skill. */
+export interface IncubateOpts extends BudOpts {
+  /** Source repo (org/repo, URL, or local path). Required. */
+  source: string;
+  /** Override auto-derived oracle stem (default: source basename). */
+  stem?: string;
+  /** Skill mode passed through to `/incubate` in the new oracle. */
   mode?: IncubateMode;
-  /** Restore all origins from .origins manifest. */
-  init?: boolean;
-  /** Custom trigger override (replaces auto-built `/incubate <args>`). */
+  /** Custom trigger override (replaces auto-built `/incubate <source>`). */
   trigger?: string;
-  /** Skip firing the skill (dispatch only, debug). */
+  /** Skip firing the skill (just bud + wake — debug). */
   noTrigger?: boolean;
-  /** Don't actually send — just print what would be sent. */
-  dryRun?: boolean;
 }
 
-const SKILL = "/incubate";
+/**
+ * Derive the oracle stem from a source slug.
+ *   "Soul-Brews-Studio/foo"           → "foo"
+ *   "https://github.com/org/foo"      → "foo"
+ *   "https://github.com/org/foo.git"  → "foo"
+ *   "foo"                             → "foo"
+ */
+export function deriveStemFromSource(source: string): string {
+  const lastSlash = source.lastIndexOf("/");
+  let name = lastSlash >= 0 ? source.slice(lastSlash + 1) : source;
+  name = name.replace(/\.git$/, "");
+  return name;
+}
 
 /**
- * Build the slash-command line from options. Pure function — testable.
+ * Build the slash-command line. Pure — testable without IO.
  *
- *   { source: "org/foo" }                       → "/incubate org/foo"
- *   { source: "org/foo", mode: "flash" }        → "/incubate org/foo --flash"
- *   { mode: "status" }                          → "/incubate --status"
- *   { init: true }                              → "/incubate --init"
- *   { trigger: "/incubate-custom" }             → "/incubate-custom"  (override)
+ *   { source: "org/foo" }                          → "/incubate org/foo"
+ *   { source: "org/foo", mode: "flash" }           → "/incubate org/foo --flash"
+ *   { source: "org/foo", mode: "contribute" }      → "/incubate org/foo --contribute"
+ *   { source: "org/foo", trigger: "/foo-custom" }  → "/foo-custom"  (override)
  */
-export function buildSkillCommand(opts: IncubateOptions): string {
+export function buildSkillCommand(opts: IncubateOpts): string {
   if (opts.trigger) return opts.trigger;
-
-  const parts: string[] = [SKILL];
-  if (opts.source) parts.push(opts.source);
-
+  const parts = ["/incubate", opts.source];
   if (opts.mode === "flash") parts.push("--flash");
   else if (opts.mode === "contribute") parts.push("--contribute");
-  else if (opts.mode === "status") parts.push("--status");
-  else if (opts.mode === "offload") parts.push("--offload");
-
-  if (opts.init) parts.push("--init");
-
   return parts.join(" ");
+}
+
+export async function cmdIncubate(opts: IncubateOpts): Promise<void> {
+  if (!opts.source) {
+    throw new Error('usage: maw incubate <source-repo> [--stem <name>] [--flash | --contribute] [--from <oracle>] [--root] ...all bud flags');
+  }
+
+  const stem = opts.stem ?? deriveStemFromSource(opts.source);
+  if (!stem) {
+    throw new Error(`could not derive stem from source: "${opts.source}"`);
+  }
+
+  const trigger = opts.noTrigger ? null : buildSkillCommand(opts);
+
+  // Step 1: bud (creates <stem>-oracle, seeds ψ from source via --repo, wakes)
+  const budOpts: BudOpts = { ...opts };
+  // BudOpts doesn't have source/stem/mode/trigger/noTrigger — strip them.
+  delete (budOpts as any).source;
+  delete (budOpts as any).stem;
+  delete (budOpts as any).mode;
+  delete (budOpts as any).trigger;
+  delete (budOpts as any).noTrigger;
+  // Pass source as bud's --repo flag (one-time ψ seed copy if source has ψ/memory)
+  budOpts.repo = opts.source;
+
+  await cmdBud(stem, budOpts);
+
+  // Dry-run / root-without-wake: bud already returned early, nothing to send.
+  if (opts.dryRun) {
+    if (trigger) {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would send \x1b[33m${trigger}\x1b[0m to ${stem}`);
+    } else {
+      console.log(`  \x1b[36m⬡\x1b[0m [dry-run] --no-trigger: would NOT fire /incubate`);
+    }
+    return;
+  }
+
+  if (!trigger) {
+    console.log(`  \x1b[90m○\x1b[0m --no-trigger: bud + wake done, skipping /incubate`);
+    return;
+  }
+
+  // Step 2: resolve the new oracle's pane (no readiness wait — graceful).
+  const config = loadConfig();
+  const sessions = await listSessions();
+  const result = resolveTarget(stem, config, sessions);
+
+  if (!result || result.type === "error") {
+    console.log(
+      `  \x1b[33m⚠\x1b[0m could not resolve ${stem} after wake — skipping ${trigger}`,
+    );
+    console.log(`  \x1b[90m  try manually: maw send-text ${stem} '${trigger}'\x1b[0m`);
+    return;
+  }
+
+  // Step 3: fire the skill into the NEW oracle's pane
+  console.log(`  \x1b[36m🔔\x1b[0m firing \x1b[33m${trigger}\x1b[0m → ${stem}`);
+  try {
+    await cmdSendText({ target: stem, text: trigger });
+    console.log(`  \x1b[32m✓\x1b[0m incubation dispatched`);
+  } catch (e: any) {
+    console.log(`  \x1b[33m⚠\x1b[0m send-text failed: ${e?.message || e}`);
+    console.log(`  \x1b[90m  try manually: maw send-text ${stem} '${trigger}'\x1b[0m`);
+  }
 }
 
 /**
  * Resolve mode from flag booleans. Mutually exclusive.
  */
-export function resolveMode(
-  flash: boolean,
-  contribute: boolean,
-  status: boolean,
-  offload: boolean,
-): IncubateMode {
-  const count = [flash, contribute, status, offload].filter(Boolean).length;
-  if (count > 1) {
-    throw new Error("--flash, --contribute, --status, --offload are mutually exclusive");
+export function resolveMode(flash: boolean, contribute: boolean): IncubateMode {
+  if (flash && contribute) {
+    throw new Error("--flash and --contribute are mutually exclusive");
   }
   if (flash) return "flash";
   if (contribute) return "contribute";
-  if (status) return "status";
-  if (offload) return "offload";
   return "default";
-}
-
-/**
- * Infer the current oracle from cwd. Walks up to find a CLAUDE.md + ψ/ pair
- * (oracle root signature). Returns the basename (which matches the fleet
- * stem when the oracle was created via `maw bud`).
- *
- * Returns null if no oracle root found above cwd.
- */
-export function inferCurrentOracle(cwd: string = process.cwd()): string | null {
-  let dir = cwd;
-  while (dir && dir !== "/") {
-    if (existsSync(join(dir, "CLAUDE.md")) && existsSync(join(dir, "ψ"))) {
-      // Strip "-oracle" suffix if present, mirror fleet stem convention.
-      const base = dir.split("/").pop() || "";
-      return base.replace(/-oracle$/, "");
-    }
-    dir = dir.split("/").slice(0, -1).join("/");
-  }
-  return null;
-}
-
-export async function cmdIncubate(opts: IncubateOptions): Promise<void> {
-  // Validate input
-  if (opts.mode !== "status" && !opts.init && !opts.source) {
-    throw new Error('usage: maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init]');
-  }
-
-  // Resolve target oracle
-  const target = opts.oracle ?? inferCurrentOracle();
-  if (!target) {
-    throw new Error(
-      'could not infer current oracle from cwd — run from inside an oracle repo or pass --oracle <name>',
-    );
-  }
-
-  // Verify the oracle resolves to a live target before sending
-  const config = loadConfig();
-  const sessions = await listSessions();
-  const result = resolveTarget(target, config, sessions);
-  if (!result || result.type === "error") {
-    const hint = result?.type === "error" && result.hint ? ` — ${result.hint}` : "";
-    throw new Error(`could not resolve oracle "${target}"${hint} — try: maw wake ${target}`);
-  }
-
-  // Build the skill command
-  const cmd = buildSkillCommand(opts);
-
-  if (opts.dryRun) {
-    console.log(`\x1b[33m[dry-run]\x1b[0m would send to \x1b[36m${target}\x1b[0m: ${cmd}`);
-    return;
-  }
-
-  if (opts.noTrigger) {
-    console.log(`\x1b[90m○\x1b[0m --no-trigger: would have sent to ${target}: ${cmd}`);
-    return;
-  }
-
-  // Fire the skill via send-text
-  console.log(`\x1b[36m🔔\x1b[0m firing \x1b[33m${cmd}\x1b[0m → ${target}`);
-  try {
-    await cmdSendText({ target, text: cmd });
-    console.log(`\x1b[32m✓\x1b[0m skill dispatched`);
-  } catch (e: any) {
-    console.log(`\x1b[33m⚠\x1b[0m send-text failed: ${e?.message || e}`);
-    console.log(`\x1b[90m  try manually: maw send-text ${target} '${cmd}'\x1b[0m`);
-    throw e;
-  }
 }

--- a/plugins/incubate/incubate.test.ts
+++ b/plugins/incubate/incubate.test.ts
@@ -1,22 +1,44 @@
 /**
- * incubate — thin-router tests for `maw incubate`.
+ * incubate — bud + wake + fire /incubate <source> tests.
  *
- * 3 layers:
- *   1. CLI test  — buildSkillCommand + resolveMode + handler arg parsing
- *   2. Call test — cmdIncubate composition (with stubbed send-text + sdk)
- *   3. Smoke test — full handler dispatch via dry-run
+ * 3 layers (mirrors awaken):
+ *   1. CLI test  — buildSkillCommand + resolveMode + deriveStemFromSource
+ *   2. Call test — cmdIncubate composes cmdBud + cmdSendText (with stubs)
+ *   3. Smoke test — full handler dispatch via dry-run + edge cases
  */
 
 import { test, expect, mock } from "bun:test";
 import {
   buildSkillCommand,
   resolveMode,
-  inferCurrentOracle,
+  deriveStemFromSource,
 } from "./impl";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 1. CLI tests — pure helpers (no IO)
 // ─────────────────────────────────────────────────────────────────────────────
+
+test("deriveStemFromSource: org/repo slug", () => {
+  expect(deriveStemFromSource("Soul-Brews-Studio/foo")).toBe("foo");
+});
+
+test("deriveStemFromSource: GitHub URL", () => {
+  expect(deriveStemFromSource("https://github.com/org/foo")).toBe("foo");
+});
+
+test("deriveStemFromSource: URL with .git suffix", () => {
+  expect(deriveStemFromSource("https://github.com/org/foo.git")).toBe("foo");
+});
+
+test("deriveStemFromSource: bare name (no slash)", () => {
+  expect(deriveStemFromSource("foo")).toBe("foo");
+});
+
+test("deriveStemFromSource: complex name preserved", () => {
+  expect(deriveStemFromSource("Soul-Brews-Studio/arra-oracle-skills-cli")).toBe(
+    "arra-oracle-skills-cli",
+  );
+});
 
 test("buildSkillCommand: bare source", () => {
   expect(buildSkillCommand({ source: "Soul-Brews-Studio/foo" })).toBe(
@@ -25,82 +47,54 @@ test("buildSkillCommand: bare source", () => {
 });
 
 test("buildSkillCommand: source + flash", () => {
-  expect(
-    buildSkillCommand({ source: "org/foo", mode: "flash" }),
-  ).toBe("/incubate org/foo --flash");
+  expect(buildSkillCommand({ source: "org/foo", mode: "flash" })).toBe(
+    "/incubate org/foo --flash",
+  );
 });
 
 test("buildSkillCommand: source + contribute", () => {
+  expect(buildSkillCommand({ source: "org/foo", mode: "contribute" })).toBe(
+    "/incubate org/foo --contribute",
+  );
+});
+
+test("buildSkillCommand: trigger override wins", () => {
   expect(
-    buildSkillCommand({ source: "org/foo", mode: "contribute" }),
-  ).toBe("/incubate org/foo --contribute");
-});
-
-test("buildSkillCommand: status alone (no source needed)", () => {
-  expect(buildSkillCommand({ mode: "status" })).toBe("/incubate --status");
-});
-
-test("buildSkillCommand: offload + source", () => {
-  expect(
-    buildSkillCommand({ source: "org/foo", mode: "offload" }),
-  ).toBe("/incubate org/foo --offload");
-});
-
-test("buildSkillCommand: init alone", () => {
-  expect(buildSkillCommand({ init: true })).toBe("/incubate --init");
-});
-
-test("buildSkillCommand: trigger override wins (custom)", () => {
-  expect(
-    buildSkillCommand({ source: "org/foo", trigger: "/incubate-mine" }),
-  ).toBe("/incubate-mine");
+    buildSkillCommand({ source: "org/foo", trigger: "/foo-custom" }),
+  ).toBe("/foo-custom");
 });
 
 test("resolveMode: no flags → default", () => {
-  expect(resolveMode(false, false, false, false)).toBe("default");
+  expect(resolveMode(false, false)).toBe("default");
 });
 
 test("resolveMode: --flash", () => {
-  expect(resolveMode(true, false, false, false)).toBe("flash");
+  expect(resolveMode(true, false)).toBe("flash");
 });
 
-test("resolveMode: --status", () => {
-  expect(resolveMode(false, false, true, false)).toBe("status");
+test("resolveMode: --contribute", () => {
+  expect(resolveMode(false, true)).toBe("contribute");
 });
 
-test("resolveMode: throws on multiple modes", () => {
-  expect(() => resolveMode(true, true, false, false)).toThrow(
-    /mutually exclusive/,
-  );
-  expect(() => resolveMode(true, false, true, false)).toThrow(
-    /mutually exclusive/,
-  );
-  expect(() => resolveMode(false, true, true, true)).toThrow(
-    /mutually exclusive/,
-  );
-});
-
-test("inferCurrentOracle: returns null for /tmp", () => {
-  // /tmp doesn't have CLAUDE.md or ψ
-  expect(inferCurrentOracle("/tmp")).toBeNull();
-});
-
-test("inferCurrentOracle: detects mawjs-oracle from its own cwd", () => {
-  // Walking up from a known oracle subdir should land on the oracle
-  const oracle = inferCurrentOracle(
-    "/Users/nat/Code/github.com/Soul-Brews-Studio/mawjs-oracle/scripts",
-  );
-  expect(oracle).toBe("mawjs");
+test("resolveMode: throws on flash + contribute", () => {
+  expect(() => resolveMode(true, true)).toThrow(/mutually exclusive/);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 2. Call tests — cmdIncubate composes with stubbed send-text + sdk
+// 2. Call tests — cmdIncubate composes cmdBud + cmdSendText
 // ─────────────────────────────────────────────────────────────────────────────
 
 function setupHappyPathMocks() {
   const calls = {
+    bud: [] as Array<{ name: string; opts: any }>,
     sendText: [] as Array<{ target: string; text: string }>,
   };
+
+  mock.module("../bud/impl", () => ({
+    cmdBud: async (name: string, opts: any) => {
+      calls.bud.push({ name, opts });
+    },
+  }));
 
   mock.module("../send-text/impl", () => ({
     cmdSendText: async (opts: { target: string; text: string }) => {
@@ -118,58 +112,64 @@ function setupHappyPathMocks() {
   return calls;
 }
 
-test("call: cmdIncubate fires /incubate with source + explicit oracle", async () => {
+test("call: cmdIncubate composes bud → sendText('/incubate <source>')", async () => {
   const calls = setupHappyPathMocks();
   const { cmdIncubate } = await import("./impl");
 
-  await cmdIncubate({
-    source: "org/foo",
-    oracle: "mawjs",
-  });
+  await cmdIncubate({ source: "Soul-Brews-Studio/foo", root: true });
 
+  expect(calls.bud.length).toBe(1);
+  expect(calls.bud[0].name).toBe("foo");                  // stem derived
+  expect(calls.bud[0].opts.repo).toBe("Soul-Brews-Studio/foo"); // source as bud --repo
+  expect(calls.bud[0].opts.root).toBe(true);              // bud passthrough
+  expect(calls.bud[0].opts.source).toBeUndefined();       // not bud's flag
   expect(calls.sendText.length).toBe(1);
-  expect(calls.sendText[0].target).toBe("mawjs");
-  expect(calls.sendText[0].text).toBe("/incubate org/foo");
+  expect(calls.sendText[0].target).toBe("foo");           // stem
+  expect(calls.sendText[0].text).toBe("/incubate Soul-Brews-Studio/foo");
   mock.restore();
 });
 
-test("call: cmdIncubate with --flash mode passes through", async () => {
+test("call: cmdIncubate with --stem override", async () => {
+  const calls = setupHappyPathMocks();
+  const { cmdIncubate } = await import("./impl");
+
+  await cmdIncubate({
+    source: "Soul-Brews-Studio/very-long-name",
+    stem: "vln",
+    root: true,
+  });
+
+  expect(calls.bud[0].name).toBe("vln");
+  expect(calls.sendText[0].target).toBe("vln");
+  expect(calls.sendText[0].text).toBe("/incubate Soul-Brews-Studio/very-long-name");
+  mock.restore();
+});
+
+test("call: cmdIncubate with --flash mode", async () => {
   const calls = setupHappyPathMocks();
   const { cmdIncubate } = await import("./impl");
 
   await cmdIncubate({
     source: "org/foo",
-    oracle: "mawjs",
     mode: "flash",
+    root: true,
   });
 
   expect(calls.sendText[0].text).toBe("/incubate org/foo --flash");
   mock.restore();
 });
 
-test("call: cmdIncubate --status without source works", async () => {
+test("call: cmdIncubate with --contribute mode", async () => {
   const calls = setupHappyPathMocks();
   const { cmdIncubate } = await import("./impl");
 
   await cmdIncubate({
-    oracle: "mawjs",
-    mode: "status",
+    source: "org/foo",
+    mode: "contribute",
+    root: true,
   });
 
-  expect(calls.sendText[0].text).toBe("/incubate --status");
-  mock.restore();
-});
-
-test("call: cmdIncubate --init without source works", async () => {
-  const calls = setupHappyPathMocks();
-  const { cmdIncubate } = await import("./impl");
-
-  await cmdIncubate({
-    oracle: "mawjs",
-    init: true,
-  });
-
-  expect(calls.sendText[0].text).toBe("/incubate --init");
+  expect(calls.sendText[0].text).toBe("/incubate org/foo --contribute");
   mock.restore();
 });
 
@@ -179,10 +179,11 @@ test("call: cmdIncubate --no-trigger does NOT send", async () => {
 
   await cmdIncubate({
     source: "org/foo",
-    oracle: "mawjs",
     noTrigger: true,
+    root: true,
   });
 
+  expect(calls.bud.length).toBe(1);
   expect(calls.sendText.length).toBe(0);
   mock.restore();
 });
@@ -193,42 +194,50 @@ test("call: cmdIncubate --dry-run does NOT send", async () => {
 
   await cmdIncubate({
     source: "org/foo",
-    oracle: "mawjs",
     dryRun: true,
+    root: true,
   });
 
+  expect(calls.bud[0].opts.dryRun).toBe(true);
   expect(calls.sendText.length).toBe(0);
   mock.restore();
 });
 
-test("call: missing source + non-status mode throws usage", async () => {
+test("call: missing source throws usage", async () => {
   setupHappyPathMocks();
   const { cmdIncubate } = await import("./impl");
-  await expect(
-    cmdIncubate({ oracle: "mawjs", mode: "default" }),
-  ).rejects.toThrow(/usage/);
+  await expect(cmdIncubate({ source: "" } as any)).rejects.toThrow(/usage/);
   mock.restore();
 });
 
-test("call: unresolvable oracle throws", async () => {
+test("call: send-text failure does NOT throw — graceful", async () => {
+  setupHappyPathMocks();
   mock.module("../send-text/impl", () => ({
-    cmdSendText: async () => {},
+    cmdSendText: async () => { throw new Error("tmux pane dead"); },
   }));
+  const { cmdIncubate } = await import("./impl");
+  // Should NOT throw — graceful per awaken pattern
+  await expect(
+    cmdIncubate({ source: "org/foo", root: true }),
+  ).resolves.toBeUndefined();
+  mock.restore();
+});
+
+test("call: unresolvable target after wake → warn but no throw", async () => {
+  setupHappyPathMocks();
   mock.module("maw-js/sdk", () => ({
     listSessions: async () => [],
     resolveTarget: () => null,
   }));
-  mock.module("maw-js/config", () => ({ loadConfig: () => ({}) }));
-
   const { cmdIncubate } = await import("./impl");
   await expect(
-    cmdIncubate({ source: "org/foo", oracle: "ghost-oracle" }),
-  ).rejects.toThrow(/could not resolve oracle/);
+    cmdIncubate({ source: "org/foo", root: true }),
+  ).resolves.toBeUndefined();
   mock.restore();
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 3. Smoke test — full handler dispatch
+// 3. Smoke tests — full handler dispatch
 // ─────────────────────────────────────────────────────────────────────────────
 
 function setupHandlerMocks() {
@@ -253,60 +262,47 @@ function setupHandlerMocks() {
   return calls;
 }
 
-test("smoke: handler CLI dispatch with source + --oracle", async () => {
+test("smoke: handler CLI dispatch with source + --root", async () => {
   const calls = setupHandlerMocks();
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "cli",
-    args: ["org/foo", "--oracle", "mawjs"],
+    args: ["Soul-Brews-Studio/foo", "--root"],
     writer: () => {},
   } as any);
 
   expect(result.ok).toBe(true);
-  expect(calls.sendText[0].text).toBe("/incubate org/foo");
-  expect(calls.sendText[0].target).toBe("mawjs");
+  expect(calls.bud[0].name).toBe("foo");
+  expect(calls.sendText[0].text).toBe("/incubate Soul-Brews-Studio/foo");
   mock.restore();
 });
 
-test("smoke: handler CLI --flash passes through", async () => {
+test("smoke: handler CLI --stem + --flash", async () => {
   const calls = setupHandlerMocks();
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "cli",
-    args: ["org/foo", "--oracle", "mawjs", "--flash"],
+    args: ["Soul-Brews-Studio/long-name", "--stem", "lname", "--flash", "--root"],
     writer: () => {},
   } as any);
 
   expect(result.ok).toBe(true);
-  expect(calls.sendText[0].text).toBe("/incubate org/foo --flash");
+  expect(calls.bud[0].name).toBe("lname");
+  expect(calls.sendText[0].text).toBe("/incubate Soul-Brews-Studio/long-name --flash");
   mock.restore();
 });
 
-test("smoke: handler CLI --status with no source", async () => {
-  const calls = setupHandlerMocks();
-  const handler = (await import("./index")).default;
-  const result = await handler({
-    source: "cli",
-    args: ["--oracle", "mawjs", "--status"],
-    writer: () => {},
-  } as any);
-
-  expect(result.ok).toBe(true);
-  expect(calls.sendText[0].text).toBe("/incubate --status");
-  mock.restore();
-});
-
-test("smoke: handler rejects mutually exclusive modes", async () => {
+test("smoke: handler missing source returns usage", async () => {
   setupHandlerMocks();
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "cli",
-    args: ["org/foo", "--oracle", "mawjs", "--flash", "--contribute"],
+    args: [],
     writer: () => {},
   } as any);
 
   expect(result.ok).toBe(false);
-  expect(result.error).toMatch(/mutually exclusive/);
+  expect(result.error).toMatch(/usage/);
   mock.restore();
 });
 
@@ -315,7 +311,7 @@ test("smoke: handler rejects flag-shaped source", async () => {
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "cli",
-    args: ["-bad", "--oracle", "mawjs"],
+    args: ["-bad-name"],
     writer: () => {},
   } as any);
 
@@ -324,16 +320,44 @@ test("smoke: handler rejects flag-shaped source", async () => {
   mock.restore();
 });
 
+test("smoke: handler rejects --flash + --contribute", async () => {
+  setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["org/foo", "--root", "--flash", "--contribute"],
+    writer: () => {},
+  } as any);
+
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/mutually exclusive/);
+  mock.restore();
+});
+
 test("smoke: API dispatch", async () => {
   const calls = setupHandlerMocks();
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "api",
-    args: { source: "org/api-test", oracle: "mawjs", mode: "flash" },
+    args: { source: "org/api-test", root: true, mode: "flash" },
   } as any);
 
   expect(result.ok).toBe(true);
+  expect(calls.bud[0].name).toBe("api-test");
   expect(calls.sendText[0].text).toBe("/incubate org/api-test --flash");
+  mock.restore();
+});
+
+test("smoke: API rejects missing source", async () => {
+  setupHandlerMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "api",
+    args: { root: true },
+  } as any);
+
+  expect(result.ok).toBe(false);
+  expect(result.error).toMatch(/source required/);
   mock.restore();
 });
 
@@ -342,7 +366,7 @@ test("smoke: API rejects invalid mode", async () => {
   const handler = (await import("./index")).default;
   const result = await handler({
     source: "api",
-    args: { source: "org/foo", oracle: "mawjs", mode: "garbage" },
+    args: { source: "org/foo", mode: "garbage" },
   } as any);
 
   expect(result.ok).toBe(false);

--- a/plugins/incubate/index.ts
+++ b/plugins/incubate/index.ts
@@ -4,11 +4,11 @@ import { parseFlags } from "maw-js/cli/parse-args";
 
 export const command = {
   name: "incubate",
-  description: "Fire /incubate skill into an oracle's Claude TUI — thin router.",
+  description: "Bud + wake + fire /incubate <source> — yeast-budding plus wrapping a source repo.",
 };
 
 const USAGE =
-  "usage: maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init] [--no-trigger] [--trigger <text>] [--dry-run]";
+  "usage: maw incubate <source-repo> [--stem <name>] [--from <oracle>] [--root] [--seed] [--org <org>] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run] [--flash | --contribute] [--no-trigger] [--trigger <text>]";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -29,68 +29,97 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       const flags = parseFlags(
         args,
         {
-          "--oracle": String,
+          // Plugin-specific
+          "--stem": String,
           "--trigger": String,
           "--no-trigger": Boolean,
           "--flash": Boolean,
           "--contribute": Boolean,
-          "--status": Boolean,
-          "--offload": Boolean,
-          "--init": Boolean,
+          // Bud passthrough
+          "--from": String,
+          "--from-repo": String,
+          "--org": String,
+          "--issue": Number,
+          "--note": String,
+          "--nickname": String,
+          "--fast": Boolean,
+          "--root": Boolean,
+          "--blank": Boolean,
+          "--seed": Boolean,
+          "--split": Boolean,
           "--dry-run": Boolean,
+          "--signal-on-birth": Boolean,
+          "--force": Boolean,
+          "--track-vault": Boolean,
+          "--sync-peers": Boolean,
         },
         0,
       );
 
-      let mode;
-      try {
-        mode = resolveMode(
-          !!flags["--flash"],
-          !!flags["--contribute"],
-          !!flags["--status"],
-          !!flags["--offload"],
-        );
-      } catch (e: any) {
-        return { ok: false, error: e.message };
-      }
-
       const source = flags._[0];
-      // --status and --init don't need a source positional
-      const needsSource = mode !== "status" && !flags["--init"];
-      if (needsSource && !source) {
+      if (!source || source === "--help" || source === "-h") {
         return { ok: false, error: USAGE };
       }
-      if (source && source.startsWith("-")) {
+      if (source.startsWith("-")) {
         return {
           ok: false,
           error: `"${source}" looks like a flag, not a source repo.\n  ${USAGE}`,
         };
       }
 
+      let mode;
+      try {
+        mode = resolveMode(!!flags["--flash"], !!flags["--contribute"]);
+      } catch (e: any) {
+        return { ok: false, error: e.message };
+      }
+
       await cmdIncubate({
         source,
-        oracle: flags["--oracle"],
+        stem: flags["--stem"],
         mode,
-        init: flags["--init"],
         trigger: flags["--trigger"],
         noTrigger: flags["--no-trigger"],
+        // bud passthrough
+        from: flags["--from"],
+        org: flags["--org"],
+        issue: flags["--issue"],
+        note: flags["--note"],
+        nickname: flags["--nickname"],
+        fast: flags["--fast"],
+        root: flags["--root"],
+        blank: flags["--blank"],
+        seed: flags["--seed"],
+        split: flags["--split"],
         dryRun: flags["--dry-run"],
+        signalOnBirth: flags["--signal-on-birth"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
       const source = body.source as string | undefined;
+      if (!source) return { ok: false, error: "source required" };
       const mode = (body.mode as string | undefined) ?? "default";
-      if (!["default", "flash", "contribute", "status", "offload"].includes(mode)) {
+      if (!["default", "flash", "contribute"].includes(mode)) {
         return { ok: false, error: `invalid mode: ${mode}` };
       }
       await cmdIncubate({
         source,
-        oracle: body.oracle as string | undefined,
+        stem: body.stem as string | undefined,
         mode: mode as any,
-        init: body.init as boolean | undefined,
         trigger: body.trigger as string | undefined,
         noTrigger: body.noTrigger as boolean | undefined,
+        from: body.from as string | undefined,
+        org: body.org as string | undefined,
+        issue: body.issue as number | undefined,
+        note: body.note as string | undefined,
+        nickname: body.nickname as string | undefined,
+        fast: body.fast as boolean | undefined,
+        root: body.root as boolean | undefined,
+        blank: body.blank as boolean | undefined,
+        seed: body.seed as boolean | undefined,
+        split: body.split as boolean | undefined,
         dryRun: body.dryRun as boolean | undefined,
+        signalOnBirth: body.signalOnBirth as boolean | undefined,
       });
     }
 

--- a/plugins/incubate/plugin.json
+++ b/plugins/incubate/plugin.json
@@ -1,24 +1,40 @@
 {
   "name": "incubate",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Fire /incubate skill into an oracle's Claude TUI — thin router. Skill does the actual ghq clone, ψ/incubate symlink, .origins manifest, hub file, and mode workflow.",
+  "description": "Bud + wake + fire /incubate <source> — yeast-budding plus wrapping a source repo in a dedicated oracle.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "incubate",
-    "help": "maw incubate <source> [--oracle <name>] [--flash | --contribute | --status | --offload | --init] [--no-trigger] [--trigger <text>]\n       Fire `/incubate <source>` into an oracle's Claude TUI. The skill clones via ghq, symlinks into ψ/incubate/, manages .origins + hub files.\n       Default oracle: inferred from cwd (must be inside an oracle's repo). Override with --oracle.\n       Mode flags pass straight through to the skill.\n       Use --status to query existing incubations (no source arg required).\n       Use --init to restore all origins from .origins manifest.",
+    "help": "maw incubate <source-repo> [--stem <name>] [--from <oracle>] [--root] [--seed] [--org <org>] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run] [--flash | --contribute] [--no-trigger] [--trigger <text>]\n       Mirrors `maw bud` flags + 4 incubate-specific.\n       Creates a NEW dedicated <stem>-oracle wrapping <source-repo>, then fires /incubate <source> in the new oracle's TUI.\n       Use --stem to override the auto-derived stem (default: source basename).\n       Mode flags pass through to the /incubate skill (--flash, --contribute).\n       Use --no-trigger for bud + wake without firing /incubate (debug).",
     "flags": {
-      "--oracle": "string",
+      "--stem": "string",
       "--trigger": "string",
       "--no-trigger": "boolean",
       "--flash": "boolean",
       "--contribute": "boolean",
-      "--status": "boolean",
-      "--offload": "boolean",
-      "--init": "boolean",
-      "--dry-run": "boolean"
+      "--from": "string",
+      "--from-repo": "string",
+      "--org": "string",
+      "--issue": "number",
+      "--note": "string",
+      "--nickname": "string",
+      "--fast": "boolean",
+      "--root": "boolean",
+      "--blank": "boolean",
+      "--seed": "boolean",
+      "--split": "boolean",
+      "--dry-run": "boolean",
+      "--signal-on-birth": "boolean",
+      "--force": "boolean",
+      "--track-vault": "boolean",
+      "--sync-peers": "boolean"
     }
+  },
+  "api": {
+    "path": "/api/incubate",
+    "methods": ["POST"]
   },
   "weight": 0
 }


### PR DESCRIPTION
**BREAKING** rewrite of `maw incubate` (PR #15 was v1.0 thin-router; this is v2.0 bud-aware composition).

## Summary

**Old (v1.0)**: thin router — sent `/incubate <source>` to current oracle (no new oracle created).
**New (v2.0)**: mirror `awaken` — creates a NEW `<stem>-oracle` dedicated to wrapping the source.

@nazt's correction:
> "this should wrong i think we shuld crate a new oracle name same-repo-oracle"

`maw incubate` is a **new-oracle gesture** (parallel to bud/awaken), not a current-oracle dispatcher. The 1:1 source-to-oracle pattern is the right call.

## Composition

```typescript
async function cmdIncubate(opts) {
  const stem = opts.stem ?? deriveStemFromSource(opts.source);  // org/foo → foo
  await cmdBud(stem, { ...opts, repo: opts.source });           // creates <stem>-oracle, wakes
  if (!opts.noTrigger) {
    await cmdSendText({ target: stem, text: buildSkillCommand(opts) });
  }
}
```

Mirrors `awaken` exactly. Same shape, same testing template.

## Verb family — now complete

| Verb | Composition | Oracle scope |
|------|-------------|--------------|
| `bud foo` | repo create + ψ vault + wake | New (foo-oracle) |
| `awaken foo` | bud foo + send `/awaken` | New + ritual |
| **`incubate org/foo`** | **bud foo + send `/incubate org/foo`** | **New + source wrap** |

For the "add source to CURRENT oracle's ψ/incubate" workflow, use the `/incubate <source>` skill directly inside the oracle's TUI (multi-source-per-oracle, pre-existing pattern).

## CLI shape

```bash
maw incubate <source-repo> [--stem <name>]
                          [--from <oracle>] [--root] [--seed] [--org <org>]
                          [--note <text>] [--nickname <pretty>] [--fast]
                          [--split] [--dry-run]
                          [--flash | --contribute]
                          [--no-trigger] [--trigger <text>]
```

Stem auto-derived: `Soul-Brews-Studio/foo` → `foo` → bud creates `Soul-Brews-Studio/foo-oracle`.

Mode flags pass through to `/incubate` skill in the new oracle:
- `--flash` → `/incubate <source> --flash`
- `--contribute` → `/incubate <source> --contribute`

Dropped from v1.0: `--status`, `--offload`, `--init` (those are for the inline skill pattern).

## Tests (30/30 passing, +2 vs v1.0's 28)

3-tier mirroring `awaken`:

```
CLI tests   13  buildSkillCommand variants, resolveMode, deriveStemFromSource
call tests   8  cmdIncubate composition (bud + sendText), failure modes
smoke tests  9  handler dispatch CLI/API, edge cases, --stem, --flash, etc.
```

## Verified end-to-end (dry-run)

```bash
$ maw incubate Soul-Brews-Studio/test-incubate --root --dry-run
🌱 Root Bud — test-incubate (no parent lineage)
⬡ would create repo: Soul-Brews-Studio/test-incubate-oracle
⬡ would init ψ/ vault at: ~/Code/.../test-incubate-oracle
⬡ would wake test-incubate
⬡ would send /incubate Soul-Brews-Studio/test-incubate to test-incubate

$ maw incubate Soul-Brews-Studio/long-name --stem ln --flash --root --dry-run
⬡ would create repo: Soul-Brews-Studio/ln-oracle
⬡ would send /incubate Soul-Brews-Studio/long-name --flash to ln
```

## Migration from v1.0

Anyone who used `maw incubate` post-PR-#15 (likely none — this PR follows ~1 hour later) should know that v1.0 didn't create a new oracle, it just routed to current. v2.0 always creates a new oracle. **No backwards compat layer** since v1.0 had no real users yet.

## Test plan

- [x] `bun test plugins/incubate/` → 30/30 green
- [x] Dry-run with `--root` → expected new-oracle output
- [x] Dry-run with `--stem` override → custom stem in `<stem>-oracle`
- [x] Dry-run with `--flash` → mode flag in slash command
- [x] Mutually exclusive guard works (`--flash --contribute` rejected)
- [ ] Real e2e on disposable target — operator approval (creates real GitHub repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)