### PR TITLE
feat(doctor): warn when local maw-js is behind alpha (maw-js#1180)

### DIFF
--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "maw-js/config";
 import { C } from "maw-js/commands/shared/fleet-doctor-fixer";
 import { loadManifestCached, invalidateManifest } from "maw-js/lib/oracle-manifest";
 import { findGaps, summarizeGaps } from "./cross-source-detect";
+import { checkMawJsBranch } from "./internal/maw-js-branch-check";
 
 export interface DoctorResult {
   ok: boolean;
@@ -38,6 +39,9 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
     }
     if (!only || only === "manifest" || only === "all") {
       checks.push(checkCrossSourceConsistency());
+    }
+    if (!only || only === "maw-js" || only === "all") {
+      checks.push(await checkMawJsBranch());
     }
   }
 

--- a/plugins/doctor/internal/maw-js-branch-check.test.ts
+++ b/plugins/doctor/internal/maw-js-branch-check.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { execSync } from "child_process";
+import { checkMawJsBranch } from "./maw-js-branch-check";
+
+// We test the full check by setting $MAW_JS_SOURCE to a tmp git repo
+// and exercising each branch state.
+
+function init(repo: string) {
+  execSync(`git -C '${repo}' init -q`);
+  execSync(`git -C '${repo}' config user.email t@e`);
+  execSync(`git -C '${repo}' config user.name t`);
+  execSync(`git -C '${repo}' commit --allow-empty -q -m base`);
+}
+
+describe("checkMawJsBranch (#1180)", () => {
+  let tmp: string;
+  let prevEnv: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "maw-js-test-"));
+    prevEnv = process.env.MAW_JS_SOURCE;
+    process.env.MAW_JS_SOURCE = tmp;
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    if (prevEnv === undefined) delete process.env.MAW_JS_SOURCE;
+    else process.env.MAW_JS_SOURCE = prevEnv;
+  });
+
+  it("missing clone → ok with skip message", async () => {
+    process.env.MAW_JS_SOURCE = "/nonexistent/path";
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("no local maw-js clone found");
+  });
+
+  it("on alpha → ok", async () => {
+    init(tmp);
+    execSync(`git -C '${tmp}' checkout -q -b alpha`);
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("on alpha");
+  });
+
+  it("on other branch with no alpha ref → ok, no comparison", async () => {
+    init(tmp);
+    execSync(`git -C '${tmp}' checkout -q -b feat/foo`);
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("no local alpha ref");
+  });
+
+  it("on other branch, alpha at parity → ok", async () => {
+    init(tmp);
+    execSync(`git -C '${tmp}' checkout -q -b alpha`);
+    execSync(`git -C '${tmp}' checkout -q -b feat/foo`);
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain("at parity");
+  });
+
+  it("on other branch, alpha ahead → WARN with count", async () => {
+    init(tmp);
+    execSync(`git -C '${tmp}' checkout -q -b feat/foo`);
+    execSync(`git -C '${tmp}' checkout -q -b alpha`);
+    execSync(`git -C '${tmp}' commit --allow-empty -q -m fix1`);
+    execSync(`git -C '${tmp}' commit --allow-empty -q -m fix2`);
+    execSync(`git -C '${tmp}' commit --allow-empty -q -m fix3`);
+    execSync(`git -C '${tmp}' checkout -q feat/foo`);
+
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("3 unmerged commits");
+    expect(result.message).toContain("git checkout alpha");
+  });
+
+  it("singular commit count uses 'commit' not 'commits'", async () => {
+    init(tmp);
+    execSync(`git -C '${tmp}' checkout -q -b feat/foo`);
+    execSync(`git -C '${tmp}' checkout -q -b alpha`);
+    execSync(`git -C '${tmp}' commit --allow-empty -q -m fix1`);
+    execSync(`git -C '${tmp}' checkout -q feat/foo`);
+
+    const result = await checkMawJsBranch();
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain("1 unmerged commit ");
+    expect(result.message).not.toContain("1 unmerged commits");
+  });
+});

