### PR TITLE
feat(ci): run bun test (#42)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,62 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  bun-test:
+    name: bun test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout maw-plugin-registry
+        uses: actions/checkout@v4
+        with:
+          path: maw-plugin-registry
+
+      - name: Checkout sibling maw-js (resolves file:../maw-js dep)
+        uses: actions/checkout@v4
+        with:
+          repository: Soul-Brews-Studio/maw-js
+          path: maw-js
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install maw-js deps
+        working-directory: maw-js
+        run: bun install
+
+      - name: Install maw-plugin-registry deps
+        working-directory: maw-plugin-registry
+        run: bun install
+
+      - name: Run bun test (non-blocking — see #42)
+        id: bun-test
+        working-directory: maw-plugin-registry
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          bun test 2>&1 | tee bun-test.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Surface test summary in PR
+        if: always()
+        working-directory: maw-plugin-registry
+        run: |
+          {
+            echo "## bun test results"
+            echo ""
+            if [ -f bun-test.log ]; then
+              # Last line of bun test output is "Ran N tests across M files."
+              # Preceding lines include the pass/skip/fail counts.
+              tail -n 6 bun-test.log | sed 's/^/    /'
+            else
+              echo "_no log produced_"
+            fi
+            echo ""
+            echo "Test step is **non-blocking** while pre-existing failures are triaged (issue #42)."
+            echo "Exit code: \`${{ steps.bun-test.outputs.exit_code }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Adds a new `test` workflow that runs `bun test` on every PR and on pushes to `main`. Closes #42.

- Checks out maw-plugin-registry + sibling `maw-js` (resolves the `file:../maw-js` dep)
- Installs deps with bun for both repos
- Runs `bun test` with `continue-on-error: true` (Strategy **A — non-blocking**)
- Writes pass/skip/fail tail + exit code to `$GITHUB_STEP_SUMMARY` so failures are visible on the PR even though the check stays green

## Why non-blocking (Strategy A)

Local run on `main` (this branch's base): **386 pass / 17 skip / 40 fail across 39 files, 1 error**. Failures span many suites (bud/take/wake/stop/done/peers/run/etc.) — too scattered for a clean `test.todo` retrofit or file-pattern filter. Shipping visibility now is more valuable than gating; failing tests will be triaged separately.

Once the existing ~40 failures are resolved, drop the `continue-on-error: true` line to flip this gate to blocking.

## What's intentionally not changed

- No test files touched (no `test.todo` retrofit)
- No `package.json` changes (no dep bumps)
- Existing `validate.yml` (JSON schema check) untouched

## Test plan

- [ ] PR run completes and `bun test` step shows red output with summary in PR
- [ ] Overall check stays green (non-blocking)
- [ ] Sibling `maw-js` checkout resolves `file:../maw-js` correctly in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)