### PR TITLE
feat(cleanup): add --prune-stale for bulk-removing dead oracles.json entries (#41)

### DIFF
--- a/plugins/cleanup/index.ts
+++ b/plugins/cleanup/index.ts
@@ -1,9 +1,10 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
 import { cmdCleanupZombies } from "./internal/team-cleanup-zombies";
+import { cmdPruneStale } from "./internal/prune-stale-oracles";
 
 export const command = {
   name: "cleanup",
-  description: "Cleanup zombie agent panes.",
+  description: "Cleanup zombie agent panes and stale oracles.json entries.",
 };
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
@@ -20,14 +21,24 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
   };
   try {
     const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const has = (...flags: string[]) => flags.some((f) => args.includes(f));
 
-    if (args.includes("--zombie-agents") || args.includes("--zombies")) {
-      await cmdCleanupZombies({ yes: args.includes("--yes") || args.includes("-y") });
+    if (has("--zombie-agents", "--zombies")) {
+      await cmdCleanupZombies({ yes: has("--yes", "-y") });
+    } else if (has("--prune-stale")) {
+      // Default is dry-run preview; --yes prunes SAFE; --ask walks ASK-FIRST.
+      // --dry-run is an explicit alias for the default (helps shell history).
+      await cmdPruneStale({
+        yes: has("--yes", "-y"),
+        ask: has("--ask"),
+        dryRun: has("--dry-run"),
+      });
     } else {
       logs.push("\x1b[36mmaw cleanup\x1b[0m \u2014 Cleanup utilities\n");
-      logs.push("  maw cleanup --zombie-agents [--yes]  Find and kill orphan zombie panes");
-      logs.push("  maw cleanup --zombies [--yes]        Alias for --zombie-agents\n");
-      logs.push("\x1b[90mWithout --yes, only lists zombies without killing them.\x1b[0m");
+      logs.push("  maw cleanup --zombie-agents [--yes]              Find and kill orphan zombie panes");
+      logs.push("  maw cleanup --zombies [--yes]                    Alias for --zombie-agents");
+      logs.push("  maw cleanup --prune-stale [--yes|--ask|--dry-run]  Prune dead oracles.json entries\n");
+      logs.push("\x1b[90mWithout --yes, only lists candidates without modifying anything.\x1b[0m");
     }
 
     return { ok: true, output: logs.join("\n") || undefined };

--- a/plugins/cleanup/internal/prune-stale-oracles.test.ts
+++ b/plugins/cleanup/internal/prune-stale-oracles.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Tests for `maw cleanup --prune-stale` (#41).
+ *
+ * Pure bucketing + a smoke test for `cmdPruneStale` against a temp
+ * oracles.json. The smoke test injects mock disk/git/manifest so it never
+ * touches the operator's real `~/.config/maw/oracles.json`.
+ */
+
+import { test, expect } from "bun:test";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  bucketEntry,
+  isStaleByManifest,
+  isCwdSelfExclude,
+  findPruneCandidates,
+  cmdPruneStale,
+  readOraclesCache,
+  writeOraclesCache,
+  type OracleEntryLite,
+  type DirStat,
+  type GitStat,
+} from "./prune-stale-oracles";
+import type { OracleManifestEntry } from "maw-js/lib/oracle-manifest";
+
+const NOW = new Date("2026-05-13T00:00:00Z").getTime();
+const DAY_MS = 86_400_000;
+
+const ENTRY: OracleEntryLite = {
+  org: "Soul-Brews-Studio",
+  repo: "demo-oracle",
+  name: "demo",
+  local_path: "/tmp/demo-oracle",
+  has_psi: false,
+  has_fleet_config: false,
+  budded_from: null,
+  budded_at: null,
+  federation_node: null,
+  detected_at: NOW.toString(),
+};
+
+const CLEAN_GIT: GitStat = {
+  isClean: true,
+  unpushed: 0,
+  uncommitted: 0,
+  totalCommits: 10,
+  detached: false,
+};
+
+const EMPTY_GIT: GitStat = {
+  isClean: true,
+  unpushed: 0,
+  uncommitted: 0,
+  totalCommits: 0,
+  detached: false,
+};
+
+const stat = (mtimeDaysAgo: number, kb: number): DirStat => ({
+  mtimeMs: NOW - mtimeDaysAgo * DAY_MS,
+  sizeBytes: kb * 1024,
+});
+
+// ─── isStaleByManifest ───────────────────────────────────────────────────────
+
+test("isStaleByManifest: yes when only oracles-json", () => {
+  const m: OracleManifestEntry = { name: "x", sources: ["oracles-json"], isLive: false };
+  expect(isStaleByManifest(m)).toBe(true);
+});
+
+test("isStaleByManifest: no when fleet present", () => {
+  const m: OracleManifestEntry = { name: "x", sources: ["oracles-json", "fleet"], isLive: false };
+  expect(isStaleByManifest(m)).toBe(false);
+});
+
+test("isStaleByManifest: no when session present", () => {
+  const m: OracleManifestEntry = { name: "x", sources: ["oracles-json", "session"], isLive: false };
+  expect(isStaleByManifest(m)).toBe(false);
+});
+
+test("isStaleByManifest: no when agent present", () => {
+  const m: OracleManifestEntry = { name: "x", sources: ["oracles-json", "agent"], isLive: false };
+  expect(isStaleByManifest(m)).toBe(false);
+});
+
+// ─── bucketEntry ─────────────────────────────────────────────────────────────
+
+test("bucketEntry: clone missing → SAFE", () => {
+  const b = bucketEntry(ENTRY, null, null, NOW);
+  expect(b.bucket).toBe("safe");
+  expect(b.cloneMissing).toBe(true);
+  expect(b.reason).toMatch(/clone missing/);
+});
+
+test("bucketEntry: empty repo (0 commits) → SAFE", () => {
+  const b = bucketEntry(ENTRY, stat(60, 80), EMPTY_GIT, NOW);
+  expect(b.bucket).toBe("safe");
+  expect(b.reason).toMatch(/empty/);
+});
+
+test("bucketEntry: clean + 60d old → SAFE", () => {
+  const b = bucketEntry(ENTRY, stat(60, 5000), CLEAN_GIT, NOW);
+  expect(b.bucket).toBe("safe");
+  expect(b.reason).toMatch(/60d old/);
+});
+
+test("bucketEntry: clean + 3d old → ASK-FIRST (recent)", () => {
+  const b = bucketEntry(ENTRY, stat(3, 5000), CLEAN_GIT, NOW);
+  expect(b.bucket).toBe("ask-first");
+  expect(b.reason).toMatch(/recent/);
+});
+
+test("bucketEntry: 124-128K placeholder → ASK-FIRST", () => {
+  const b = bucketEntry(ENTRY, stat(15, 126), CLEAN_GIT, NOW);
+  expect(b.bucket).toBe("ask-first");
+  expect(b.reason).toMatch(/126K/);
+});
+
+test("bucketEntry: clean + 15d old + normal size → ASK-FIRST (middle zone)", () => {
+  const b = bucketEntry(ENTRY, stat(15, 5000), CLEAN_GIT, NOW);
+  expect(b.bucket).toBe("ask-first");
+  expect(b.reason).toMatch(/15d/);
+});
+
+test("bucketEntry: uncommitted → NEVER-TOUCH", () => {
+  const dirty: GitStat = { ...CLEAN_GIT, isClean: false, uncommitted: 3 };
+  const b = bucketEntry(ENTRY, stat(60, 5000), dirty, NOW);
+  expect(b.bucket).toBe("never-touch");
+  expect(b.reason).toMatch(/3 uncommitted/);
+});
+
+test("bucketEntry: unpushed → NEVER-TOUCH", () => {
+  const ahead: GitStat = { ...CLEAN_GIT, unpushed: 57 };
+  const b = bucketEntry(ENTRY, stat(60, 5000), ahead, NOW);
+  expect(b.bucket).toBe("never-touch");
+  expect(b.reason).toMatch(/57 unpushed commits/);
+});
+
+test("bucketEntry: detached HEAD with commits → NEVER-TOUCH", () => {
+  const detached: GitStat = { ...CLEAN_GIT, detached: true };
+  const b = bucketEntry(ENTRY, stat(60, 5000), detached, NOW);
+  expect(b.bucket).toBe("never-touch");
+  expect(b.reason).toMatch(/detached/);
+});
+
+test("bucketEntry: clone exists but git probe failed → NEVER-TOUCH (conservative)", () => {
+  const b = bucketEntry(ENTRY, stat(60, 5000), null, NOW);
+  expect(b.bucket).toBe("never-touch");
+  expect(b.reason).toMatch(/git inspect failed/);
+});
+
+// ─── isCwdSelfExclude ────────────────────────────────────────────────────────
+
+test("isCwdSelfExclude: exact match", () => {
+  expect(isCwdSelfExclude("/a/b/c", "/a/b/c")).toBe(true);
+});
+
+test("isCwdSelfExclude: cwd inside clone", () => {
+  expect(isCwdSelfExclude("/a/b/c", "/a/b/c/sub")).toBe(true);
+});
+
+test("isCwdSelfExclude: clone inside cwd (parent guard)", () => {
+  expect(isCwdSelfExclude("/a/b/c", "/a/b")).toBe(true);
+});
+
+test("isCwdSelfExclude: unrelated paths", () => {
+  expect(isCwdSelfExclude("/a/b/c", "/x/y/z")).toBe(false);
+});
+
+test("isCwdSelfExclude: trailing slash tolerated", () => {
+  expect(isCwdSelfExclude("/a/b/c/", "/a/b/c")).toBe(true);
+});
+
+// ─── findPruneCandidates ─────────────────────────────────────────────────────
+
+function manifestFor(names: { name: string; sources: OracleManifestEntry["sources"] }[]): OracleManifestEntry[] {
+  return names.map(({ name, sources }) => ({ name, sources, isLive: false }));
+}
+
+test("findPruneCandidates: psi vault skipped (counted as kept)", async () => {
+  const cacheEntries: OracleEntryLite[] = [
+    { ...ENTRY, name: "with-psi", local_path: "/tmp/with-psi", has_psi: true },
+    { ...ENTRY, name: "without-psi", local_path: "/tmp/without-psi", has_psi: false },
+  ];
+  const manifest = manifestFor([
+    { name: "with-psi", sources: ["oracles-json"] },
+    { name: "without-psi", sources: ["oracles-json"] },
+  ]);
+  const survey = await findPruneCandidates({
+    manifest,
+    cacheEntries,
+    cwd: "/elsewhere",
+    statDir: () => null, // clone missing for all
+    checkGit: async () => CLEAN_GIT, // unused — stat null short-circuits
+    now: NOW,
+  });
+  expect(survey.totalStale).toBe(2);
+  expect(survey.withPsi).toBe(1);
+  expect(survey.safe.length).toBe(1);
+  expect(survey.safe[0]?.entry.name).toBe("without-psi");
+});
+
+test("findPruneCandidates: PWD self-exclude removes candidate", async () => {
+  const cacheEntries: OracleEntryLite[] = [
+    { ...ENTRY, name: "im-here", local_path: "/work/im-here" },
+  ];
+  const manifest = manifestFor([{ name: "im-here", sources: ["oracles-json"] }]);
+  const survey = await findPruneCandidates({
+    manifest,
+    cacheEntries,
+    cwd: "/work/im-here",
+    statDir: () => stat(60, 5000),
+    checkGit: async () => CLEAN_GIT,
+    now: NOW,
+  });
+  expect(survey.totalStale).toBe(1);
+  expect(survey.safe.length).toBe(0);
+  expect(survey.neverTouch.length).toBe(0);
+  expect(survey.askFirst.length).toBe(0);
+});
+
+test("findPruneCandidates: non-stale entries (with fleet) untouched", async () => {
+  const cacheEntries: OracleEntryLite[] = [
+    { ...ENTRY, name: "live", local_path: "/tmp/live" },
+  ];
+  const manifest = manifestFor([
+    { name: "live", sources: ["oracles-json", "fleet"] },
+  ]);
+  const survey = await findPruneCandidates({
+    manifest,
+    cacheEntries,
+    cwd: "/elsewhere",
+    statDir: () => stat(60, 5000),
+    checkGit: async () => CLEAN_GIT,
+    now: NOW,
+  });
+  expect(survey.totalStale).toBe(0);
+  expect(survey.safe.length).toBe(0);
+});
+
+test("findPruneCandidates: three-way bucket split", async () => {
+  const entries: OracleEntryLite[] = [
+    { ...ENTRY, name: "safe-old", local_path: "/tmp/safe-old" },
+    { ...ENTRY, name: "ask-recent", local_path: "/tmp/ask-recent" },
+    { ...ENTRY, name: "never-dirty", local_path: "/tmp/never-dirty" },
+  ];
+  const manifest = manifestFor(entries.map((e) => ({ name: e.name, sources: ["oracles-json"] })));
+  const statByPath: Record<string, DirStat> = {
+    "/tmp/safe-old": stat(60, 4000),
+    "/tmp/ask-recent": stat(3, 4000),
+    "/tmp/never-dirty": stat(60, 4000),
+  };
+  const gitByPath: Record<string, GitStat> = {
+    "/tmp/safe-old": CLEAN_GIT,
+    "/tmp/ask-recent": CLEAN_GIT,
+    "/tmp/never-dirty": { ...CLEAN_GIT, isClean: false, uncommitted: 1 },
+  };
+  const survey = await findPruneCandidates({
+    manifest,
+    cacheEntries: entries,
+    cwd: "/elsewhere",
+    statDir: (p) => statByPath[p] ?? null,
+    checkGit: async (p) => gitByPath[p]!,
+    now: NOW,
+  });
+  expect(survey.safe.map((c) => c.entry.name)).toEqual(["safe-old"]);
+  expect(survey.askFirst.map((c) => c.entry.name)).toEqual(["ask-recent"]);
+  expect(survey.neverTouch.map((c) => c.entry.name)).toEqual(["never-dirty"]);
+});
+
+// ─── readOraclesCache / writeOraclesCache (preserves unknown keys) ───────────
+
+test("readOraclesCache / writeOraclesCache: preserves unknown top-level keys", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prune-stale-test-"));
+  try {
+    const file = join(tmp, "oracles.json");
+    writeFileSync(
+      file,
+      JSON.stringify(
+        {
+          schema: 1,
+          local_scanned_at: "2026-05-12T00:00:00Z",
+          ghq_root: "/x",
+          oracles: [{ ...ENTRY, name: "a" }, { ...ENTRY, name: "b" }],
+          // legacy / external key — must be preserved on rewrite
+          leaves: [{ name: "legacy-leaf" }],
+        },
+        null,
+        2,
+      ),
+    );
+    const cache = readOraclesCache(file)!;
+    expect(cache.entries.length).toBe(2);
+    expect(cache.raw.leaves).toEqual([{ name: "legacy-leaf" }]);
+
+    writeOraclesCache({ raw: cache.raw, entries: cache.entries.filter((e) => e.name !== "b") }, file);
+    const reread = JSON.parse(readFileSync(file, "utf-8"));
+    expect(reread.oracles.length).toBe(1);
+    expect(reread.oracles[0].name).toBe("a");
+    expect(reread.leaves).toEqual([{ name: "legacy-leaf" }]);
+    expect(reread.schema).toBe(1);
+    expect(reread.ghq_root).toBe("/x");
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── cmdPruneStale smoke ─────────────────────────────────────────────────────
+
+test("cmdPruneStale: dry-run by default — does not mutate file", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prune-stale-test-"));
+  try {
+    const file = join(tmp, "oracles.json");
+    const initial = {
+      schema: 1,
+      local_scanned_at: "2026-05-12T00:00:00Z",
+      ghq_root: "/x",
+      oracles: [
+        { ...ENTRY, name: "safe-old", local_path: "/tmp/safe-old" },
+      ],
+    };
+    writeFileSync(file, JSON.stringify(initial, null, 2));
+    const manifest = manifestFor([{ name: "safe-old", sources: ["oracles-json"] }]);
+
+    await cmdPruneStale({
+      cacheFile: file,
+      env: {
+        manifest,
+        cwd: "/elsewhere",
+        statDir: () => stat(60, 4000),
+        checkGit: async () => CLEAN_GIT,
+        now: NOW,
+      },
+    });
+
+    const reread = JSON.parse(readFileSync(file, "utf-8"));
+    expect(reread.oracles.length).toBe(1);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cmdPruneStale: --yes prunes SAFE bucket, leaves NEVER-TOUCH and ASK-FIRST", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prune-stale-test-"));
+  try {
+    const file = join(tmp, "oracles.json");
+    const oracles: OracleEntryLite[] = [
+      { ...ENTRY, name: "safe-old", local_path: "/tmp/safe-old" },
+      { ...ENTRY, name: "ask-recent", local_path: "/tmp/ask-recent" },
+      { ...ENTRY, name: "never-dirty", local_path: "/tmp/never-dirty" },
+      { ...ENTRY, name: "with-psi", local_path: "/tmp/with-psi", has_psi: true },
+      { ...ENTRY, name: "live", local_path: "/tmp/live" },
+    ];
+    writeFileSync(file, JSON.stringify({ schema: 1, local_scanned_at: "x", ghq_root: "/x", oracles }, null, 2));
+
+    const manifest = manifestFor([
+      { name: "safe-old", sources: ["oracles-json"] },
+      { name: "ask-recent", sources: ["oracles-json"] },
+      { name: "never-dirty", sources: ["oracles-json"] },
+      { name: "with-psi", sources: ["oracles-json"] },
+      { name: "live", sources: ["oracles-json", "fleet"] }, // not stale
+    ]);
+
+    const statByPath: Record<string, DirStat> = {
+      "/tmp/safe-old": stat(60, 4000),
+      "/tmp/ask-recent": stat(3, 4000),
+      "/tmp/never-dirty": stat(60, 4000),
+      "/tmp/with-psi": stat(60, 4000),
+      "/tmp/live": stat(1, 4000),
+    };
+    const gitByPath: Record<string, GitStat> = {
+      "/tmp/safe-old": CLEAN_GIT,
+      "/tmp/ask-recent": CLEAN_GIT,
+      "/tmp/never-dirty": { ...CLEAN_GIT, isClean: false, uncommitted: 1 },
+      "/tmp/with-psi": CLEAN_GIT,
+      "/tmp/live": CLEAN_GIT,
+    };
+
+    await cmdPruneStale({
+      yes: true,
+      cacheFile: file,
+      env: {
+        manifest,
+        cwd: "/elsewhere",
+        statDir: (p) => statByPath[p] ?? null,
+        checkGit: async (p) => gitByPath[p]!,
+        now: NOW,
+      },
+    });
+
+    const reread = JSON.parse(readFileSync(file, "utf-8"));
+    const names = (reread.oracles as OracleEntryLite[]).map((e) => e.name).sort();
+    expect(names).toEqual(["ask-recent", "live", "never-dirty", "with-psi"]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cmdPruneStale: --ask prunes only entries the prompt approves", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prune-stale-test-"));
+  try {
+    const file = join(tmp, "oracles.json");
+    const oracles: OracleEntryLite[] = [
+      { ...ENTRY, name: "ask-a", local_path: "/tmp/ask-a" },
+      { ...ENTRY, name: "ask-b", local_path: "/tmp/ask-b" },
+    ];
+    writeFileSync(file, JSON.stringify({ schema: 1, local_scanned_at: "x", ghq_root: "/x", oracles }, null, 2));
+
+    const manifest = manifestFor([
+      { name: "ask-a", sources: ["oracles-json"] },
+      { name: "ask-b", sources: ["oracles-json"] },
+    ]);
+    const statByPath: Record<string, DirStat> = {
+      "/tmp/ask-a": stat(3, 4000),
+      "/tmp/ask-b": stat(3, 4000),
+    };
+
+    const seen: string[] = [];
+    await cmdPruneStale({
+      ask: true,
+      cacheFile: file,
+      prompt: async (q) => {
+        seen.push(q);
+        return q.includes("ask-a") ? "y" : "n";
+      },
+      env: {
+        manifest,
+        cwd: "/elsewhere",
+        statDir: (p) => statByPath[p] ?? null,
+        checkGit: async () => CLEAN_GIT,
+        now: NOW,
+      },
+    });
+
+    expect(seen.length).toBe(2);
+    const reread = JSON.parse(readFileSync(file, "utf-8"));
+    const names = (reread.oracles as OracleEntryLite[]).map((e) => e.name);
+    expect(names).toEqual(["ask-b"]);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("cmdPruneStale: --yes with no SAFE entries leaves file unchanged", async () => {
+  const tmp = mkdtempSync(join(tmpdir(), "prune-stale-test-"));
+  try {
+    const file = join(tmp, "oracles.json");
+    const oracles: OracleEntryLite[] = [
+      { ...ENTRY, name: "only-dirty", local_path: "/tmp/only-dirty" },
+    ];
+    writeFileSync(file, JSON.stringify({ schema: 1, local_scanned_at: "x", ghq_root: "/x", oracles }, null, 2));
+
+    const manifest = manifestFor([{ name: "only-dirty", sources: ["oracles-json"] }]);
+    const statByPath: Record<string, DirStat> = {
+      "/tmp/only-dirty": stat(60, 4000),
+    };
+    const gitByPath: Record<string, GitStat> = {
+      "/tmp/only-dirty": { ...CLEAN_GIT, isClean: false, uncommitted: 1 },
+    };
+
+    await cmdPruneStale({
+      yes: true,
+      cacheFile: file,
+      env: {
+        manifest,
+        cwd: "/elsewhere",
+        statDir: (p) => statByPath[p] ?? null,
+        checkGit: async (p) => gitByPath[p]!,
+        now: NOW,
+      },
+    });
+
+    const reread = JSON.parse(readFileSync(file, "utf-8"));
+    expect(reread.oracles.length).toBe(1);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});

--- a/plugins/cleanup/internal/prune-stale-oracles.ts
+++ b/plugins/cleanup/internal/prune-stale-oracles.ts
@@ -1,0 +1,502 @@
+/**
+ * cleanup/internal/prune-stale-oracles.ts — `maw cleanup --prune-stale` (#41).
+ *
+ * Bulk-removes dead oracles.json entries that no fleet window, no
+ * config.sessions UUID, and no config.agents route reference. Without this,
+ * `maw doctor` flags `oracles-json-without-runtime` 99× on a healthy operator
+ * machine and tells the user "remove the directory" — there was no CLI
+ * affordance to act on it in bulk.
+ *
+ * Safety rails (all checked BEFORE bucketing):
+ *
+ *   1. PWD self-exclude — never prune the entry whose `local_path` is
+ *      `process.cwd()` or one of its ancestors. The operator is standing
+ *      INSIDE the candidate clone; the registry record is presumed live.
+ *   2. ψ vault wins — `has_psi: true` means "intentional dormant oracle",
+ *      skip entirely (kept count surfaced in the summary).
+ *   3. Clone missing → SAFE (the disk entry is already dead).
+ *
+ * Decision tree (applied per surviving stale entry, after probing disk + git):
+ *
+ *   - NEVER-TOUCH: uncommitted work (`git status --porcelain` non-empty) OR
+ *                  unpushed commits ahead of upstream OR detached HEAD with
+ *                  commits.
+ *   - ASK-FIRST:   clean git, recent mtime (≤8 days) or "intentional
+ *                  placeholder" size band (124-128 K — empirically the size
+ *                  of a freshly-budded oracle scaffold), or between 8 and 30
+ *                  days old.
+ *   - SAFE:        empty repo (no commits) OR clean + mtime ≥ 30 days.
+ *
+ * Concurrency: git probes are fanned out with a small semaphore (cap = 8) so
+ * `maw cleanup --prune-stale` on a 100-entry registry takes a second or two
+ * instead of a minute.
+ *
+ * Pure-ish: I/O (manifest read, oracles.json read/write, git, du, stat) is
+ * injectable via the `PruneEnv` shape so tests drive deterministic fixtures
+ * without touching the operator's real registry.
+ */
+
+import { readFileSync, writeFileSync, existsSync, statSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { loadManifest, type OracleManifestEntry } from "maw-js/lib/oracle-manifest";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** OracleEntry shape lifted from maw-js/core/fleet/registry-oracle-types.
+ *  Inlined here so we don't depend on an unexported internal path. */
+export interface OracleEntryLite {
+  org: string;
+  repo: string;
+  name: string;
+  local_path: string;
+  has_psi: boolean;
+  has_fleet_config: boolean;
+  budded_from: string | null;
+  budded_at: string | null;
+  federation_node: string | null;
+  detected_at: string;
+  [k: string]: unknown;
+}
+
+export interface DirStat {
+  /** mtime in epoch ms */
+  mtimeMs: number;
+  /** total directory size in bytes (du -sk × 1024). */
+  sizeBytes: number;
+}
+
+export interface GitStat {
+  /** porcelain empty */
+  isClean: boolean;
+  /** commits ahead of `@{u}` — 0 when no upstream */
+  unpushed: number;
+  /** line count of `status --porcelain` */
+  uncommitted: number;
+  /** total commits reachable from HEAD (0 = empty repo) */
+  totalCommits: number;
+  /** detached HEAD (no symbolic ref) */
+  detached: boolean;
+}
+
+export type Bucket = "never-touch" | "ask-first" | "safe";
+
+export interface PruneCandidate {
+  entry: OracleEntryLite;
+  bucket: Bucket;
+  reason: string;
+  stat?: DirStat;
+  git?: GitStat;
+  cloneMissing: boolean;
+}
+
+export interface PruneSurvey {
+  totalEntries: number;
+  totalStale: number;
+  withPsi: number;
+  neverTouch: PruneCandidate[];
+  askFirst: PruneCandidate[];
+  safe: PruneCandidate[];
+}
+
+export interface PruneEnv {
+  /** Pre-built manifest (defaults to live `loadManifest()`). */
+  manifest?: OracleManifestEntry[];
+  /** Cache entries (defaults to live oracles.json). */
+  cacheEntries?: OracleEntryLite[];
+  /** Process cwd override for PWD self-exclude (defaults to `process.cwd()`). */
+  cwd?: string;
+  /** Disk stat probe (defaults to fs.statSync + `du -sk`). */
+  statDir?: (path: string) => DirStat | null;
+  /** Git probe (defaults to `Bun.spawn` git invocations). */
+  checkGit?: (path: string) => Promise<GitStat>;
+  /** Wall-clock override for deterministic age math in tests. */
+  now?: number;
+}
+
+export interface CmdPruneStaleOpts {
+  yes?: boolean;
+  dryRun?: boolean;
+  ask?: boolean;
+  /** Override oracles.json file location — primarily for tests. */
+  cacheFile?: string;
+  /** Injectable env for tests (mocks disk + git + manifest). */
+  env?: PruneEnv;
+  /** Injectable prompt for `--ask` tests. */
+  prompt?: (q: string) => Promise<string>;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const ORACLES_JSON_PATH = join(homedir(), ".config", "maw", "oracles.json");
+const DAY_MS = 86_400_000;
+const PLACEHOLDER_KB_MIN = 124;
+const PLACEHOLDER_KB_MAX = 128;
+const RECENT_DAYS = 8;
+const STALE_DAYS = 30;
+const CONCURRENCY = 8;
+
+// ─── Cache I/O (preserves unknown top-level keys) ────────────────────────────
+
+interface OraclesCacheFile {
+  raw: Record<string, unknown>;
+  entries: OracleEntryLite[];
+}
+
+export function readOraclesCache(file: string = ORACLES_JSON_PATH): OraclesCacheFile | null {
+  try {
+    if (!existsSync(file)) return null;
+    const raw = JSON.parse(readFileSync(file, "utf-8"));
+    if (!raw || typeof raw !== "object") return null;
+    const entries = Array.isArray((raw as { oracles?: unknown }).oracles)
+      ? ((raw as { oracles: OracleEntryLite[] }).oracles)
+      : [];
+    return { raw: raw as Record<string, unknown>, entries };
+  } catch {
+    return null;
+  }
+}
+
+export function writeOraclesCache(cache: OraclesCacheFile, file: string = ORACLES_JSON_PATH): void {
+  const merged = { ...cache.raw, oracles: cache.entries };
+  writeFileSync(file, JSON.stringify(merged, null, 2) + "\n", "utf-8");
+}
+
+// ─── Default probes ──────────────────────────────────────────────────────────
+
+function defaultStatDir(path: string): DirStat | null {
+  try {
+    const s = statSync(path);
+    if (!s.isDirectory()) return null;
+    let sizeBytes = 0;
+    try {
+      const proc = Bun.spawnSync(["du", "-sk", path]);
+      const out = new TextDecoder().decode(proc.stdout).trim();
+      const sizeKb = parseInt(out.split(/\s+/)[0] ?? "0", 10);
+      if (!Number.isNaN(sizeKb)) sizeBytes = sizeKb * 1024;
+    } catch { /* du missing — leave size at 0 */ }
+    return { mtimeMs: s.mtimeMs, sizeBytes };
+  } catch {
+    return null;
+  }
+}
+
+async function runGit(args: string[]): Promise<{ ok: boolean; stdout: string; stderr: string }> {
+  try {
+    const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+    await proc.exited;
+    const stdout = proc.stdout ? await new Response(proc.stdout).text() : "";
+    const stderr = proc.stderr ? await new Response(proc.stderr).text() : "";
+    return { ok: proc.exitCode === 0, stdout, stderr };
+  } catch {
+    return { ok: false, stdout: "", stderr: "git-spawn-failed" };
+  }
+}
+
+async function defaultCheckGit(path: string): Promise<GitStat> {
+  const status = await runGit(["git", "-C", path, "status", "--porcelain"]);
+  const porcelain = status.stdout.replace(/\n$/, "");
+  const isClean = porcelain.length === 0;
+  const uncommitted = isClean ? 0 : porcelain.split("\n").length;
+
+  let unpushed = 0;
+  const upstream = await runGit(["git", "-C", path, "rev-parse", "--abbrev-ref", "@{u}"]);
+  if (upstream.ok) {
+    const rev = await runGit(["git", "-C", path, "rev-list", "--count", "@{u}..HEAD"]);
+    if (rev.ok) {
+      const n = parseInt(rev.stdout.trim() || "0", 10);
+      if (!Number.isNaN(n)) unpushed = n;
+    }
+  }
+
+  const headRef = await runGit(["git", "-C", path, "symbolic-ref", "-q", "HEAD"]);
+  const detached = !headRef.ok;
+
+  let totalCommits = 0;
+  const count = await runGit(["git", "-C", path, "rev-list", "--all", "--count"]);
+  if (count.ok) {
+    const n = parseInt(count.stdout.trim() || "0", 10);
+    if (!Number.isNaN(n)) totalCommits = n;
+  }
+
+  return { isClean, unpushed, uncommitted, totalCommits, detached };
+}
+
+// ─── Bucketing ───────────────────────────────────────────────────────────────
+
+/** True when only the oracles-json source surfaces this entry — no fleet,
+ *  no claude session, no agents-map route. */
+export function isStaleByManifest(m: OracleManifestEntry): boolean {
+  const has = (s: string) => m.sources.includes(s as OracleManifestEntry["sources"][number]);
+  return has("oracles-json") && !has("fleet") && !has("session") && !has("agent");
+}
+
+export function bucketEntry(
+  _entry: OracleEntryLite,
+  stat: DirStat | null,
+  git: GitStat | null,
+  nowMs: number,
+): { bucket: Bucket; reason: string; cloneMissing: boolean } {
+  // Clone missing — already dead on disk, registry is the only thing left.
+  if (!stat) {
+    return { bucket: "safe", reason: "clone missing", cloneMissing: true };
+  }
+  // Git probe blew up — be conservative and never auto-prune.
+  if (!git) {
+    return { bucket: "never-touch", reason: "git inspect failed", cloneMissing: false };
+  }
+  // NEVER-TOUCH layer.
+  if (git.uncommitted > 0 || git.unpushed > 0 || (git.detached && git.totalCommits > 0)) {
+    const parts: string[] = [];
+    if (git.unpushed > 0) parts.push(`${git.unpushed} unpushed commit${git.unpushed === 1 ? "" : "s"}`);
+    if (git.uncommitted > 0) parts.push(`${git.uncommitted} uncommitted`);
+    if (git.detached && git.totalCommits > 0) parts.push("detached HEAD");
+    return { bucket: "never-touch", reason: parts.join(", "), cloneMissing: false };
+  }
+  const sizeKb = Math.round(stat.sizeBytes / 1024);
+  // Empty repo — no commits ever made → SAFE.
+  if (git.totalCommits === 0) {
+    return { bucket: "safe", reason: `empty, ${sizeKb}K`, cloneMissing: false };
+  }
+  const ageDays = (nowMs - stat.mtimeMs) / DAY_MS;
+  // Clean + cold → SAFE.
+  if (ageDays >= STALE_DAYS) {
+    return {
+      bucket: "safe",
+      reason: `clean, ${Math.round(ageDays)}d old, ${sizeKb}K`,
+      cloneMissing: false,
+    };
+  }
+  // Either recent OR the "intentional placeholder" 124-128 K size band — ASK.
+  const looksPlaceholder = sizeKb >= PLACEHOLDER_KB_MIN && sizeKb <= PLACEHOLDER_KB_MAX;
+  if (ageDays <= RECENT_DAYS || looksPlaceholder) {
+    const reason = looksPlaceholder
+      ? `${sizeKb}K, modified ${formatDate(stat.mtimeMs)}`
+      : `recent, modified ${formatDate(stat.mtimeMs)}`;
+    return { bucket: "ask-first", reason, cloneMissing: false };
+  }
+  // 8 < ageDays < 30 — clean but neither emphatically fresh nor cold → ASK.
+  return {
+    bucket: "ask-first",
+    reason: `${Math.round(ageDays)}d old, ${sizeKb}K`,
+    cloneMissing: false,
+  };
+}
+
+function formatDate(ms: number): string {
+  return new Date(ms).toISOString().slice(0, 10);
+}
+
+// ─── PWD self-exclude ────────────────────────────────────────────────────────
+
+export function isCwdSelfExclude(localPath: string, cwd: string): boolean {
+  if (!localPath) return false;
+  const norm = (p: string) => p.replace(/\/+$/, "");
+  const lp = norm(localPath);
+  const c = norm(cwd);
+  if (!lp || !c) return false;
+  return lp === c || c === lp || c.startsWith(lp + "/") || lp.startsWith(c + "/");
+}
+
+// ─── Concurrency helper ──────────────────────────────────────────────────────
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const out: R[] = new Array(items.length);
+  let next = 0;
+  const width = Math.max(1, Math.min(limit, items.length));
+  const workers = Array.from({ length: width }, async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) break;
+      out[i] = await fn(items[i]!);
+    }
+  });
+  await Promise.all(workers);
+  return out;
+}
+
+// ─── Main survey ─────────────────────────────────────────────────────────────
+
+export async function findPruneCandidates(env: PruneEnv = {}): Promise<PruneSurvey> {
+  const manifest = env.manifest ?? loadManifest();
+  const cacheEntries = env.cacheEntries ?? (readOraclesCache()?.entries ?? []);
+  const cwd = env.cwd ?? process.cwd();
+  const statDir = env.statDir ?? defaultStatDir;
+  const checkGit = env.checkGit ?? defaultCheckGit;
+  const nowMs = env.now ?? Date.now();
+
+  const manifestByName = new Map(manifest.map((m) => [m.name, m]));
+
+  let withPsi = 0;
+  let totalStale = 0;
+  const survivors: OracleEntryLite[] = [];
+
+  for (const entry of cacheEntries) {
+    const m = manifestByName.get(entry.name);
+    // Every oracles.json entry should appear in the manifest with at least
+    // "oracles-json" as a source. If it doesn't, the manifest didn't see it
+    // (maw-js workspace not loaded?) — be safe, skip.
+    if (!m) continue;
+    if (!isStaleByManifest(m)) continue;
+    totalStale++;
+    if (entry.has_psi) {
+      withPsi++;
+      continue;
+    }
+    if (isCwdSelfExclude(entry.local_path ?? "", cwd)) {
+      // Operator is standing inside this clone right now — treat the
+      // registry record as live regardless of cross-source state.
+      continue;
+    }
+    survivors.push(entry);
+  }
+
+  const probes = await mapWithConcurrency(survivors, CONCURRENCY, async (entry) => {
+    const stat = entry.local_path ? statDir(entry.local_path) : null;
+    let git: GitStat | null = null;
+    if (stat) {
+      try {
+        git = await checkGit(entry.local_path);
+      } catch {
+        git = null;
+      }
+    }
+    const b = bucketEntry(entry, stat, git, nowMs);
+    const c: PruneCandidate = {
+      entry,
+      bucket: b.bucket,
+      reason: b.reason,
+      stat: stat ?? undefined,
+      git: git ?? undefined,
+      cloneMissing: b.cloneMissing,
+    };
+    return c;
+  });
+
+  return {
+    totalEntries: cacheEntries.length,
+    totalStale,
+    withPsi,
+    neverTouch: probes.filter((p) => p.bucket === "never-touch"),
+    askFirst: probes.filter((p) => p.bucket === "ask-first"),
+    safe: probes.filter((p) => p.bucket === "safe"),
+  };
+}
+
+// ─── Output rendering ────────────────────────────────────────────────────────
+
+function pad(s: string, n: number): string {
+  return s.length >= n ? s : s + " ".repeat(n - s.length);
+}
+
+function renderBucket(
+  prefix: string,
+  title: string,
+  color: string,
+  list: PruneCandidate[],
+  log: (s: string) => void,
+): void {
+  if (!list.length) return;
+  log("");
+  log(`${color}${prefix} ${title} (${list.length})\x1b[0m`);
+  for (const c of list) {
+    log(`  \x1b[36m${pad(c.entry.name, 22)}\x1b[0m ${c.reason}`);
+  }
+}
+
+// ─── Entrypoint ──────────────────────────────────────────────────────────────
+
+export async function cmdPruneStale(opts: CmdPruneStaleOpts = {}): Promise<void> {
+  const log = (s: string) => console.log(s);
+  const file = opts.cacheFile ?? ORACLES_JSON_PATH;
+  const cache = readOraclesCache(file);
+  if (!cache) {
+    log(`\x1b[33mNo oracles.json found at ${file} — nothing to prune.\x1b[0m`);
+    return;
+  }
+  log(`Reading oracles.json (${cache.entries.length} entries)...`);
+
+  const survey = await findPruneCandidates({
+    cacheEntries: cache.entries,
+    ...(opts.env ?? {}),
+  });
+
+  log("");
+  log(`Stale candidates (no fleet, no session, no agent): ${survey.totalStale}`);
+  log(`  \x1b[90mwith ψ vault (keeping): ${survey.withPsi}\x1b[0m`);
+  log(`  \x1b[90mwithout ψ vault (candidates): ${survey.totalStale - survey.withPsi}\x1b[0m`);
+
+  renderBucket("🛑", "NEVER-TOUCH — has unpushed or uncommitted work", "\x1b[31m", survey.neverTouch, log);
+  renderBucket("⚠", "ASK-FIRST — recent or suspicious", "\x1b[33m", survey.askFirst, log);
+  renderBucket("✅", "SAFE TO PRUNE — empty or old + clean", "\x1b[32m", survey.safe, log);
+
+  // Dry-run / preview path (default and explicit --dry-run).
+  if (!opts.yes && !opts.ask) {
+    log("");
+    if (survey.safe.length === 0 && survey.askFirst.length === 0) {
+      log("\x1b[32mNothing to prune.\x1b[0m");
+      return;
+    }
+    if (survey.safe.length > 0) {
+      log(
+        `Run with \x1b[36m--yes\x1b[0m to prune ${survey.safe.length} ` +
+          `SAFE ${survey.safe.length === 1 ? "entry" : "entries"} from oracles.json.`,
+      );
+    }
+    if (survey.askFirst.length > 0) {
+      log(`Run with \x1b[36m--ask\x1b[0m to interactively decide on ASK-FIRST.`);
+    }
+    return;
+  }
+
+  // Build the prune set.
+  const toPrune = new Set<string>();
+  if (opts.yes) {
+    for (const c of survey.safe) toPrune.add(c.entry.name);
+  }
+  if (opts.ask) {
+    const prompt = opts.prompt ?? defaultPrompt;
+    for (const c of survey.askFirst) {
+      const ans = (await prompt(`Prune ${c.entry.name} (${c.reason})? [y/N] `)).trim().toLowerCase();
+      if (ans === "y" || ans === "yes") toPrune.add(c.entry.name);
+    }
+  }
+
+  if (toPrune.size === 0) {
+    log("\n\x1b[90mNothing selected for pruning.\x1b[0m");
+    return;
+  }
+
+  // Abort window before write — mirrors the team-cleanup-zombies idiom (PR #43).
+  // Skipped in MAW_TEST_MODE so test runs stay deterministic.
+  if (opts.yes && !process.env.MAW_TEST_MODE) {
+    log(`\n\x1b[33m! Pruning in 3s — Ctrl-C to abort.\x1b[0m`);
+    for (let i = 3; i > 0; i--) {
+      process.stdout.write(`  \x1b[90m${i}...\x1b[0m\r`);
+      await Bun.sleep(1000);
+    }
+    process.stdout.write(`        \r`); // clear countdown line
+  }
+
+  log(`\x1b[36mPruning ${toPrune.size} ${toPrune.size === 1 ? "entry" : "entries"}...\x1b[0m`);
+  const remaining = cache.entries.filter((e) => !toPrune.has(e.name));
+  writeOraclesCache({ raw: cache.raw, entries: remaining }, file);
+  log(
+    `\x1b[32m✓\x1b[0m wrote oracles.json (${remaining.length} entries remain, ` +
+      `${toPrune.size} pruned)`,
+  );
+}
+
+async function defaultPrompt(q: string): Promise<string> {
+  const { createInterface } = await import("readline/promises");
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    return await rl.question(q);
+  } finally {
+    rl.close();
+  }
+}

--- a/plugins/cleanup/plugin.json
+++ b/plugins/cleanup/plugin.json
@@ -1,14 +1,14 @@
 {
   "name": "cleanup",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Cleanup zombie agent panes.",
+  "description": "Cleanup zombie agent panes and stale oracles.json entries.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "cleanup",
     "aliases": [],
-    "help": "maw cleanup --zombie-agents [--yes] — Kill orphan zombie panes"
+    "help": "maw cleanup --zombie-agents [--yes] — kill orphan panes; maw cleanup --prune-stale [--yes|--ask|--dry-run] — prune dead oracles.json entries"
   },
   "weight": 50
 }

--- a/plugins/doctor/cross-source-detect.ts
+++ b/plugins/doctor/cross-source-detect.ts
@@ -143,7 +143,7 @@ export function findGaps(manifest: OracleManifestEntry[]): CrossSourceGap[] {
         kind: "oracles-json-without-runtime",
         detail:
           `oracles.json lists '${e.name}' but no fleet window, session, or agent route — ` +
-          `orphan checkout or stale cache. Wake it once or remove the directory.`,
+          `orphan checkout or stale cache. Run 'maw cleanup --prune-stale' to triage in bulk.`,
       });
     }
 


