### PR TITLE
fix(#40): countdown + clearer preview for cleanup --yes destructive kill

### DIFF
--- a/plugins/cleanup/internal/team-cleanup-zombies.ts
+++ b/plugins/cleanup/internal/team-cleanup-zombies.ts
@@ -19,7 +19,10 @@ export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
     return;
   }
 
-  console.log(`\nFound \x1b[33m${zombies.length}\x1b[0m orphan claude pane(s):\n`);
+  // Preview ALWAYS prints — even with --yes — so destructive ops aren't
+  // silent. The countdown below gives the operator a moment to Ctrl-C
+  // when --yes is set. (#40)
+  console.log(`\n\x1b[33m${zombies.length}\x1b[0m orphan claude pane(s) to kill:\n`);
   for (const z of zombies) {
     console.log(`  \x1b[33m${z.paneId}\x1b[0m  ${z.info}  \x1b[90m(team: ${z.teamName} — DELETED)\x1b[0m`);
   }
@@ -29,6 +32,18 @@ export async function cmdCleanupZombies(opts: { yes?: boolean } = {}) {
     return;
   }
 
+  // Brief abort window before destructive action. Skipped in test/CI
+  // (MAW_TEST_MODE) to keep test runs fast and deterministic.
+  if (!process.env.MAW_TEST_MODE) {
+    console.log(`\n\x1b[33m! Killing in 3s — Ctrl-C to abort.\x1b[0m`);
+    for (let i = 3; i > 0; i--) {
+      process.stdout.write(`  \x1b[90m${i}...\x1b[0m\r`);
+      await Bun.sleep(1000);
+    }
+    process.stdout.write(`        \r`); // clear countdown line
+  }
+
+  console.log(`\x1b[36mKilling...\x1b[0m`);
   for (const z of zombies) {
     await tmux.killPane(z.paneId);
     console.log(`\x1b[32m✓\x1b[0m killed ${z.paneId}`);


### PR DESCRIPTION
## Summary

Yesterday's near-miss (PR #39) added defense-in-depth so the zombie detector can't flag the operator's own pane. This PR addresses the orthogonal UX issue from #40: the transition from preview → kill was instant under \`--yes\`.

### Changes

- Preview header now reads \"N orphan claude pane(s) to kill\" (was \"Found N orphan\") — makes intent explicit
- 3-second countdown after the preview when \`--yes\` is set
- Distinct \"Killing...\" marker so the destructive moment is visible
- Countdown skipped under \`MAW_TEST_MODE=1\` for fast/deterministic tests

The dry-run output was already preserved before kill — the issue title was about silencing destructive ops, the real gap was the no-abort-window between preview and action.

Closes #40.

## Test plan

- [x] Live smoke — `cmdCleanupZombies({ yes: false })` with no zombies → \"No zombie agent panes found.\"
- [x] Audit by eye — countdown loop + MAW_TEST_MODE bypass clear
- [ ] Manual --yes test next time real zombies appear (intentional — no fake-zombie test fixture exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)