### PR TITLE
fix(sleep): strip slot prefix from oracle name (maw-js#1181)

### DIFF
--- a/plugins/sleep/derive-window-name.ts
+++ b/plugins/sleep/derive-window-name.ts
@@ -1,0 +1,9 @@
+/**
+ * Fleet convention: session = "NN-stem", window = "stem-oracle".
+ * Strip the slot prefix so `maw sleep 29-foo` resolves to window `foo-oracle`.
+ * Explicit window argument is used as-is. (#1181)
+ */
+export function deriveWindowName(oracle: string, window?: string): string {
+  const stem = oracle.replace(/^\d+-/, "");
+  return window ?? `${stem}-oracle`;
+}

--- a/plugins/sleep/impl.ts
+++ b/plugins/sleep/impl.ts
@@ -5,6 +5,7 @@ import { appendFile, mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
 import { takeSnapshot } from "maw-js/sdk";
+import { deriveWindowName } from "./derive-window-name";
 
 /**
  * maw sleep <oracle> [window]
@@ -22,8 +23,7 @@ export async function cmdSleepOne(oracle: string, window?: string) {
     throw new Error(`no running session found for '${oracle}'`);
   }
 
-  // Determine window name
-  const windowName = window ? `${oracle}-${window}` : `${oracle}-oracle`;
+  const windowName = deriveWindowName(oracle, window);
 
   // Save tab order before sleeping (so wake can restore positions)
   await saveTabOrder(session);

--- a/plugins/sleep/sleep.test.ts
+++ b/plugins/sleep/sleep.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
+import { deriveWindowName } from "./derive-window-name";
 
 const root = join(import.meta.dir, "../../..");
 
@@ -11,6 +12,33 @@ mock.module(join(root, "commands/plugins/sleep/impl"), () => ({
 }));
 
 const { default: handler } = await import("./index");
+
+describe("deriveWindowName (#1181)", () => {
+  it("stem oracle → stem-oracle", () => {
+    expect(deriveWindowName("neo")).toBe("neo-oracle");
+  });
+
+  it("slot-prefixed oracle → stem-oracle (slot stripped)", () => {
+    expect(deriveWindowName("29-arra-oracle-skills-cli")).toBe("arra-oracle-skills-cli-oracle");
+  });
+
+  it("multi-digit slot prefix stripped", () => {
+    expect(deriveWindowName("123-foo")).toBe("foo-oracle");
+  });
+
+  it("explicit window arg used as-is — no concat", () => {
+    expect(deriveWindowName("29-arra-oracle-skills-cli", "arra-oracle-skills-cli-oracle"))
+      .toBe("arra-oracle-skills-cli-oracle");
+  });
+
+  it("explicit window arg used as-is even with stem oracle", () => {
+    expect(deriveWindowName("neo", "skills")).toBe("skills");
+  });
+
+  it("oracle without slot prefix passes through unchanged", () => {
+    expect(deriveWindowName("homekeeper")).toBe("homekeeper-oracle");
+  });
+});
 
 describe("sleep plugin", () => {
   it("CLI — valid oracle sleeps ok", async () => {


### PR DESCRIPTION
## Summary

Fixes [maw-js#1181](https://github.com/Soul-Brews-Studio/maw-js/issues/1181) — \`maw sleep\` failed to resolve windows for slot-prefixed sessions because of bad string concatenation in the window-name derivation.

## What broke

\`plugins/sleep/impl.ts:26\` derived the window name as:

\`\`\`ts
const windowName = window ? \`\${oracle}-\${window}\` : \`\${oracle}-oracle\`;
\`\`\`

Two flaws in one line:
1. Slot prefix not stripped — \`oracle = "29-arra-oracle-skills-cli"\` produced \`29-arra-oracle-skills-cli-oracle\` (no fleet entry uses that pattern).
2. Explicit window arg got concatenated, not used as-is — \`maw sleep <session> <window>\` produced \`<oracle>-<window>\` junk.

## What changes

- Extracted \`deriveWindowName(oracle, window?)\` as a pure function in a new file (\`derive-window-name.ts\`)
- Strips leading \`\\d+-\` from oracle → handles slot-prefix
- Uses \`window\` arg as-is when supplied → no concat

## Tests

- 6 new tests covering all combinations (stem only, slot-prefixed, multi-digit slot, explicit window arg, etc.) — all pass
- The 3 pre-existing failures in \`sleep.test.ts\` (mock path doesn't match \`./impl\` resolution) are unrelated and predate this branch — leaving for a separate cleanup

## Test plan

- [x] \`bun test plugins/sleep/\` — 9 pass / 3 fail (the 3 fails are pre-existing)
- [x] All 6 new \`deriveWindowName\` tests pass
- [ ] Manual verify after merge: \`maw sleep 29-<slot>\` resolves correctly

## Real repro that motivated this

During cleanup of \`29-arra-oracle-skills-cli\` oracle today, \`maw sleep\` with full session name failed; only the bare stem worked. With \`maw incubate\` (PR #16) shipping today and creating slot-prefixed sessions, this is hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)