### PR TITLE
feat(awaken): reserve -y/--yes flag (#31)

### DIFF
--- a/plugins/awaken/index.ts
+++ b/plugins/awaken/index.ts
@@ -50,6 +50,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "--force": Boolean,
           "--track-vault": Boolean,
           "--sync-peers": Boolean,
+          "--yes": Boolean,
+          "-y": "--yes",
         },
         0,
       );


### PR DESCRIPTION
Forward-compat reservation of -y/--yes on awaken. Schema-only — no-op until #31 lands the prompt.