### PR TITLE
fix(costs): resolve "local" host sentinel to localhost for HTTP fetch

### DIFF
--- a/plugins/costs/impl.ts
+++ b/plugins/costs/impl.ts
@@ -19,7 +19,8 @@ type CostsResponse = {
 
 export async function cmdCosts() {
   const config = loadConfig();
-  const base = `http://${config.host}:${config.port}`;
+  const effectiveHost = config.host === "local" ? "localhost" : config.host;
+  const base = `http://${effectiveHost}:${config.port}`;
 
   // Split three distinct failure paths so diagnostics aren't misleading (#390.1):
   //   1. fetch throws  → real network failure, pm2 server not running
@@ -109,7 +110,8 @@ type DailyResponse = {
 
 export async function cmdCostsDaily(days: number, json: boolean) {
   const config = loadConfig();
-  const base = `http://${config.host}:${config.port}`;
+  const effectiveHost = config.host === "local" ? "localhost" : config.host;
+  const base = `http://${effectiveHost}:${config.port}`;
 
   let res: Response;
   try {


### PR DESCRIPTION
## Problem

`maw costs` fails with:

```
cannot reach maw server — is `maw serve` running?
```

even when `maw serve` is running normally on `localhost:3456`.

## Root cause

`config.host` stores `"local"` as a sentinel meaning "this machine" — maw auto-migrates bind addresses (including `"localhost"`) to `"local"` on config load (see `BIND_ADDRESSES` in `config/load.ts`).

Other transport layers handle this correctly, e.g. `ssh.ts`:
```ts
const IS_LOCAL = DEFAULT_HOST === "local" || DEFAULT_HOST === "localhost";
```

But `cmdCosts` and `cmdCostsDaily` used `config.host` directly in the fetch URL:
```ts
const base = `http://${config.host}:${config.port}`;
// → http://local:3456  ← does not resolve
```

## Fix

Resolve `"local"` → `"localhost"` before building the base URL in both functions:
```ts
const effectiveHost = config.host === "local" ? "localhost" : config.host;
const base = `http://${effectiveHost}:${config.port}`;
```

## Reproduction

1. Default `maw.config.json` has `"host": "local"` (or start from `"localhost"` — maw migrates it automatically)
2. `maw serve` running
3. `maw costs` → `cannot reach maw server`