### PR TITLE
fix(artifact-manager): rich -h output (subcommands + flags + aliases)

### DIFF
--- a/plugins/artifact-manager/plugin.json
+++ b/plugins/artifact-manager/plugin.json
@@ -7,7 +7,12 @@
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "art",
-    "help": "maw art [ls|get|write|attach|init] — task artifact manager"
+    "aliases": ["artifact-manager"],
+    "help": "maw art [ls|get|write|attach|init] [--json] [--team <team>]\n       maw art ls [team]                              — list artifacts (table or --json)\n       maw art get <team> <task-id>                   — show full artifact (spec + result + attachments)\n       maw art write <team> <task-id> <message...>    — write result.md\n       maw art attach <team> <task-id> <file-path>    — attach a file\n       maw art init <team> <task-id> <subject> [...]  — create artifact manually",
+    "flags": {
+      "--json": "boolean",
+      "--team": "string"
+    }
   },
   "api": {
     "path": "/api/plugins/artifact-manager",


### PR DESCRIPTION
## Problem
\`maw art -h\` only showed the bare single-line manifest entry — no subcommand usage, no flag docs:

\`\`\`
artifact-manager v1.0.0
  Task artifact lifecycle — ls, get, write, attach, init. Pure TypeScript, no WASM.

  usage: maw art [ls|get|write|attach|init] — task artifact manager
  ...
\`\`\`

Users had to read \`index.ts\`'s JSDoc to learn that \`maw art get\` takes \`<team> <task-id>\`, etc.

## Fix
Use the manifest shape sibling plugins (awaken, bud) already use:
- Multi-line \`cli.help\` with one usage line per subcommand
- \`cli.flags\` listing \`--json\` and \`--team\`
- \`cli.aliases: [\"artifact-manager\"]\` to match index.ts's dual \`name\` declaration

No code change — the help renderer in maw-js already supports all of this. Only the manifest was underspecified.

## After
\`\`\`
artifact-manager v1.0.0
  Task artifact lifecycle — ls, get, write, attach, init. Pure TypeScript, no WASM.

  usage: maw art [ls|get|write|attach|init] [--json] [--team <team>]
       maw art ls [team]                              — list artifacts (table or --json)
       maw art get <team> <task-id>                   — show full artifact (spec + result + attachments)
       maw art write <team> <task-id> <message...>    — write result.md
       maw art attach <team> <task-id> <file-path>    — attach a file
       maw art init <team> <task-id> <subject> [...]  — create artifact manually
  aliases: artifact-manager
  flags:
    --json               boolean
    --team               string
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)