### PR TITLE
feat(peers): TTL-based stale peer detection + maw doctor --fix-stale (#1238)

### DIFF
--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -10,6 +10,7 @@ import { loadManifestCached, invalidateManifest } from "maw-js/lib/oracle-manife
 import { findGaps, summarizeGaps } from "./cross-source-detect";
 import { checkMawJsBranch } from "./internal/maw-js-branch-check";
 import { checkStillbornWorktrees } from "./internal/stillborn-worktrees";
+import { checkStalePeers, cmdFixStalePeers } from "./internal/stale-peers";
 
 export interface DoctorResult {
   ok: boolean;
@@ -24,6 +25,13 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
   const smoke = flags.has("--smoke") || only === "smoke";
   const checks: DoctorResult["checks"] = [];
 
+  // #1238 — `maw doctor --fix-stale` short-circuits the normal check
+  // suite: this is a destructive sweep, not a diagnostic. Returns the
+  // fix result directly so index.ts surfaces it unchanged.
+  if (flags.has("--fix-stale")) {
+    return await cmdFixStalePeers();
+  }
+
   if (smoke) {
     const smokeChecks = await runSmokeTests();
     for (const c of smokeChecks) checks.push(c);
@@ -37,6 +45,7 @@ export async function cmdDoctor(args: string[] = []): Promise<DoctorResult> {
     }
     if (!only || only === "peers" || only === "all") {
       checks.push(checkPeerDuplicates());
+      checks.push(checkStalePeers());
     }
     if (!only || only === "manifest" || only === "all") {
       checks.push(checkCrossSourceConsistency());

--- a/plugins/doctor/internal/peers-store.ts
+++ b/plugins/doctor/internal/peers-store.ts
@@ -188,3 +188,52 @@ export function clearStaleTmp(): void {
   const tmp = `${peersPath()}.tmp`;
   try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
 }
+
+// ─── TTL stale-peer detection (#1238) ──────────────────────────────────────
+//
+// Mirrored from `plugins/peers/store.ts` so the doctor plugin's internal
+// copy keeps full parity. See the canonical comment block there for the
+// design rationale.
+
+/** Default stale TTL: 7 days in milliseconds. */
+export const DEFAULT_STALE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the effective stale TTL from `MAW_PEER_STALE_TTL_MS` or the
+ * default. Bad values (NaN, ≤0) fall back to the default — never throw,
+ * never disable.
+ */
+export function getStaleTtlMs(): number {
+  const raw = process.env.MAW_PEER_STALE_TTL_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_STALE_TTL_MS;
+}
+
+/**
+ * Age of the most informative timestamp on a peer — `lastSeen` if we've
+ * ever heard from it, else `addedAt`. Returns `null` when neither is a
+ * parseable ISO date.
+ */
+export function staleAgeMs(peer: Peer, now: number = Date.now()): number | null {
+  const ref = peer.lastSeen ?? peer.addedAt;
+  if (!ref) return null;
+  const t = Date.parse(ref);
+  if (!Number.isFinite(t)) return null;
+  return Math.max(0, now - t);
+}
+
+/**
+ * Is this peer stale per `ttlMs`?
+ *
+ * True when `lastSeen` is set AND older than `ttlMs`, OR `lastSeen` is
+ * null AND `addedAt` is older than `ttlMs`. A peer with no usable
+ * provenance is treated as stale.
+ */
+export function isStale(peer: Peer, ttlMs: number, now: number = Date.now()): boolean {
+  const age = staleAgeMs(peer, now);
+  if (age === null) return true;
+  return age > ttlMs;
+}

--- a/plugins/doctor/internal/stale-peers.test.ts
+++ b/plugins/doctor/internal/stale-peers.test.ts
@@ -1,0 +1,204 @@
+/**
+ * doctor/internal/stale-peers.test.ts — #1238.
+ *
+ * Black-box tests for the stale-peer doctor surface:
+ *
+ *   - `findStalePeers()` — pure enumeration over `~/.maw/peers.json`.
+ *   - `checkStalePeers()` — `maw doctor` check entry: ok:true when
+ *     none, ok:false with operator-pointer message otherwise.
+ *   - `cmdFixStalePeers()` — destructive sweep. We drive it under
+ *     `MAW_TEST_MODE=1` to skip the 3s abort countdown and assert
+ *     the on-disk state mutates correctly.
+ *   - Integration via `cmdDoctor(['--fix-stale'])` so the full
+ *     index.ts → impl.ts → stale-peers.ts wire-up is exercised.
+ *
+ * Tests use a tmp PEERS_FILE for hermeticity; MAW_TEST_MODE is set
+ * once per test to keep the countdown out of the test loop.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-doctor-stale-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+  process.env.MAW_TEST_MODE = "1";
+  delete process.env.MAW_PEER_STALE_TTL_MS;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+  delete process.env.MAW_TEST_MODE;
+  delete process.env.MAW_PEER_STALE_TTL_MS;
+});
+
+/** Hand-write peers.json so we can backdate timestamps without waiting. */
+function writePeers(peers: Record<string, any>) {
+  const path = process.env.PEERS_FILE!;
+  writeFileSync(path, JSON.stringify({ version: 1, peers }, null, 2));
+}
+
+function isoAgo(ms: number): string {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+describe("findStalePeers", () => {
+  it("empty store → []", async () => {
+    const { findStalePeers } = await import("./stale-peers");
+    expect(findStalePeers()).toEqual([]);
+  });
+
+  it("returns only peers older than the TTL, sorted by alias", async () => {
+    writePeers({
+      fresh: { url: "http://fresh.local", node: "f", addedAt: isoAgo(DAY_MS), lastSeen: isoAgo(DAY_MS) },
+      zebra: { url: "http://z.local", node: "z", addedAt: isoAgo(10 * DAY_MS), lastSeen: isoAgo(10 * DAY_MS) },
+      ancient: { url: "http://a.local", node: "a", addedAt: isoAgo(60 * DAY_MS), lastSeen: isoAgo(60 * DAY_MS) },
+    });
+    const { findStalePeers } = await import("./stale-peers");
+    const stale = findStalePeers();
+    expect(stale.map(s => s.alias)).toEqual(["ancient", "zebra"]);
+  });
+
+  it("treats null lastSeen + old addedAt as stale", async () => {
+    writePeers({
+      never: { url: "http://n.local", node: "n", addedAt: isoAgo(30 * DAY_MS), lastSeen: null },
+    });
+    const { findStalePeers } = await import("./stale-peers");
+    expect(findStalePeers().map(s => s.alias)).toEqual(["never"]);
+  });
+});
+
+describe("checkStalePeers", () => {
+  it("no peers → ok:true 'no stale peers'", async () => {
+    const { checkStalePeers } = await import("./stale-peers");
+    const r = checkStalePeers();
+    expect(r.ok).toBe(true);
+    expect(r.name).toBe("peers:stale");
+    expect(r.message).toBe("no stale peers");
+  });
+
+  it("stale peers present → ok:false with count + pointer", async () => {
+    writePeers({
+      a: { url: "http://a", node: "a", addedAt: isoAgo(10 * DAY_MS), lastSeen: isoAgo(10 * DAY_MS) },
+      b: { url: "http://b", node: "b", addedAt: isoAgo(20 * DAY_MS), lastSeen: isoAgo(20 * DAY_MS) },
+    });
+    const { checkStalePeers } = await import("./stale-peers");
+    const r = checkStalePeers();
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain("2 stale peers");
+    expect(r.message).toContain("--fix-stale");
+  });
+
+  it("singular phrasing when exactly one stale peer", async () => {
+    writePeers({
+      only: { url: "http://o", node: "o", addedAt: isoAgo(10 * DAY_MS), lastSeen: isoAgo(10 * DAY_MS) },
+    });
+    const { checkStalePeers } = await import("./stale-peers");
+    const r = checkStalePeers();
+    expect(r.message).toContain("1 stale peer ");
+    expect(r.message).not.toContain("1 stale peers");
+  });
+
+  it("respects MAW_PEER_STALE_TTL_MS override", async () => {
+    process.env.MAW_PEER_STALE_TTL_MS = String(365 * DAY_MS); // 1 year — even a 30d old peer is fresh
+    writePeers({
+      mid: { url: "http://m", node: "m", addedAt: isoAgo(30 * DAY_MS), lastSeen: isoAgo(30 * DAY_MS) },
+    });
+    const { checkStalePeers } = await import("./stale-peers");
+    expect(checkStalePeers().ok).toBe(true);
+  });
+});
+
+describe("cmdFixStalePeers", () => {
+  it("no stale peers → no-op, ok:true", async () => {
+    writePeers({
+      fresh: { url: "http://f", node: "f", addedAt: isoAgo(DAY_MS), lastSeen: isoAgo(DAY_MS) },
+    });
+    const { cmdFixStalePeers } = await import("./stale-peers");
+    const r = await cmdFixStalePeers();
+    expect(r.ok).toBe(true);
+    expect(r.checks[0].message).toContain("no stale");
+    // Fresh peer survives.
+    const after = JSON.parse(readFileSync(process.env.PEERS_FILE!, "utf-8"));
+    expect(after.peers.fresh).toBeDefined();
+  });
+
+  it("removes stale peers, keeps fresh ones", async () => {
+    writePeers({
+      fresh: { url: "http://f", node: "f", addedAt: isoAgo(DAY_MS), lastSeen: isoAgo(DAY_MS) },
+      stale1: { url: "http://s1", node: "s1", addedAt: isoAgo(20 * DAY_MS), lastSeen: isoAgo(20 * DAY_MS) },
+      stale2: { url: "http://s2", node: "s2", addedAt: isoAgo(30 * DAY_MS), lastSeen: null },
+    });
+    const { cmdFixStalePeers } = await import("./stale-peers");
+    const r = await cmdFixStalePeers();
+    expect(r.ok).toBe(true);
+    expect(r.checks[0].message).toContain("removed 2");
+
+    const after = JSON.parse(readFileSync(process.env.PEERS_FILE!, "utf-8"));
+    expect(after.peers.fresh).toBeDefined();
+    expect(after.peers.stale1).toBeUndefined();
+    expect(after.peers.stale2).toBeUndefined();
+  });
+
+  it("MAW_TEST_MODE bypasses the 3s countdown (fast)", async () => {
+    writePeers({
+      old: { url: "http://o", node: "o", addedAt: isoAgo(30 * DAY_MS), lastSeen: isoAgo(30 * DAY_MS) },
+    });
+    const { cmdFixStalePeers } = await import("./stale-peers");
+    const t0 = Date.now();
+    await cmdFixStalePeers();
+    const elapsed = Date.now() - t0;
+    // Should be far under 3000ms — call it 2s to be tolerant of slow CI.
+    expect(elapsed).toBeLessThan(2000);
+  });
+});
+
+describe("cmdDoctor --fix-stale integration", () => {
+  it("doctor --fix-stale removes stale peers end-to-end", async () => {
+    writePeers({
+      keep: { url: "http://k", node: "k", addedAt: isoAgo(DAY_MS), lastSeen: isoAgo(DAY_MS) },
+      drop: { url: "http://d", node: "d", addedAt: isoAgo(20 * DAY_MS), lastSeen: isoAgo(20 * DAY_MS) },
+    });
+    const { cmdDoctor } = await import("../impl");
+    const r = await cmdDoctor(["--fix-stale"]);
+    expect(r.ok).toBe(true);
+    expect(r.checks[0].name).toBe("peers:fix-stale");
+    expect(r.checks[0].message).toContain("removed 1");
+
+    const after = JSON.parse(readFileSync(process.env.PEERS_FILE!, "utf-8"));
+    expect(after.peers.keep).toBeDefined();
+    expect(after.peers.drop).toBeUndefined();
+  });
+
+  it("doctor --fix-stale on a clean store reports no stale peers", async () => {
+    const { cmdDoctor } = await import("../impl");
+    const r = await cmdDoctor(["--fix-stale"]);
+    expect(r.ok).toBe(true);
+    expect(r.checks[0].message).toContain("no stale");
+  });
+
+  it("doctor peers check surfaces the new peers:stale entry", async () => {
+    writePeers({
+      drop: { url: "http://d", node: "d", addedAt: isoAgo(30 * DAY_MS), lastSeen: isoAgo(30 * DAY_MS) },
+    });
+    const { cmdDoctor } = await import("../impl");
+    const r = await cmdDoctor(["peers"]);
+    const stale = r.checks.find(c => c.name === "peers:stale");
+    expect(stale).toBeDefined();
+    expect(stale!.ok).toBe(false);
+    expect(stale!.message).toContain("--fix-stale");
+  });
+});
+
+// Sanity guard: the file we wrote actually exists where we expect.
+describe("setup sanity", () => {
+  it("PEERS_FILE points at the tmp dir", () => {
+    expect(process.env.PEERS_FILE).toContain("maw-doctor-stale-");
+    writePeers({ x: { url: "http://x", node: "x", addedAt: new Date().toISOString(), lastSeen: null } });
+    expect(existsSync(process.env.PEERS_FILE!)).toBe(true);
+  });
+});

--- a/plugins/doctor/internal/stale-peers.ts
+++ b/plugins/doctor/internal/stale-peers.ts
@@ -1,0 +1,148 @@
+/**
+ * doctor/internal/stale-peers.ts — #1238.
+ *
+ * Stale-peer detection on top of the TTL helpers in
+ * `./peers-store` (mirrored from `plugins/peers/store.ts`).
+ *
+ * Two surfaces:
+ *
+ *   - `checkStalePeers()` — read-only doctor entry. Returns `ok:true`
+ *     when no peer is stale, `ok:false` with a count + pointer to
+ *     `--fix-stale` when there are stale entries. Mirrors the severity
+ *     pattern from `checkPeerDuplicates` (#804 Step 3): hard failure
+ *     so the operator notices, but the fix is one explicit flag away.
+ *
+ *   - `cmdFixStalePeers()` — destructive sweep. Prints a preview, runs
+ *     a 3s abort window (skipped in MAW_TEST_MODE — same idiom as
+ *     `cleanup --zombie-agents`), then removes each stale peer via
+ *     `mutatePeers` (atomic, lock-safe). Returns a `DoctorResult`-shape
+ *     payload so `cmdDoctor` can return it directly without going
+ *     through the regular renderResults path.
+ *
+ * Self-exclude: this is a registry-only sweep — peers are remote nodes
+ * we point at, not the local oracle itself — so there's nothing to
+ * exclude. (Contrast with `cleanup --zombie-agents`, which had to
+ * exclude the operator's live primary pane.)
+ */
+import { C } from "maw-js/commands/shared/fleet-doctor-fixer";
+import {
+  loadPeers,
+  mutatePeers,
+  isStale,
+  getStaleTtlMs,
+  staleAgeMs,
+  type Peer,
+} from "./peers-store";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export interface StalePeer {
+  alias: string;
+  url: string;
+  /** Age in ms since lastSeen (or addedAt for never-probed peers). `null` when timestamps are unparseable. */
+  ageMs: number | null;
+}
+
+/**
+ * Pure: enumerate stale peers from `~/.maw/peers.json` (or `$PEERS_FILE`).
+ * Sorted by alias for stable output. Returns `[]` on any load error —
+ * the caller turns that into a "skipping" ok:true check.
+ */
+export function findStalePeers(now: number = Date.now()): StalePeer[] {
+  let peers: Record<string, Peer> = {};
+  try {
+    peers = loadPeers().peers;
+  } catch {
+    return [];
+  }
+  const ttlMs = getStaleTtlMs();
+  return Object.entries(peers)
+    .filter(([_, p]) => isStale(p, ttlMs, now))
+    .map(([alias, p]) => ({ alias, url: p.url, ageMs: staleAgeMs(p, now) }))
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+export interface DoctorCheck {
+  name: string;
+  ok: boolean;
+  message: string;
+}
+
+/**
+ * `maw doctor` entry: surface a count of stale peers and point the
+ * operator at the explicit `--fix-stale` removal flag. ok:false on
+ * non-zero count so the doctor exit code reflects "needs attention".
+ */
+export function checkStalePeers(now: number = Date.now()): DoctorCheck {
+  let stale: StalePeer[];
+  try {
+    stale = findStalePeers(now);
+  } catch (e: any) {
+    return {
+      name: "peers:stale",
+      ok: true,
+      message: `peer cache unreadable (${e?.message || e}) — skipping stale check`,
+    };
+  }
+  if (stale.length === 0) {
+    return { name: "peers:stale", ok: true, message: "no stale peers" };
+  }
+  const days = Math.round(getStaleTtlMs() / DAY_MS);
+  return {
+    name: "peers:stale",
+    ok: false,
+    message: `${stale.length} stale peer${stale.length === 1 ? "" : "s"} (>${days}d) — run 'maw doctor --fix-stale' to remove`,
+  };
+}
+
+/**
+ * Destructive: remove every stale peer after a 3s abort window.
+ *
+ * Test mode (`MAW_TEST_MODE=1`) skips the countdown for deterministic,
+ * fast test runs — same pattern as `cmdCleanupZombies`. Removal goes
+ * through `mutatePeers` so the lock + atomic write semantics from
+ * `peers/store.ts` apply (concurrent writers don't lose updates).
+ *
+ * Returns a `DoctorResult`-shape payload so the dispatch path in
+ * `cmdDoctor` can short-circuit and hand it straight back to index.ts.
+ */
+export async function cmdFixStalePeers(): Promise<{ ok: boolean; checks: DoctorCheck[] }> {
+  const stale = findStalePeers();
+  console.log("");
+  console.log(`  ${C.green}✓${C.reset} maw doctor --fix-stale${C.reset}`);
+  if (stale.length === 0) {
+    console.log(`    ${C.green}✓${C.reset} peers:fix-stale: no stale peers to remove`);
+    console.log("");
+    return { ok: true, checks: [{ name: "peers:fix-stale", ok: true, message: "no stale peers" }] };
+  }
+
+  console.log(`    ${C.yellow}⚠${C.reset} ${stale.length} stale peer${stale.length === 1 ? "" : "s"} to remove:`);
+  for (const s of stale) {
+    const ago = s.ageMs != null ? `${Math.floor(s.ageMs / DAY_MS)}d ago` : "never seen";
+    console.log(`      ${C.yellow}${s.alias}${C.reset}  ${s.url}  ${C.gray}(${ago})${C.reset}`);
+  }
+
+  if (!process.env.MAW_TEST_MODE) {
+    console.log(`    ${C.yellow}! Removing in 3s — Ctrl-C to abort.${C.reset}`);
+    for (let i = 3; i > 0; i--) {
+      process.stdout.write(`      ${C.gray}${i}...${C.reset}\r`);
+      await Bun.sleep(1000);
+    }
+    process.stdout.write(`            \r`); // clear countdown line
+  }
+
+  let removed = 0;
+  for (const s of stale) {
+    mutatePeers((d) => {
+      if (d.peers[s.alias]) {
+        delete d.peers[s.alias];
+        removed++;
+      }
+    });
+    console.log(`      ${C.green}✓${C.reset} removed ${s.alias}`);
+  }
+  const msg = `removed ${removed} stale peer${removed === 1 ? "" : "s"}`;
+  console.log(`    ${C.green}✓${C.reset} peers:fix-stale: ${msg}`);
+  console.log("");
+  return { ok: true, checks: [{ name: "peers:fix-stale", ok: true, message: msg }] };
+}

--- a/plugins/peers/impl.ts
+++ b/plugins/peers/impl.ts
@@ -11,7 +11,7 @@
  * valid — it just means `alias:<agent>` routing needs the URL-to-node
  * map from another source. That's a follow-up concern.
  */
-import { loadPeers, mutatePeers, type Peer, type LastError } from "./store";
+import { loadPeers, mutatePeers, isStale, getStaleTtlMs, staleAgeMs, type Peer, type LastError } from "./store";
 import { probePeer } from "./probe";
 import { evaluatePeerIdentity, applyTofuDecision, PeerPubkeyMismatchError } from "./tofu";
 
@@ -207,11 +207,28 @@ export async function cmdProbe(alias: string): Promise<ProbeResult> {
   };
 }
 
-export function cmdList(): Array<{ alias: string } & Peer> {
+/**
+ * One peers-list row — base Peer fields plus derived staleness metadata.
+ *
+ * `stale` / `staleAgeMs` are derived at list-time (not persisted) from
+ * the current TTL (`MAW_PEER_STALE_TTL_MS` or default). Renderers append
+ * the stale annotation; consumers can ignore the fields entirely and
+ * still get back valid Peer data.
+ */
+export type PeerListRow = { alias: string; stale: boolean; staleAgeMs: number | null } & Peer;
+
+export function cmdList(): PeerListRow[] {
   const data = loadPeers();
+  const ttlMs = getStaleTtlMs();
+  const now = Date.now();
   return Object.entries(data.peers)
     .sort(([a], [b]) => a.localeCompare(b))
-    .map(([alias, p]) => ({ alias, ...p }));
+    .map(([alias, p]) => ({
+      alias,
+      ...p,
+      stale: isStale(p, ttlMs, now),
+      staleAgeMs: staleAgeMs(p, now),
+    }));
 }
 
 export function cmdInfo(alias: string): ({ alias: string } & Peer) | null {
@@ -253,7 +270,16 @@ export async function cmdForget(alias: string): Promise<ForgetOutcome> {
   return forgetPeerPubkey(alias);
 }
 
-export function formatList(rows: Array<{ alias: string } & Peer>): string {
+/**
+ * Render the peer list as a fixed-width table.
+ *
+ * #1238: when a row carries `stale: true` we append a dim
+ * ` (stale, last seen Nd ago)` suffix after the normal column line.
+ * Rows without staleness metadata (legacy callers passing raw
+ * `{ alias } & Peer` shapes) render unchanged, so existing callers
+ * keep working.
+ */
+export function formatList(rows: Array<{ alias: string; stale?: boolean; staleAgeMs?: number | null } & Peer>): string {
   if (!rows.length) return "no peers";
   const header = ["alias", "url", "node", "nickname", "lastSeen"];
   const lines = rows.map(r => [
@@ -266,5 +292,17 @@ export function formatList(rows: Array<{ alias: string } & Peer>): string {
   const widths = header.map((h, i) =>
     Math.max(h.length, ...lines.map(l => l[i].length)));
   const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
-  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...lines.map(fmt)].join("\n");
+  const DAY_MS = 24 * 60 * 60 * 1000;
+  const dataLines = rows.map((r, i) => {
+    let line = fmt(lines[i]);
+    if (r.stale) {
+      const age = r.staleAgeMs;
+      const suffix = age != null
+        ? `last seen ${Math.floor(age / DAY_MS)}d ago`
+        : "never seen";
+      line += `  \x1b[2m(stale, ${suffix})\x1b[0m`;
+    }
+    return line;
+  });
+  return [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...dataLines].join("\n");
 }

--- a/plugins/peers/stale.test.ts
+++ b/plugins/peers/stale.test.ts
@@ -1,0 +1,248 @@
+/**
+ * maw peers — TTL stale-peer detection tests (#1238).
+ *
+ * Covers:
+ *   - `isStale()` truth table across (lastSeen, addedAt) × (fresh, old, null).
+ *   - `getStaleTtlMs()` default + env override.
+ *   - `staleAgeMs()` picks lastSeen over addedAt, handles unparseable.
+ *   - `cmdList()` populates stale + staleAgeMs on every row.
+ *   - `formatList()` appends the dim "(stale, last seen Nd ago)" suffix
+ *     to stale rows and leaves fresh rows untouched.
+ *
+ * Each test uses a tmp PEERS_FILE so they're hermetic & parallel-safe.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Hand-write peers.json so tests don't depend on `cmdAdd`'s network probe. */
+function writePeers(peers: Record<string, any>) {
+  writeFileSync(process.env.PEERS_FILE!, JSON.stringify({ version: 1, peers }, null, 2));
+}
+function isoAgo(ms: number): string {
+  return new Date(Date.now() - ms).toISOString();
+}
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-peers-stale-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+  delete process.env.MAW_PEER_STALE_TTL_MS;
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+  delete process.env.MAW_PEER_STALE_TTL_MS;
+});
+
+describe("isStale truth table", () => {
+  it("fresh lastSeen → not stale", async () => {
+    const { isStale, DEFAULT_STALE_TTL_MS } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 30 * DAY_MS).toISOString(),
+      lastSeen: new Date(now - 1 * DAY_MS).toISOString(),
+    };
+    expect(isStale(peer, DEFAULT_STALE_TTL_MS, now)).toBe(false);
+  });
+
+  it("old lastSeen (>TTL) → stale", async () => {
+    const { isStale, DEFAULT_STALE_TTL_MS } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 30 * DAY_MS).toISOString(),
+      lastSeen: new Date(now - 8 * DAY_MS).toISOString(),
+    };
+    expect(isStale(peer, DEFAULT_STALE_TTL_MS, now)).toBe(true);
+  });
+
+  it("null lastSeen + fresh addedAt → not stale (grace period via addedAt)", async () => {
+    const { isStale, DEFAULT_STALE_TTL_MS } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 1 * DAY_MS).toISOString(),
+      lastSeen: null,
+    };
+    expect(isStale(peer, DEFAULT_STALE_TTL_MS, now)).toBe(false);
+  });
+
+  it("null lastSeen + old addedAt → stale", async () => {
+    const { isStale, DEFAULT_STALE_TTL_MS } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 30 * DAY_MS).toISOString(),
+      lastSeen: null,
+    };
+    expect(isStale(peer, DEFAULT_STALE_TTL_MS, now)).toBe(true);
+  });
+
+  it("unparseable timestamps → stale (defensive)", async () => {
+    const { isStale, DEFAULT_STALE_TTL_MS } = await import("./store");
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: "not-a-date",
+      lastSeen: null,
+    };
+    expect(isStale(peer, DEFAULT_STALE_TTL_MS)).toBe(true);
+  });
+
+  it("exactly at TTL boundary → not stale (uses strict >)", async () => {
+    const { isStale } = await import("./store");
+    const now = Date.now();
+    const ttl = 1000;
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - ttl).toISOString(),
+      lastSeen: new Date(now - ttl).toISOString(),
+    };
+    expect(isStale(peer, ttl, now)).toBe(false);
+  });
+});
+
+describe("getStaleTtlMs", () => {
+  it("default = 7 days when env unset", async () => {
+    const { getStaleTtlMs, DEFAULT_STALE_TTL_MS } = await import("./store");
+    expect(getStaleTtlMs()).toBe(DEFAULT_STALE_TTL_MS);
+    expect(DEFAULT_STALE_TTL_MS).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("MAW_PEER_STALE_TTL_MS env override (positive integer)", async () => {
+    process.env.MAW_PEER_STALE_TTL_MS = "12345";
+    const { getStaleTtlMs } = await import("./store");
+    expect(getStaleTtlMs()).toBe(12345);
+  });
+
+  it("MAW_PEER_STALE_TTL_MS bad value (NaN) → falls back to default", async () => {
+    process.env.MAW_PEER_STALE_TTL_MS = "garbage";
+    const { getStaleTtlMs, DEFAULT_STALE_TTL_MS } = await import("./store");
+    expect(getStaleTtlMs()).toBe(DEFAULT_STALE_TTL_MS);
+  });
+
+  it("MAW_PEER_STALE_TTL_MS negative → falls back to default", async () => {
+    process.env.MAW_PEER_STALE_TTL_MS = "-100";
+    const { getStaleTtlMs, DEFAULT_STALE_TTL_MS } = await import("./store");
+    expect(getStaleTtlMs()).toBe(DEFAULT_STALE_TTL_MS);
+  });
+});
+
+describe("staleAgeMs", () => {
+  it("prefers lastSeen over addedAt when both set", async () => {
+    const { staleAgeMs } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 30 * DAY_MS).toISOString(),
+      lastSeen: new Date(now - 2 * DAY_MS).toISOString(),
+    };
+    const age = staleAgeMs(peer, now);
+    expect(age).not.toBeNull();
+    // ~2 days, within a few ms tolerance
+    expect(Math.abs(age! - 2 * DAY_MS)).toBeLessThan(1000);
+  });
+
+  it("falls back to addedAt when lastSeen null", async () => {
+    const { staleAgeMs } = await import("./store");
+    const now = Date.now();
+    const peer = {
+      url: "http://x",
+      node: "x",
+      addedAt: new Date(now - 5 * DAY_MS).toISOString(),
+      lastSeen: null,
+    };
+    const age = staleAgeMs(peer, now);
+    expect(Math.abs(age! - 5 * DAY_MS)).toBeLessThan(1000);
+  });
+
+  it("returns null when timestamps unparseable", async () => {
+    const { staleAgeMs } = await import("./store");
+    const peer = { url: "http://x", node: "x", addedAt: "junk", lastSeen: null };
+    expect(staleAgeMs(peer)).toBeNull();
+  });
+});
+
+describe("cmdList stale wiring", () => {
+  it("populates stale + staleAgeMs on every row", async () => {
+    writePeers({
+      fresh: { url: "http://a", node: "a", addedAt: isoAgo(DAY_MS), lastSeen: isoAgo(DAY_MS) },
+    });
+    const { cmdList } = await import("./impl");
+    const rows = cmdList();
+    expect(rows).toHaveLength(1);
+    expect(typeof rows[0].stale).toBe("boolean");
+    expect(rows[0].stale).toBe(false);
+    expect(rows[0].staleAgeMs).not.toBeNull();
+  });
+
+  it("flags peers older than the configured TTL as stale", async () => {
+    writePeers({
+      old: { url: "http://a", node: "a", addedAt: isoAgo(30 * DAY_MS), lastSeen: isoAgo(30 * DAY_MS) },
+    });
+    const { cmdList } = await import("./impl");
+    const rows = cmdList();
+    expect(rows[0].stale).toBe(true);
+  });
+});
+
+describe("formatList stale annotation", () => {
+  it("appends dim '(stale, last seen Nd ago)' to stale rows", async () => {
+    const { formatList } = await import("./impl");
+    const now = new Date().toISOString();
+    const old = new Date(Date.now() - 10 * DAY_MS).toISOString();
+    const out = formatList([
+      { alias: "fresh", url: "http://a", node: "a", addedAt: now, lastSeen: now, stale: false, staleAgeMs: 0 },
+      { alias: "old", url: "http://b", node: "b", addedAt: old, lastSeen: old, stale: true, staleAgeMs: 10 * DAY_MS },
+    ]);
+    expect(out).toContain("(stale, last seen 10d ago)");
+    // Dim ANSI escape present on the stale annotation.
+    expect(out).toMatch(/\x1b\[2m\(stale,/);
+    // Fresh row has no stale suffix.
+    const freshLine = out.split("\n").find(l => l.startsWith("fresh "));
+    expect(freshLine).toBeDefined();
+    expect(freshLine!).not.toContain("(stale");
+  });
+
+  it("never-seen peer renders '(stale, never seen)'", async () => {
+    const { formatList } = await import("./impl");
+    const oldAdded = new Date(Date.now() - 30 * DAY_MS).toISOString();
+    const out = formatList([
+      { alias: "z", url: "http://z", node: "z", addedAt: oldAdded, lastSeen: null, stale: true, staleAgeMs: null },
+    ]);
+    expect(out).toContain("(stale, never seen)");
+  });
+
+  it("rows without stale metadata render unchanged (back-compat)", async () => {
+    const { formatList } = await import("./impl");
+    const now = new Date().toISOString();
+    const out = formatList([
+      { alias: "x", url: "http://x", node: "x", addedAt: now, lastSeen: now },
+    ]);
+    expect(out).not.toContain("(stale");
+  });
+});
+
+describe("dispatcher ls shows stale annotation", () => {
+  it("maw peers ls flags an aged-out peer", async () => {
+    writePeers({
+      ancient: { url: "http://a.local", node: "a", addedAt: isoAgo(30 * DAY_MS), lastSeen: isoAgo(30 * DAY_MS) },
+    });
+    const { default: handler } = await import("./index");
+    const ls = await handler({ source: "cli", args: ["ls"] });
+    expect(ls.ok).toBe(true);
+    expect(ls.output).toContain("ancient");
+    expect(ls.output).toContain("(stale,");
+  });
+});

--- a/plugins/peers/store.ts
+++ b/plugins/peers/store.ts
@@ -188,3 +188,67 @@ export function clearStaleTmp(): void {
   const tmp = `${peersPath()}.tmp`;
   try { if (existsSync(tmp)) unlinkSync(tmp); } catch { /* ignore */ }
 }
+
+// ─── TTL stale-peer detection (#1238) ──────────────────────────────────────
+//
+// A peer is "stale" when its most-recent successful probe (`lastSeen`) is
+// older than `ttlMs` — or, if it was never successfully probed, when its
+// `addedAt` timestamp itself is older than `ttlMs`. The never-probed branch
+// keeps unreachable bootstraps from lingering forever in the cache; an
+// alias added via `peers add --allow-unreachable` against a typo'd URL
+// will fall out on its own once the TTL elapses, exactly like a peer that
+// went offline. Both branches share the same TTL — there's no reason to
+// give never-probed peers a longer grace period than peers we've actively
+// lost contact with.
+//
+// Default: 7 days. Override via `MAW_PEER_STALE_TTL_MS` (positive integer
+// milliseconds). Anything non-positive, non-numeric, or unset falls back
+// to the default — never silently disables the TTL.
+
+/** Default stale TTL: 7 days in milliseconds. */
+export const DEFAULT_STALE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Resolve the effective stale TTL from `MAW_PEER_STALE_TTL_MS` or the
+ * default. Bad values (NaN, ≤0) fall back to the default — never throw,
+ * never disable.
+ */
+export function getStaleTtlMs(): number {
+  const raw = process.env.MAW_PEER_STALE_TTL_MS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return DEFAULT_STALE_TTL_MS;
+}
+
+/**
+ * Age of the most informative timestamp on a peer — `lastSeen` if we've
+ * ever heard from it, else `addedAt`. Returns `null` when neither is a
+ * parseable ISO date (defensive — schema requires `addedAt` but old/hand-
+ * edited stores may violate that).
+ */
+export function staleAgeMs(peer: Peer, now: number = Date.now()): number | null {
+  const ref = peer.lastSeen ?? peer.addedAt;
+  if (!ref) return null;
+  const t = Date.parse(ref);
+  if (!Number.isFinite(t)) return null;
+  return Math.max(0, now - t);
+}
+
+/**
+ * Is this peer stale per `ttlMs`?
+ *
+ * Returns true if:
+ *   - `lastSeen` is set AND older than `ttlMs`, OR
+ *   - `lastSeen` is null AND `addedAt` is older than `ttlMs`.
+ *
+ * If neither timestamp is parseable we err on the side of "stale" — a
+ * peer with no usable provenance is exactly the kind of entry the
+ * operator wants `--fix-stale` to sweep out.
+ */
+export function isStale(peer: Peer, ttlMs: number, now: number = Date.now()): boolean {
+  const age = staleAgeMs(peer, now);
+  if (age === null) return true;
+  return age > ttlMs;
+}


### PR DESCRIPTION
## Summary

Implements #1238 — peers gain a configurable TTL so unreachable aliases
fall out of the cache after a grace period instead of lingering forever.

- **`isStale(peer, ttlMs)` + `DEFAULT_STALE_TTL_MS = 7 days`** in
  `plugins/peers/store.ts` (mirrored into
  `plugins/doctor/internal/peers-store.ts` for parity). Stale when
  `lastSeen` is older than TTL, OR `lastSeen` is null AND `addedAt` is
  older than TTL (never-probed gets the same TTL window — no longer
  grace period for typo'd bootstraps).
- **Env override**: `MAW_PEER_STALE_TTL_MS` (positive ms integer). Bad
  values fall back to default — never silently disables.
- **`maw peers ls`** appends a dim `(stale, last seen Nd ago)` suffix
  to each stale row (or `(stale, never seen)` when no timestamp is
  parseable). `cmdList()` returns the staleness as derived metadata.
- **`maw doctor`** gains a `peers:stale` check: ok:false with count +
  pointer to `--fix-stale` when stale entries exist.
- **`maw doctor --fix-stale`** previews stale peers, runs the 3s abort
  countdown (skipped in `MAW_TEST_MODE`, same idiom as
  `cleanup --zombie-agents`), then removes each via the lock-safe
  `mutatePeers` API.

Self-exclude: registry-only sweep — there's no "currently-active
probing peer" to protect (contrast cleanup #45 protecting the live
primary pane).

## Test plan

- [x] 33 new test cases pass (`MAW_TEST_MODE=1 bun test
  plugins/peers/stale.test.ts plugins/doctor/internal/stale-peers.test.ts`)
- [x] No regressions vs. baseline in `plugins/peers/` +
  `plugins/doctor/` sweep (same 7-9 pre-existing network-probe timeouts
  in `peers.test.ts`/`peers-probe.test.ts` — unrelated to this change)
- [x] `isStale` truth table: fresh / old / null+fresh-addedAt /
  null+old-addedAt / unparseable / boundary
- [x] `getStaleTtlMs` env override + NaN/negative fallback
- [x] `formatList` annotation on stale rows; back-compat for callers
  passing raw `Peer` shapes (no stale field)
- [x] `cmdDoctor(['--fix-stale'])` end-to-end removes stale, keeps
  fresh, returns DoctorResult cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)