### PR DESCRIPTION
## Summary

Adds `maw cleanup --prune-stale` to bulk-triage dead `oracles.json` entries — the ones `maw doctor` flags as `oracles-json-without-runtime` (no fleet, no session, no agent route). On the operator's machine that count was 99; manual deletion was unrealistic.

Closes #41.

## Usage

```bash
maw cleanup --prune-stale            # preview only (dry-run default)
maw cleanup --prune-stale --dry-run  # explicit alias
maw cleanup --prune-stale --yes      # prune SAFE bucket (3s Ctrl-C window)
maw cleanup --prune-stale --ask      # interactive per ASK-FIRST entry
```

## Safety design

**Hard guards (checked BEFORE bucketing):**
- `$PWD` self-exclude — never prune the entry whose `local_path` is the operator's cwd or its parent
- ψ-vault wins — `has_psi: true` → skip entirely (intentional dormant)
- Clone missing → SAFE (registry pointing at a dead path)

**Three-bucket decision tree** (per surviving stale entry):
- 🛑 **NEVER-TOUCH** — uncommitted (`git status --porcelain`), unpushed (`git rev-list @{u}..HEAD`), or detached HEAD with commits. Always shown, never auto-pruned.
- ⚠ **ASK-FIRST** — clean git + (recent mtime ≤8d, 124–128K placeholder size band, or 8–30d). `--ask` walks these one-by-one.
- ✅ **SAFE** — empty repo (0 commits) OR clean + mtime ≥30d. `--yes` prunes these in bulk.

