### PR TITLE
fix(tests): use maw-js subpath imports instead of broken `../../../../`

### DIFF
--- a/plugins/costs/costs.test.ts
+++ b/plugins/costs/costs.test.ts
@@ -1,11 +1,8 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
-import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
-const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
-mock.module(join(root, "config"), () => mockConfigModule(() => ({ host: "localhost", port: 3456 })));
+const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+mock.module("maw-js/config", () => mockConfigModule(() => ({ host: "localhost", port: 3456 })));
 
 const mockAgentData = {
   agents: [

--- a/plugins/health/health.test.ts
+++ b/plugins/health/health.test.ts
@@ -1,12 +1,9 @@
 import { describe, it, expect, mock } from "bun:test";
-import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
 // Use the shared mock helper to provide ALL config exports (Bun 1.3 mock leaks globally)
-const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
-mock.module(join(root, "config"), () => mockConfigModule(() => ({ host: "localhost", port: 3456, peers: [] })));
+const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+mock.module("maw-js/config", () => mockConfigModule(() => ({ host: "localhost", port: 3456, peers: [] })));
 
 // Mock the health impl directly — do NOT mock child_process (leaks globally in Bun 1.3)
 mock.module("./impl", () => ({

--- a/plugins/hey-test/hey-plugin.test.ts
+++ b/plugins/hey-test/hey-plugin.test.ts
@@ -26,15 +26,15 @@ let fakeInvokeResult: { ok: boolean; output?: string; error?: string } = {
   output: "federation context: source=peer from=local-node",
 };
 
-mock.module("../../../plugin/registry", () => ({
+mock.module("maw-js/plugin/registry", () => ({
   discoverPackages: () => fakePlugins,
   invokePlugin: async (_plugin: LoadedPlugin, _ctx: unknown) => fakeInvokeResult,
 }));
 
-const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
-mock.module("../../../config", () => mockConfigModule(() => ({ node: "local-node", port: 3456 })));
+const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+mock.module("maw-js/config", () => mockConfigModule(() => ({ node: "local-node", port: 3456 })));
 
-mock.module("../../../core/transport/ssh", () => ({
+mock.module("maw-js/core/transport/ssh", () => ({
   listSessions: async () => [],
   capture: async () => "",
   sendKeys: async () => {},
@@ -43,16 +43,16 @@ mock.module("../../../core/transport/ssh", () => ({
   getPaneInfos: async () => ({}),
 }));
 
-mock.module("../../../core/routing", () => ({
+mock.module("maw-js/core/routing", () => ({
   resolveTarget: () => ({ type: "error", detail: "not found", hint: "" }),
 }));
 
-mock.module("../../../core/runtime/hooks", () => ({ runHook: async () => {} }));
-mock.module("../../../core/transport/peers", () => ({ findPeerForTarget: async () => undefined }));
-mock.module("../../../core/fleet/worktrees", () => ({ scanWorktrees: async () => [] }));
+mock.module("maw-js/core/runtime/hooks", () => ({ runHook: async () => {} }));
+mock.module("maw-js/core/transport/peers", () => ({ findPeerForTarget: async () => undefined }));
+mock.module("maw-js/core/fleet/worktrees", () => ({ scanWorktrees: async () => [] }));
 // NOTE: do NOT mock find-window here — it leaks globally and breaks routing tests (#198)
-mock.module("../../../core/transport/curl-fetch", () => ({ curlFetch: async () => ({ ok: false, data: {} }) }));
-mock.module("../../../commands/shared/wake", () => ({ resolveFleetSession: () => undefined }));
+mock.module("maw-js/core/transport/curl-fetch", () => ({ curlFetch: async () => ({ ok: false, data: {} }) }));
+mock.module("maw-js/commands/shared/wake", () => ({ resolveFleetSession: () => undefined }));
 
 import { cmdSend } from "maw-js/commands/shared/comm";
 

--- a/plugins/ping/ping.test.ts
+++ b/plugins/ping/ping.test.ts
@@ -1,17 +1,15 @@
 import { describe, it, expect, mock } from "bun:test";
-import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-const { mockConfigModule } = await import("../../../../test/helpers/mock-config");
+const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
 
-mock.module(join(root, "config"), () => mockConfigModule(() => ({
+mock.module("maw-js/config", () => mockConfigModule(() => ({
   namedPeers: [{ name: "white", url: "http://white.local:3456" }],
   peers: [],
   federationToken: "test-token",
 })));
 
-mock.module(join(root, "core/transport/curl-fetch"), () => ({
+mock.module("maw-js/core/transport/curl-fetch", () => ({
   curlFetch: async (_url: string) => ({
     ok: true,
     data: { node: "white", version: "2.0.0-alpha.10" },


### PR DESCRIPTION
## Summary
4 test files imported the shared bun:test config helper via \`../../../../test/helpers/mock-config\` — that path walked out of \`maw-plugin-registry\` into a sibling directory (broken since the plugins were extracted from maw-js). Same root-cause pattern as #34 (doctor's \`package.json\` path-walk).

Same shape for the \`mock.module(join(root, \"config\"), …)\` style — \`root\` resolved to \`maw-plugin-registry/\`, then \`join(root, \"config\")\` pointed at \`maw-plugin-registry/config\` which doesn't exist; mocks silently no-op'd and the real module won assertions.

## Fix
Switch all four test files to bare-specifier imports through maw-js's exports map:

\`\`\`ts
await import(\"maw-js/test/helpers/mock-config\")
mock.module(\"maw-js/config\", …)
mock.module(\"maw-js/core/transport/curl-fetch\", …)
mock.module(\"maw-js/plugin/registry\", …)
\`\`\`

## Files
- \`plugins/costs/costs.test.ts\`
- \`plugins/ping/ping.test.ts\`
- \`plugins/health/health.test.ts\`
- \`plugins/hey-test/hey-plugin.test.ts\` (most paths — 10 \`mock.module\` rewrites)

## Dependency
**Blocked on maw-js#1243** — adds the \`./test/helpers/mock-config\` export. Other subpaths (\`./config\`, \`./plugin/registry\`, …) are already exported.

## Before / after
- Before: 4 errors (\`Cannot find module ...\`), 16+ cascade failures
- After: **14 pass / 0 fail** across the 4 files (\`bun test plugins/{costs,ping,health,hey-test}/*.test.ts\`)

## Test plan
- [x] All 4 files pass locally with maw-js#1243 branch checked out
- [ ] CI green once maw-js#1243 merges + this PR rebases

🤖 Generated with [Claude Code](https://claude.com/claude-code)