### PR TITLE
test(sleep): fix mock.module path (#18)

### DIFF
--- a/plugins/sleep/sleep.test.ts
+++ b/plugins/sleep/sleep.test.ts
@@ -3,9 +3,11 @@ import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 import { deriveWindowName } from "./derive-window-name";
 
-const root = join(import.meta.dir, "../../..");
-
-mock.module(join(root, "commands/plugins/sleep/impl"), () => ({
+// Mock the actual ./impl resolution path the handler uses.
+// Previously targeted <registry-root>/commands/plugins/sleep/impl which did
+// not match — the handler imports "./impl" which resolves to this directory.
+// (#18 fix)
+mock.module(join(import.meta.dir, "impl"), () => ({
   cmdSleepOne: async (oracle: string, window?: string) => {
     console.log(`sleep ${oracle}${window ? ` window=${window}` : ""}`);
   },


### PR DESCRIPTION
## Summary

Closes #18 — the 3 pre-existing test failures in \`plugins/sleep/sleep.test.ts\` were caused by \`mock.module()\` targeting the wrong path.

### Before

\`\`\`ts
mock.module(join(root, "commands/plugins/sleep/impl"), () => ({...}));
\`\`\`

That path (\`<registry-root>/commands/plugins/sleep/impl\`) doesn't match anything the handler imports. Handler at \`plugins/sleep/index.ts:2\` does \`import { cmdSleepOne } from "./impl"\` — relative to itself.

Mock never intercepted → real \`cmdSleepOne\` ran → threw "no running session found for 'neo'" → \`result.ok=false\` → 3 tests fail.

### After

\`\`\`ts
mock.module(join(import.meta.dir, "impl"), () => ({...}));
\`\`\`

\`import.meta.dir\` resolves to the test file's dir, + "impl" gives the absolute path that matches what \`./impl\` resolves to from the handler.

### Result

\`\`\`
12 pass
0 fail
18 expect() calls
Ran 12 tests across 1 file. [7ms]
\`\`\`

(was 9 pass / 3 fail before this fix)

## Test plan

- [x] \`bun test plugins/sleep/\` — all 12 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)