Git probes are fanned out with a concurrency cap of 8 — a 100-entry registry triages in seconds.

## Touched files

- `plugins/cleanup/internal/prune-stale-oracles.ts` — main implementation (~480 LOC, pure-ish with injectable disk/git/manifest probes)
- `plugins/cleanup/internal/prune-stale-oracles.test.ts` — 28 unit tests
- `plugins/cleanup/index.ts` — flag dispatch
- `plugins/cleanup/plugin.json` — bump 1.0.0 → 1.1.0, update help string
- `plugins/doctor/cross-source-detect.ts` — message body now points operators at `maw cleanup --prune-stale` instead of "remove the directory"

Reuses the countdown idiom + `MAW_TEST_MODE` bypass from `team-cleanup-zombies.ts` (PR #43).

## Test plan

- [x] `bun test plugins/cleanup` — 35 pass (7 pre-existing + 28 new)
- [x] `bun test plugins/doctor plugins/cleanup` — 41 pass, 0 fail
- [x] Dry-run smoke against a temp `oracles.json` — preview only, file unchanged
- [x] `--yes` smoke — only SAFE entries removed; ψ, ASK-FIRST, NEVER-TOUCH preserved
- [x] `--ask` smoke — only entries the prompt approves are removed
- [x] Unknown top-level keys (`leaves`, etc.) preserved on rewrite
- [x] PWD self-exclude verified — entry whose path equals cwd is dropped from candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)