### PR TITLE
feat: -y/--yes prompt (#31) + smart attach Phase 1 (#25)

### DIFF
--- a/plugins/attach/attach.test.ts
+++ b/plugins/attach/attach.test.ts
@@ -1,0 +1,271 @@
+/**
+ * attach plugin tests (#25 Phase 1).
+ *
+ * Two layers:
+ *   1. Resolver — pure, no mocks, exercises Tier 1 / Tier 2 / ambiguous / null
+ *   2. Handler — mocks listSessions + loadFleet + the maw subprocess via
+ *      mock.module on Bun.spawn, verifies the cascade emits the right command
+ */
+
+import { test, expect, mock } from "bun:test";
+import { resolveAttachTarget, type SessionLike, type FleetLike } from "./resolve-attach-target";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Resolver tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeDeps(sessions: SessionLike[], fleet: FleetLike[]) {
+  return {
+    listSessions: async () => sessions,
+    loadFleet: () => fleet,
+  };
+}
+
+test("resolver: Tier 1 — exact session name match", async () => {
+  const deps = makeDeps([{ name: "discord-oracle", windows: [{ name: "discord-oracle" }] }], []);
+  const r = await resolveAttachTarget("discord-oracle", deps);
+  expect(r).toEqual({ tier: 1, sessionName: "discord-oracle" });
+});
+
+test("resolver: Tier 1 — slot-prefix-aware suffix match", async () => {
+  const deps = makeDeps([{ name: "24-discord-oracle", windows: [{ name: "discord-oracle" }] }], []);
+  const r = await resolveAttachTarget("discord-oracle", deps);
+  expect(r).toEqual({ tier: 1, sessionName: "24-discord-oracle" });
+});
+
+test("resolver: Tier 1 — case-insensitive match", async () => {
+  const deps = makeDeps([{ name: "Discord-Oracle", windows: [{ name: "x" }] }], []);
+  const r = await resolveAttachTarget("DISCORD-ORACLE", deps);
+  expect(r).toEqual({ tier: 1, sessionName: "Discord-Oracle" });
+});
+
+test("resolver: Tier 2 — fleet entry, no live session", async () => {
+  const deps = makeDeps([], [{ name: "24-discord-oracle", windows: [{ name: "discord-oracle" }] }]);
+  const r = await resolveAttachTarget("discord-oracle", deps);
+  expect(r).toEqual({ tier: 2, fleetName: "24-discord-oracle" });
+});
+
+test("resolver: ambiguous Tier 1 — multiple live sessions match", async () => {
+  const deps = makeDeps(
+    [
+      { name: "24-discord-oracle", windows: [{ name: "x" }] },
+      { name: "99-discord-oracle", windows: [{ name: "x" }] },
+    ],
+    [],
+  );
+  const r = await resolveAttachTarget("discord-oracle", deps);
+  expect(r?.tier).toBe(1);
+  expect(r?.ambiguousCandidates).toEqual(["24-discord-oracle", "99-discord-oracle"]);
+});
+
+test("resolver: ambiguous Tier 2 — multiple fleet entries match", async () => {
+  const deps = makeDeps(
+    [],
+    [
+      { name: "24-discord-oracle", windows: [{ name: "x" }] },
+      { name: "30-discord-oracle", windows: [{ name: "x" }] },
+    ],
+  );
+  const r = await resolveAttachTarget("discord-oracle", deps);
+  expect(r?.tier).toBe(2);
+  expect(r?.ambiguousCandidates).toEqual(["24-discord-oracle", "30-discord-oracle"]);
+});
+
+test("resolver: no match → null", async () => {
+  const deps = makeDeps([{ name: "foo-oracle", windows: [{ name: "x" }] }], [{ name: "bar-oracle", windows: [{ name: "x" }] }]);
+  const r = await resolveAttachTarget("does-not-exist", deps);
+  expect(r).toBeNull();
+});
+
+test("resolver: live session takes precedence over fleet entry", async () => {
+  const deps = makeDeps(
+    [{ name: "24-foo-oracle", windows: [{ name: "x" }] }],
+    [{ name: "24-foo-oracle", windows: [{ name: "x" }] }],
+  );
+  const r = await resolveAttachTarget("foo-oracle", deps);
+  expect(r).toEqual({ tier: 1, sessionName: "24-foo-oracle" });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. Handler tests — cascade + flag plumbing
+// ─────────────────────────────────────────────────────────────────────────────
+
+function setupHandlerMocks(opts: {
+  sessions?: SessionLike[];
+  fleet?: FleetLike[];
+}) {
+  const spawnCalls: string[][] = [];
+
+  mock.module("maw-js/sdk", () => ({
+    listSessions: async () => opts.sessions ?? [],
+  }));
+  mock.module("maw-js/commands/shared/fleet-load", () => ({
+    loadFleet: () => opts.fleet ?? [],
+  }));
+
+  // Bun.spawn is global — patch it with a stub that records args + returns
+  // an immediately-resolved exited promise.
+  const realSpawn = Bun.spawn;
+  (Bun as any).spawn = (args: string[]) => {
+    spawnCalls.push(args);
+    return {
+      exited: Promise.resolve(0),
+    };
+  };
+
+  mock.module("maw-js/cli/parse-args", () => ({
+    parseFlags: (args: string[], schema: any) => {
+      const out: any = { _: [] };
+      const aliases: Record<string, string> = {};
+      for (const [k, v] of Object.entries(schema)) {
+        if (typeof v === "string" && v.startsWith("--")) aliases[k] = v;
+      }
+      for (let i = 0; i < args.length; i++) {
+        let a = args[i];
+        if (aliases[a]) a = aliases[a];
+        if (a.startsWith("--")) {
+          const ty = schema[a];
+          if (ty === Boolean) out[a] = true;
+          else if (ty === Number) out[a] = Number(args[++i]);
+          else out[a] = args[++i];
+        } else {
+          out._.push(a);
+        }
+      }
+      return out;
+    },
+  }));
+
+  return {
+    spawnCalls,
+    restore: () => {
+      (Bun as any).spawn = realSpawn;
+      mock.restore();
+    },
+  };
+}
+
+test("handler: Tier 1 (live) — invokes `maw tmux attach <session>`", async () => {
+  const ctx = setupHandlerMocks({
+    sessions: [{ name: "24-discord-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["discord-oracle"], writer: undefined } as any);
+    expect(result.ok).toBe(true);
+    expect(ctx.spawnCalls.length).toBe(1);
+    expect(ctx.spawnCalls[0]).toEqual(["maw", "tmux", "attach", "24-discord-oracle"]);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: Tier 1 dry-run — no spawn, prints plan", async () => {
+  const ctx = setupHandlerMocks({
+    sessions: [{ name: "24-discord-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["discord-oracle", "--dry-run"], writer: undefined } as any);
+    expect(result.ok).toBe(true);
+    expect(ctx.spawnCalls.length).toBe(0);
+    expect(result.output).toMatch(/Tier 1/);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: Tier 2 with -y — wakes then attaches, no prompt", async () => {
+  const ctx = setupHandlerMocks({
+    fleet: [{ name: "24-discord-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["discord-oracle", "-y"], writer: undefined } as any);
+    expect(result.ok).toBe(true);
+    expect(ctx.spawnCalls.length).toBe(2);
+    expect(ctx.spawnCalls[0]).toEqual(["maw", "wake", "24-discord-oracle"]);
+    expect(ctx.spawnCalls[1]).toEqual(["maw", "tmux", "attach", "24-discord-oracle"]);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: Tier 2 dry-run — no spawn, says 'would wake … then attach'", async () => {
+  const ctx = setupHandlerMocks({
+    fleet: [{ name: "24-discord-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["discord-oracle", "--dry-run"], writer: undefined } as any);
+    expect(result.ok).toBe(true);
+    expect(ctx.spawnCalls.length).toBe(0);
+    expect(result.output).toMatch(/Tier 2/);
+    expect(result.output).toMatch(/would wake/);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: no match — returns error listing availables", async () => {
+  const ctx = setupHandlerMocks({
+    sessions: [{ name: "foo-oracle", windows: [{ name: "x" }] }],
+    fleet: [{ name: "bar-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["nonexistent"], writer: undefined } as any);
+    expect(result.ok).toBe(false);
+    expect(result.output).toMatch(/no oracle named 'nonexistent'/);
+    expect(result.output).toMatch(/foo-oracle/);
+    expect(result.output).toMatch(/bar-oracle/);
+    expect(ctx.spawnCalls.length).toBe(0);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: ambiguous match — stops without spawning", async () => {
+  const ctx = setupHandlerMocks({
+    sessions: [
+      { name: "24-discord-oracle", windows: [{ name: "x" }] },
+      { name: "99-discord-oracle", windows: [{ name: "x" }] },
+    ],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: ["discord-oracle"], writer: undefined } as any);
+    expect(result.ok).toBe(false);
+    expect(result.output).toMatch(/ambiguous/);
+    expect(ctx.spawnCalls.length).toBe(0);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("handler: missing name returns usage", async () => {
+  const ctx = setupHandlerMocks({});
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "cli", args: [], writer: undefined } as any);
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/usage/);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("API: dispatch invokes the cascade with yes=true (no TTY)", async () => {
+  const ctx = setupHandlerMocks({
+    fleet: [{ name: "24-foo-oracle", windows: [{ name: "x" }] }],
+  });
+  try {
+    const handler = (await import("./index")).default;
+    const result = await handler({ source: "api", args: { name: "foo-oracle" } } as any);
+    expect(result.ok).toBe(true);
+    expect(ctx.spawnCalls.length).toBe(2);
+    expect(ctx.spawnCalls[0]).toEqual(["maw", "wake", "24-foo-oracle"]);
+  } finally {
+    ctx.restore();
+  }
+});

--- a/plugins/attach/impl.ts
+++ b/plugins/attach/impl.ts
@@ -1,0 +1,121 @@
+/**
+ * `maw attach <name>` cascade — Phase 1 (#25).
+ *
+ *   Tier 1 (live):     attach immediately via `maw tmux attach <session>`
+ *   Tier 2 (sleeping): prompt → `maw wake <fleet-name>` → attach
+ *   no match:          error + list of available oracles
+ *
+ * Deferred to follow-up issues: T3 (ghq clone, no fleet), T4 (remote-only on
+ * GitHub), T5 (nothing exists), and the non-interactive variant beyond -y.
+ */
+import { listSessions } from "maw-js/sdk";
+import { loadFleet } from "maw-js/commands/shared/fleet-load";
+import { resolveAttachTarget, type ResolveResult } from "./resolve-attach-target";
+
+export interface AttachOpts {
+  /** Skip the human-confirmation prompt on Tier 2 (agents / scripted). */
+  yes?: boolean;
+  /** Show what the cascade picked + planned action, no side effects. */
+  dryRun?: boolean;
+}
+
+/**
+ * Read a single y/n from /dev/tty (not stdin) so a piped upstream tool can't
+ * break the prompt. Defaults to N on error or any non-y answer.
+ * Duplicates the helper in plugins/awaken/impl.ts — Phase 1 keeps these
+ * inline; a shared helper can land in a refactor PR once two more plugins
+ * grow the same pattern.
+ */
+function askYesNo(question: string): boolean {
+  const fs = require("fs");
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync("/dev/tty", "r");
+    process.stderr.write(question);
+    const buf = Buffer.alloc(8);
+    const bytesRead = fs.readSync(fd, buf, 0, 8, null);
+    const answer = buf.toString("utf-8", 0, bytesRead).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch {} }
+  }
+}
+
+function listAvailable(fleet: { name: string }[], sessions: { name: string }[]): string {
+  const all = new Set<string>([...sessions.map(s => s.name), ...fleet.map(f => f.name)]);
+  if (all.size === 0) return "(none)";
+  return [...all].sort().join(", ");
+}
+
+export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<void> {
+  if (!name) {
+    console.error("usage: maw attach <name> [--dry-run] [-y]");
+    throw new Error("name required");
+  }
+
+  const deps = { listSessions, loadFleet };
+  const result: ResolveResult = await resolveAttachTarget(name, deps);
+
+  if (!result) {
+    const sessions = await listSessions();
+    console.error(`\x1b[31m✗\x1b[0m no oracle named '${name}' is live or in the fleet`);
+    console.error(`  available: ${listAvailable(loadFleet(), sessions)}`);
+    throw new Error(`oracle '${name}' not found`);
+  }
+
+  // Ambiguous match: list candidates, stop. User picks one and re-runs with
+  // the full name. (Auto-prompt for selection can land in Phase 2.)
+  if (result.ambiguousCandidates && result.ambiguousCandidates.length > 1) {
+    console.error(`\x1b[33m⚠\x1b[0m '${name}' is ambiguous — ${result.ambiguousCandidates.length} matches:`);
+    for (const c of result.ambiguousCandidates) console.error(`    • ${c}`);
+    console.error(`  use the full name: \x1b[36mmaw attach <exact-name>\x1b[0m`);
+    throw new Error(`ambiguous: ${name}`);
+  }
+
+  if (result.tier === 1) {
+    if (opts.dryRun) {
+      console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 1 (live) — would attach to ${result.sessionName}`);
+      return;
+    }
+    console.log(`  \x1b[32m→\x1b[0m attaching to ${result.sessionName}`);
+    await spawnMaw(["tmux", "attach", result.sessionName]);
+    return;
+  }
+
+  // Tier 2 — sleeping, prompt for wake.
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 2 (sleeping) — would wake ${result.fleetName}, then attach`);
+    return;
+  }
+
+  console.log(`  \x1b[33m○\x1b[0m '${result.fleetName}' is sleeping (fleet-registered, not running)`);
+  const promptable = !opts.yes && Boolean(process.stdin.isTTY);
+  if (promptable && !askYesNo(`  Wake \"${result.fleetName}\"? [y/N] `)) {
+    console.log("  aborted — no changes made.");
+    return;
+  }
+
+  console.log(`  \x1b[36m⚡\x1b[0m waking ${result.fleetName}...`);
+  await spawnMaw(["wake", result.fleetName]);
+  console.log(`  \x1b[32m→\x1b[0m attaching to ${result.fleetName}`);
+  await spawnMaw(["tmux", "attach", result.fleetName]);
+}
+
+/**
+ * Invoke `maw` as a subprocess so we go through the same dispatch path the
+ * user would use directly. tmux attach takes over the terminal — `inherit`
+ * stdio is required for that handoff to work.
+ */
+async function spawnMaw(args: string[]): Promise<void> {
+  const proc = Bun.spawn(["maw", ...args], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`maw ${args.join(" ")} exited ${exitCode}`);
+  }
+}

--- a/plugins/attach/index.ts
+++ b/plugins/attach/index.ts
@@ -1,0 +1,66 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+import { cmdAttach } from "./impl";
+
+export const command = {
+  name: "attach",
+  description: "Smart attach — running session, or wake from fleet and attach (#25).",
+};
+
+const USAGE = "usage: maw attach <name> [--dry-run] [-y|--yes]";
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    if (ctx.source === "cli") {
+      const args = ctx.args as string[];
+      const flags = parseFlags(
+        args,
+        {
+          "--dry-run": Boolean,
+          "--yes": Boolean,
+          "-y": "--yes",
+        },
+        0,
+      );
+      const name = flags._[0];
+      if (!name || name === "--help" || name === "-h") {
+        return { ok: false, error: USAGE };
+      }
+      if (name.startsWith("-")) {
+        return { ok: false, error: `"${name}" looks like a flag, not an oracle name.\n  ${USAGE}` };
+      }
+      await cmdAttach(name, {
+        dryRun: flags["--dry-run"],
+        yes: flags["--yes"],
+      });
+    } else if (ctx.source === "api") {
+      const body = ctx.args as Record<string, unknown>;
+      const name = body.name as string;
+      if (!name) return { ok: false, error: "name required" };
+      // API path: never prompt (no TTY). Treat as -y.
+      await cmdAttach(name, {
+        dryRun: body.dryRun as boolean | undefined,
+        yes: true,
+      });
+    }
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || String(e), output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/attach/plugin.json
+++ b/plugins/attach/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "attach",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Smart attach: live tmux session, or wake from fleet and attach (#25 Phase 1).",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "attach",
+    "help": "maw attach <name> [--dry-run] [-y] — attach to a live session, or wake from fleet and attach"
+  },
+  "weight": 0
+}

--- a/plugins/attach/resolve-attach-target.ts
+++ b/plugins/attach/resolve-attach-target.ts
@@ -1,0 +1,88 @@
+/**
+ * Resolve a `maw attach <target>` invocation into a tiered match. (#25 Phase 1)
+ *
+ * Tier 1 — running:  tmux session matches (incl. slot prefix / stem suffix)
+ *                    → attach immediately, no prompt
+ * Tier 2 — sleeping: fleet entry matches but no live tmux session
+ *                    → prompt to wake, then attach
+ * null          — nothing matched: caller emits "available oracles" hint
+ *
+ * Phase 1 deliberately omits T3 (ghq clone without fleet), T4 (remote-only on
+ * GitHub), and T5 (nothing exists). Those land in follow-up issues.
+ *
+ * Deps are injected for testability — same shape as the sleep resolver.
+ */
+
+export interface SessionLike {
+  name: string;
+  windows: Array<{ name: string }>;
+}
+
+export interface FleetLike {
+  name: string;
+  windows: Array<{ name: string }>;
+}
+
+export interface ResolveDeps {
+  listSessions: () => Promise<SessionLike[]>;
+  loadFleet: () => FleetLike[];
+}
+
+export type ResolveResult =
+  | { tier: 1; sessionName: string; windowName?: string; ambiguousCandidates?: string[] }
+  | { tier: 2; fleetName: string; ambiguousCandidates?: string[] }
+  | null;
+
+const stripDash = (s: string) => s.replace(/-+$/, "");
+
+/**
+ * Try every reasonable name comparison: exact, slot-suffix
+ * (`-${target}`), and dash-trimmed stem. Matches the conventions
+ * established by sleep/done resolvers.
+ */
+function nameMatches(name: string, target: string): boolean {
+  const n = name.toLowerCase();
+  const t = target.toLowerCase();
+  return (
+    n === t ||
+    n.endsWith(`-${t}`) ||
+    stripDash(n) === stripDash(t)
+  );
+}
+
+export async function resolveAttachTarget(
+  target: string,
+  deps: ResolveDeps,
+): Promise<ResolveResult> {
+  const sessions = await deps.listSessions();
+
+  // Tier 1 — live tmux session matches.
+  const runningMatches = sessions.filter(s => nameMatches(s.name, target));
+  if (runningMatches.length === 1) {
+    return { tier: 1, sessionName: runningMatches[0].name };
+  }
+  if (runningMatches.length > 1) {
+    // Ambiguity in live sessions — surface every match for the caller's prompt.
+    return {
+      tier: 1,
+      sessionName: runningMatches[0].name,
+      ambiguousCandidates: runningMatches.map(s => s.name),
+    };
+  }
+
+  // Tier 2 — fleet-registered, sleeping.
+  const fleet = deps.loadFleet();
+  const fleetMatches = fleet.filter(f => nameMatches(f.name, target));
+  if (fleetMatches.length === 1) {
+    return { tier: 2, fleetName: fleetMatches[0].name };
+  }
+  if (fleetMatches.length > 1) {
+    return {
+      tier: 2,
+      fleetName: fleetMatches[0].name,
+      ambiguousCandidates: fleetMatches.map(f => f.name),
+    };
+  }
+
+  return null;
+}

--- a/plugins/awaken/awaken.test.ts
+++ b/plugins/awaken/awaken.test.ts
@@ -277,3 +277,103 @@ test("smoke: API dispatch missing name returns error", async () => {
   expect(result.error).toMatch(/name required/);
   mock.restore();
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Confirmation prompt (#31) — -y/--yes + TTY decision rules
+// ─────────────────────────────────────────────────────────────────────────────
+// Note: bun:test runs without a TTY (`process.stdin.isTTY` is undefined), so
+// the prompt branch is naturally skipped throughout the rest of the suite.
+// These tests pin the flag-forwarding contract explicitly.
+
+test("CLI: --yes is forwarded to cmdBud opts", async () => {
+  const calls = setupHappyPathMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["foo", "--root", "--yes"],
+    writer: () => {},
+  } as any);
+  expect(result.ok).toBe(true);
+  expect(calls.bud.length).toBe(1);
+  expect(calls.bud[0].opts.yes).toBe(true);
+  mock.restore();
+});
+
+test("CLI: -y short form maps to --yes (and forwards as opts.yes)", async () => {
+  const calls = setupHappyPathMocks();
+  // Override parser to recognize -y → --yes (alias support)
+  mock.module("maw-js/cli/parse-args", () => ({
+    parseFlags: (args: string[], schema: any) => {
+      const out: any = { _: [] };
+      const aliases: Record<string, string> = {};
+      for (const [k, v] of Object.entries(schema)) {
+        if (typeof v === "string" && v.startsWith("--")) aliases[k] = v;
+      }
+      for (let i = 0; i < args.length; i++) {
+        let a = args[i];
+        if (aliases[a]) a = aliases[a];
+        if (a.startsWith("--")) {
+          const ty = schema[a];
+          if (ty === Boolean) out[a] = true;
+          else if (ty === Number) out[a] = Number(args[++i]);
+          else out[a] = args[++i];
+        } else {
+          out._.push(a);
+        }
+      }
+      return out;
+    },
+  }));
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "cli",
+    args: ["foo", "--root", "-y"],
+    writer: () => {},
+  } as any);
+  expect(result.ok).toBe(true);
+  expect(calls.bud[0].opts.yes).toBe(true);
+  mock.restore();
+});
+
+test("call: cmdAwaken with yes:true proceeds without prompting (TTY-agnostic)", async () => {
+  const calls = setupHappyPathMocks();
+  // Pretend stdin is a TTY so the only thing keeping us from prompting is `yes`
+  const savedTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  try {
+    const { cmdAwaken } = await import("./impl");
+    await cmdAwaken("foo", { root: true, yes: true });
+    expect(calls.bud.length).toBe(1);
+    expect(calls.sendText.length).toBe(1);
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", { value: savedTTY, configurable: true });
+    mock.restore();
+  }
+});
+
+test("call: cmdAwaken with dryRun:true skips prompt even in TTY", async () => {
+  const calls = setupHappyPathMocks();
+  const savedTTY = process.stdin.isTTY;
+  Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+  try {
+    const { cmdAwaken } = await import("./impl");
+    await cmdAwaken("foo", { root: true, dryRun: true });
+    expect(calls.bud.length).toBe(1);
+    expect(calls.sendText.length).toBe(0); // dry-run bails before sendText
+  } finally {
+    Object.defineProperty(process.stdin, "isTTY", { value: savedTTY, configurable: true });
+    mock.restore();
+  }
+});
+
+test("API: yes defaults to true on the api dispatch path", async () => {
+  const calls = setupHappyPathMocks();
+  const handler = (await import("./index")).default;
+  const result = await handler({
+    source: "api",
+    args: { name: "foo", root: true },
+  } as any);
+  expect(result.ok).toBe(true);
+  expect(calls.bud[0].opts.yes).toBe(true);
+  mock.restore();
+});

--- a/plugins/awaken/impl.ts
+++ b/plugins/awaken/impl.ts
@@ -26,11 +26,72 @@ export interface AwakenOpts extends BudOpts {
   trigger?: string;
   /** Skip the trigger send entirely (just bud+wake). */
   noTrigger?: boolean;
+  /** `-y/--yes` — skip the human-confirmation prompt (#31). */
+  yes?: boolean;
 }
 
 const DEFAULT_TRIGGER = "/awaken";
 
+/**
+ * Confirmation prompt decision table (#31):
+ *   TTY + no -y + no --dry-run  → prompt
+ *   anything else                → skip
+ *
+ * Non-TTY (piped / scripted / agent) is treated as `-y` per Unix convention.
+ * --dry-run shows the plan unconditionally via cmdBud, no destructive action.
+ */
+function isPromptingNeeded(opts: AwakenOpts): boolean {
+  if (opts.yes) return false;
+  if (opts.dryRun) return false;
+  return Boolean(process.stdin.isTTY);
+}
+
+function summarizePlan(name: string, opts: AwakenOpts): string {
+  const lines: string[] = [`  Will create:`, `    oracle:  ${name}`];
+  if (opts.repo) lines.push(`    repo:    ${opts.repo}`);
+  else if (opts.org) lines.push(`    org:     ${opts.org}`);
+  if (opts.from) lines.push(`    from:    ${opts.from}`);
+  else if (opts.root) lines.push(`    parent:  root (no lineage)`);
+  const trigger = opts.noTrigger ? "(none — --no-trigger)" : (opts.trigger ?? DEFAULT_TRIGGER);
+  lines.push(`    trigger: ${trigger}`);
+  if (opts.fast) lines.push(`    mode:    fast (skip soul sync)`);
+  if (opts.seed) lines.push(`    mode:    seed (new mind)`);
+  if (opts.blank) lines.push(`    mode:    blank (no soul)`);
+  if (opts.split) lines.push(`    layout:  split pane`);
+  return lines.join("\n");
+}
+
+/**
+ * Read a single y/n from /dev/tty so a piped stdin (which might be consumed
+ * by an upstream tool) can't break the prompt. Defaults to N on any error
+ * or non-y answer.
+ */
+function askYesNo(question: string): boolean {
+  const fs = require("fs");
+  let fd: number | null = null;
+  try {
+    fd = fs.openSync("/dev/tty", "r");
+    process.stderr.write(question);
+    const buf = Buffer.alloc(8);
+    const bytesRead = fs.readSync(fd, buf, 0, 8, null);
+    const answer = buf.toString("utf-8", 0, bytesRead).trim().toLowerCase();
+    return answer === "y" || answer === "yes";
+  } catch {
+    return false;
+  } finally {
+    if (fd !== null) { try { fs.closeSync(fd); } catch {} }
+  }
+}
+
 export async function cmdAwaken(name: string, opts: AwakenOpts = {}): Promise<void> {
+  if (isPromptingNeeded(opts)) {
+    console.log(summarizePlan(name, opts));
+    if (!askYesNo("  Proceed? [y/N] ")) {
+      console.log("  aborted — no changes made.");
+      return;
+    }
+  }
+
   const trigger = opts.noTrigger ? null : (opts.trigger ?? DEFAULT_TRIGGER);
 
   // Step 1: bud (which also wakes via finalizeBud → cmdWake noAttach)

--- a/plugins/awaken/index.ts
+++ b/plugins/awaken/index.ts
@@ -8,7 +8,7 @@ export const command = {
 };
 
 const USAGE =
-  "usage: maw awaken <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run] [--trigger <text>] [--no-trigger]";
+  "usage: maw awaken <name> [--from <oracle>] [--root] [--seed] [--org <org>] [--repo org/repo] [--issue N] [--note <text>] [--nickname <pretty>] [--fast] [--split] [--dry-run] [--trigger <text>] [--no-trigger] [-y|--yes]";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -83,6 +83,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seed: flags["--seed"],
         blank: flags["--blank"],
         signalOnBirth: flags["--signal-on-birth"],
+        yes: flags["--yes"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -104,6 +105,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         seed: body.seed as boolean | undefined,
         blank: body.blank as boolean | undefined,
         signalOnBirth: body.signalOnBirth as boolean | undefined,
+        // API/HTTP path has no TTY by definition, but pass through for parity.
+        yes: (body.yes as boolean | undefined) ?? true,
       });
     }
 


### PR DESCRIPTION
Bundles two related quality-of-life features. Each commit is independently revertable and the tests cover each in isolation.

---

## #31 — -y/--yes TTY-aware confirmation prompt for awaken

`maw new` / `maw awaken` now confirms before creating an oracle when a human is at the keyboard. Agents and scripted pipelines (non-TTY stdin or `-y/--yes`) skip the prompt.

| stdin TTY? | -y flag? | --dry-run? | Action |
|---|---|---|---|
| TTY | no | no | prompt |
| TTY | yes | no | skip, run |
| TTY | * | yes | skip, show plan |
| not TTY | * | * | skip, run (Unix convention) |

Tests: 19/19 pass on `plugins/awaken/awaken.test.ts` (14 pre-existing + 5 new).

Closes #31.

---

## #25 Phase 1 — smart `maw attach` cascade

New plugin: `maw attach <name>` cascades through tiers:

  Tier 1 — live tmux session matches → attach immediately
  Tier 2 — fleet-registered, sleeping → prompt → wake → attach
  no match → error + list of available oracles

`--dry-run` shows the matched tier + planned action, no side effects.
`-y/--yes` skips the Tier 2 confirmation prompt.
Non-TTY stdin is treated as `-y`.

Name resolution mirrors the sleep/done resolvers: exact, slot-prefix suffix, dash-trimmed, case-insensitive. Ambiguous matches halt with a candidate list (auto-pick is a follow-up).

Subprocess invocations go through `Bun.spawn(['maw', …])` with inherited stdio so `tmux attach` can take over the TTY cleanly.

Plumbing the `maw a` alias to this new plugin is intentionally a separate maw-js PR (updates `top-aliases.ts`). For now `maw attach <name>` opts in explicitly while `maw a` keeps the tmux-only behavior — no regression.

Tests: 16/16 pass on `plugins/attach/attach.test.ts`.

Out of scope for Phase 1: T3 (ghq clone, no fleet), T4 (remote-only on GitHub), T5 (nothing exists), auto-pick for ambiguous, `maw a` alias wiring.

Closes #25 Phase 1.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)