### PR TITLE
fix(doctor): resolve maw-js package.json via Bun.resolveSync

### DIFF
--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -129,8 +129,13 @@ async function checkVersionDrift(): Promise<DoctorResult["checks"]> {
 }
 
 function readSourceVersion(): string | null {
+  // Resolve via Bun's module resolver so we always land on the installed
+  // maw-js (sibling repo, linked node_modules, or npm install). The old
+  // ../../../../package.json walk assumed this plugin still lived inside
+  // maw-js/src/commands/plugins/doctor — extracting it to its own repo
+  // pointed the walk at ~/Code/github.com/package.json instead.
   try {
-    const pkgPath = join(import.meta.dir, "..", "..", "..", "..", "package.json");
+    const pkgPath = Bun.resolveSync("maw-js/package.json", import.meta.dir);
     const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
     return typeof pkg.version === "string" ? pkg.version : null;
   } catch {


### PR DESCRIPTION
## Summary
- `version:source` was reporting `could not read package.json version` since the doctor plugin was extracted from `maw-js/src/commands/plugins/doctor/` into its own repo.
- The old `join(import.meta.dir, "..", "..", "..", "..", "package.json")` walk worked in-tree but now lands at `~/Code/github.com/package.json` (nonexistent).
- Replaced with `Bun.resolveSync("maw-js/package.json", import.meta.dir)` — same resolver path already used for `maw-js/config`, `maw-js/lib/oracle-manifest`, etc.

## Before
```
✗ version:source: could not read package.json version
```

## After
```
✓ version:pm2: no running maw — source 26.5.12-alpha.1441
```

## Test plan
- [ ] `maw doctor` shows `✓ version:pm2` instead of `✗ version:source`
- [ ] No regression when maw IS running under pm2 (drift comparison still works — that path didn't change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)