--- a/plugins/doctor/internal/maw-js-branch-check.ts
+++ b/plugins/doctor/internal/maw-js-branch-check.ts
@@ -1,0 +1,175 @@
+import { existsSync } from "fs";
+import { execSync } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * #1180 — Warn when local maw-js clone is on a branch behind `alpha`.
+ *
+ * Multiple times today, `maw bud`/`maw incubate` failed mysteriously because
+ * the local maw-js was on a feature branch that lacked recent alpha fixes
+ * (e.g. #1177's missing `should-auto-wake` export). Detection takes ~50 ms,
+ * surfaces the issue immediately instead of after a failed bud crashes.
+ *
+ * Resolution order for the maw-js source path:
+ *   1. $MAW_JS_SOURCE env var (explicit override)
+ *   2. `ghq list` for Soul-Brews-Studio/maw-js (if ghq present)
+ *   3. ~/Code/github.com/Soul-Brews-Studio/maw-js (conventional default)
+ *
+ * If no clone is found → ok:true with skipped message (the check is N/A
+ * for users not doing maw-js development).
+ *
+ * Behavior:
+ *   - on `alpha`        → ok, "on alpha"
+ *   - no alpha ref      → ok, "no alpha branch (single-branch checkout?)"
+ *   - on other branch with alpha 0 commits ahead → ok, "branch X is at parity with alpha"
+ *   - on other branch with alpha N commits ahead → WARN, "branch X is N commits behind alpha"
+ *     (returns ok:false so doctor exits non-zero unless --allow-drift)
+ */
+export async function checkMawJsBranch(): Promise<{
+  name: string;
+  ok: boolean;
+  message: string;
+}> {
+  const path = resolveMawJsPath();
+  if (!path) {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: "no local maw-js clone found (set $MAW_JS_SOURCE or clone to ~/Code/github.com/Soul-Brews-Studio/maw-js)",
+    };
+  }
+
+  // Detect current branch (HEAD ref name).
+  const branch = gitBranch(path);
+  if (!branch) {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: `maw-js found at ${path} but git HEAD unreadable — skipping`,
+    };
+  }
+
+  if (branch === "alpha") {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: `on alpha @ ${path}`,
+    };
+  }
+
+  // Check whether `alpha` ref exists locally
+  if (!gitRefExists(path, "alpha")) {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: `on '${branch}' — no local alpha ref to compare against`,
+    };
+  }
+
+  // Count commits in <branch>..alpha (alpha-ahead-of-branch)
+  const ahead = gitRevListCount(path, `${branch}..alpha`);
+  if (ahead == null) {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: `on '${branch}' — could not compare with alpha`,
+    };
+  }
+
+  if (ahead === 0) {
+    return {
+      name: "maw-js:branch",
+      ok: true,
+      message: `on '${branch}' — at parity with alpha`,
+    };
+  }
+
+  // Drift detected
+  return {
+    name: "maw-js:branch",
+    ok: false,
+    message: `on '${branch}' — alpha has ${ahead} unmerged commit${ahead === 1 ? "" : "s"} (cd ${path} && git checkout alpha to align)`,
+  };
+}
+
+function resolveMawJsPath(): string | null {
+  // Explicit override: if set, trust it (return null if invalid — don't fall back).
+  const env = process.env.MAW_JS_SOURCE;
+  if (env !== undefined && env !== "") {
+    return existsGitRepo(env) ? env : null;
+  }
+
+  // ghq list
+  try {
+    const raw = execSync("ghq list 2>/dev/null", { encoding: "utf-8" });
+    const root = (() => {
+      try {
+        return execSync("ghq root 2>/dev/null", { encoding: "utf-8" }).trim();
+      } catch {
+        return null;
+      }
+    })();
+    if (root) {
+      const match = raw
+        .split("\n")
+        .find(l => l.endsWith("/Soul-Brews-Studio/maw-js"));
+      if (match) {
+        const full = join(root, match);
+        if (existsGitRepo(full)) return full;
+      }
+    }
+  } catch {
+    /* ghq not available */
+  }
+
+  // Conventional default
+  const conventional = join(homedir(), "Code", "github.com", "Soul-Brews-Studio", "maw-js");
+  if (existsGitRepo(conventional)) return conventional;
+
+  return null;
+}
+
+function existsGitRepo(path: string): boolean {
+  try {
+    return existsSync(join(path, ".git"));
+  } catch {
+    return false;
+  }
+}
+
+function gitBranch(path: string): string | null {
+  try {
+    const out = execSync(`git -C '${path.replace(/'/g, "'\\''")}' branch --show-current 2>/dev/null`, {
+      encoding: "utf-8",
+    }).trim();
+    return out || null;
+  } catch {
+    return null;
+  }
+}
+
+function gitRefExists(path: string, ref: string): boolean {
+  try {
+    execSync(
+      `git -C '${path.replace(/'/g, "'\\''")}' rev-parse --verify '${ref}' 2>/dev/null`,
+      { encoding: "utf-8" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function gitRevListCount(path: string, range: string): number | null {
+  try {
+    const out = execSync(
+      `git -C '${path.replace(/'/g, "'\\''")}' rev-list --count '${range}' 2>/dev/null`,
+      { encoding: "utf-8" },
+    ).trim();
+    const n = parseInt(out, 10);
+    return Number.isFinite(n) ? n : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Closes maw-js#1180. Adds a \`maw doctor\` check that surfaces when the local maw-js clone is on a branch behind \`alpha\` — would have caught Bug B (maw-js#1176 missing export) twice today before \`maw bud\` failed with a cryptic module error.

## Implementation

- \`plugins/doctor/internal/maw-js-branch-check.ts\` — pure check function
- \`plugins/doctor/impl.ts\` — plumbed into the dispatcher (runs by default + \`maw doctor maw-js\` to scope)

## Path resolution (first wins)

1. \`\$MAW_JS_SOURCE\` env var (explicit override — strict; null if invalid)
2. \`ghq list\` for Soul-Brews-Studio/maw-js
3. \`~/Code/github.com/Soul-Brews-Studio/maw-js\` (conventional default)

If none found → ok with \"no local clone\" message (skipped for non-dev users).

## Behavior

| State | Result |
|-------|--------|
| on alpha | ✓ ok |
| no alpha ref locally | ✓ ok (single-branch checkout) |
| on other branch, alpha 0 commits ahead | ✓ ok (at parity) |
| on other branch, alpha N commits ahead | ✗ WARN with \`git checkout alpha\` hint |
| no clone resolvable | ✓ ok (N/A) |

## Output sample

\`\`\`
✗ maw doctor
  ✓ install: maw binary present and resolvable
  ✓ version:source: aligned (26.4.18)
  ✓ peers:duplicates: no <oracle>:<node> collisions across 4 peers
  ✓ manifest:cross-source: no gaps detected
  ✗ maw-js:branch: on 'feat/wake-no-prompt' — alpha has 4 unmerged commits
                   (cd ~/Code/.../maw-js && git checkout alpha to align)
\`\`\`

## Test plan

- [x] 6 unit tests via tmp git repos (\`bun test plugins/doctor/internal/\`)
  - missing clone → skip
  - on alpha → ok
  - no alpha ref → ok
  - alpha at parity → ok
  - alpha N ahead → warn
  - singular vs plural commit count

🤖 Generated with [Claude Code](https://claude.com/claude-code)