### PR TITLE
fix(artifact-manager): ANSI-aware column padding for ls

### DIFF
--- a/plugins/artifact-manager/index.ts
+++ b/plugins/artifact-manager/index.ts
@@ -148,4 +148,9 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   }
 }
 
-function col(s: string, n: number): string { return s.padEnd(n); }
+const ANSI = /\x1b\[[0-9;]*m/g;
+function visLen(s: string): number { return s.replace(ANSI, "").length; }
+function col(s: string, n: number): string {
+  const v = visLen(s);
+  return v >= n ? s : s + " ".repeat(n - v);
+}


### PR DESCRIPTION
## Problem
After #27 landed, \`maw art\` works but columns collide:

\`\`\`
TEAM            ID    STATUS      OWNER         FILES RESULT  SUBJECT
get-team        5     ✓ done—             5     yesFull artifact
list-b          1     pending     —             3     —Task B1
update-team     2     ⚡ wipscout         3     —Test task
\`\`\`

## Root cause
\`col(s, n)\` uses \`String.padEnd(n)\`, which counts bytes. ANSI color escape sequences (\`\x1b[32m✓\x1b[0m done\` = 16 bytes but 6 visible chars) eat the entire padding budget, so adjacent columns run together.

## Fix
Strip ANSI codes when measuring length, pad based on visible width.

## After
\`\`\`
TEAM            ID    STATUS      OWNER         FILES RESULT  SUBJECT
get-team        5     ✓ done      —             5     yes     Full artifact
list-b          1     pending     —             3     —       Task B1
update-team     2     ⚡ wip       scout         3     —       Test task
\`\`\`

## Test plan
- [x] Verified live: \`maw art\` and \`maw art ls\` columns align
- [x] Verdict from earlier review of #27 (bare \`return;\` + api source) tracked separately — not in scope here

🤖 Generated with [Claude Code](https://claude.com/claude-code)