### PR TITLE
feat(attach): Tier 3 cross-node attach (#1236)

### DIFF
--- a/plugins/attach/attach.test.ts
+++ b/plugins/attach/attach.test.ts
@@ -1,14 +1,25 @@
 /**
- * attach plugin tests (#25 Phase 1).
+ * attach plugin tests (#25 Phase 1 + #1236 Tier 3).
  *
- * Two layers:
- *   1. Resolver — pure, no mocks, exercises Tier 1 / Tier 2 / ambiguous / null
+ * Three layers:
+ *   1. Resolver — pure, no mocks, exercises Tier 1 / 2 / 3 / ambiguous / null
  *   2. Handler — mocks listSessions + loadFleet + the maw subprocess via
  *      mock.module on Bun.spawn, verifies the cascade emits the right command
+ *   3. Tier 3 — peer-aware resolver + handler with stubbed SSH
  */
 
 import { test, expect, mock } from "bun:test";
-import { resolveAttachTarget, type SessionLike, type FleetLike } from "./resolve-attach-target";
+import {
+  resolveAttachTarget,
+  type SessionLike,
+  type FleetLike,
+} from "./resolve-attach-target";
+import {
+  resolveRemoteAttachTarget,
+  resolveSshAlias,
+  type AggregatedSessionLike,
+} from "./resolve-remote-target";
+import type { PeerConfig } from "maw-js/config/types";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // 1. Resolver tests
@@ -18,6 +29,20 @@ function makeDeps(sessions: SessionLike[], fleet: FleetLike[]) {
   return {
     listSessions: async () => sessions,
     loadFleet: () => fleet,
+  };
+}
+
+function makeRemoteDeps(opts: {
+  sessions?: SessionLike[];
+  fleet?: FleetLike[];
+  aggregated?: AggregatedSessionLike[];
+  namedPeers?: PeerConfig[];
+}) {
+  return {
+    listSessions: async () => opts.sessions ?? [],
+    loadFleet: () => opts.fleet ?? [],
+    getAggregatedSessions: async () => opts.aggregated ?? [],
+    namedPeers: () => opts.namedPeers ?? [],
   };
 }
 
@@ -96,8 +121,20 @@ function setupHandlerMocks(opts: {
 }) {
   const spawnCalls: string[][] = [];
 
+  // Tier 3 surface mocked-out (empty aggregated, no SSH calls). Existing
+  // handler tests don't exercise it, but impl.ts imports the symbols
+  // unconditionally — so they must resolve.
+  class FakeSshAttachError extends Error {
+    constructor(message: string) { super(message); this.name = "SshAttachError"; }
+  }
   mock.module("maw-js/sdk", () => ({
     listSessions: async () => opts.sessions ?? [],
+    getAggregatedSessions: async () => [],
+    attachRemoteSession: () => { throw new Error("attachRemoteSession not stubbed in this test"); },
+    SshAttachError: FakeSshAttachError,
+  }));
+  mock.module("maw-js/config", () => ({
+    loadConfig: () => ({ namedPeers: [] }),
   }));
   mock.module("maw-js/commands/shared/fleet-load", () => ({
     loadFleet: () => opts.fleet ?? [],
@@ -265,6 +302,315 @@ test("API: dispatch invokes the cascade with yes=true (no TTY)", async () => {
     expect(result.ok).toBe(true);
     expect(ctx.spawnCalls.length).toBe(2);
     expect(ctx.spawnCalls[0]).toEqual(["maw", "wake", "24-foo-oracle"]);
+  } finally {
+    ctx.restore();
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Tier 3 — cross-node attach (#1236)
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("resolveSshAlias: namedPeers[n].ssh override beats URL hostname", () => {
+  const alias = resolveSshAlias(
+    "http://mba.wg:9090",
+    "mba",
+    [{ name: "mba", url: "http://mba.wg:9090", ssh: "mba-tunnel" }],
+  );
+  expect(alias).toBe("mba-tunnel");
+});
+
+test("resolveSshAlias: URL hostname fallback when no override", () => {
+  const alias = resolveSshAlias("http://mba.wg:9090", "mba", []);
+  expect(alias).toBe("mba.wg");
+});
+
+test("resolveSshAlias: literal node name when URL is unparseable", () => {
+  const alias = resolveSshAlias("not-a-url-at-all", "mba", []);
+  expect(alias).toBe("mba");
+});
+
+test("remote resolver: Tier 3 — single peer match", async () => {
+  const r = await resolveRemoteAttachTarget("homekeeper", {
+    getAggregatedSessions: async () => [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+    namedPeers: () => [],
+  });
+  expect(r?.kind).toBe("match");
+  if (r?.kind !== "match") return;
+  expect(r.match.sessionName).toBe("24-homekeeper");
+  expect(r.match.node).toBe("mba");
+  expect(r.match.sshAlias).toBe("mba.wg");
+});
+
+test("remote resolver: ignores local-tagged rows (those belong to Tier 1)", async () => {
+  const r = await resolveRemoteAttachTarget("homekeeper", {
+    getAggregatedSessions: async () => [
+      { name: "homekeeper", windows: [{ name: "x" }], source: "local" },
+    ],
+    namedPeers: () => [],
+  });
+  expect(r).toBeNull();
+});
+
+test("remote resolver: multiple peers expose same name → ambiguous", async () => {
+  const r = await resolveRemoteAttachTarget("homekeeper", {
+    getAggregatedSessions: async () => [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+      { name: "30-homekeeper", windows: [{ name: "x" }], source: "http://white.wg:9090", node: "white" },
+    ],
+    namedPeers: () => [],
+  });
+  expect(r?.kind).toBe("ambiguous");
+  if (r?.kind !== "ambiguous") return;
+  expect(r.candidates.length).toBe(2);
+});
+
+test("cascade: bare name with NO local match falls through to Tier 3", async () => {
+  const result = await resolveAttachTarget("homekeeper", makeRemoteDeps({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  }));
+  expect(result?.tier).toBe(3);
+  if (result?.tier !== 3) return;
+  expect(result.node).toBe("mba");
+  expect(result.peerUrl).toBe("http://mba.wg:9090");
+  expect(result.sshAlias).toBe("mba.wg");
+});
+
+test("cascade: ambiguity local+remote → prefer LOCAL, surface remote as alternates", async () => {
+  const result = await resolveAttachTarget("homekeeper", makeRemoteDeps({
+    sessions: [{ name: "homekeeper", windows: [{ name: "x" }] }],
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  }));
+  expect(result?.tier).toBe(1);
+  if (result?.tier !== 1) return;
+  expect(result.sessionName).toBe("homekeeper");
+  expect(result.remoteAlternates?.length).toBe(1);
+  expect(result.remoteAlternates?.[0].node).toBe("mba");
+});
+
+test("cascade: --remote-only skips Tier 1/2 and goes straight to Tier 3", async () => {
+  const result = await resolveAttachTarget(
+    "homekeeper",
+    makeRemoteDeps({
+      // Local has it AND a fleet entry has it — neither should win under remote-only.
+      sessions: [{ name: "homekeeper", windows: [{ name: "x" }] }],
+      fleet: [{ name: "homekeeper", windows: [{ name: "x" }] }],
+      aggregated: [
+        { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+      ],
+    }),
+    { remoteOnly: true },
+  );
+  expect(result?.tier).toBe(3);
+});
+
+test("cascade: explicit node:agent syntax short-circuits past Tier 1/2", async () => {
+  const result = await resolveAttachTarget(
+    "mba:homekeeper",
+    makeRemoteDeps({
+      sessions: [{ name: "homekeeper", windows: [{ name: "x" }] }],
+      aggregated: [
+        { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+      ],
+    }),
+  );
+  expect(result?.tier).toBe(3);
+  if (result?.tier !== 3) return;
+  expect(result.node).toBe("mba");
+});
+
+test("cascade: bare name + no local + no remote → null", async () => {
+  const result = await resolveAttachTarget("ghost", makeRemoteDeps({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  }));
+  expect(result).toBeNull();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4. Tier 3 handler — SSH failure UX
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Tier 3 handler tests stub `getAggregatedSessions` + `attachRemoteSession`
+ * via mock.module on maw-js/sdk. cmdAttach reads the SDK directly so its
+ * Tier 3 branch resolves to our fakes.
+ */
+function setupTier3Mocks(opts: {
+  aggregated?: AggregatedSessionLike[];
+  namedPeers?: PeerConfig[];
+  sshThrows?: { kind: "unreachable" | "auth-failed" | "tmux-missing"; message: string };
+}) {
+  const sshCalls: any[] = [];
+
+  // Build the SshAttachError-shaped throw without depending on the real class
+  // (mock.module replaces the whole sdk surface, so we re-export a minimal
+  // class that satisfies `instanceof SshAttachError` in the handler).
+  class FakeSshAttachError extends Error {
+    kind: string;
+    constructor(kind: string, message: string) {
+      super(message);
+      this.kind = kind;
+      this.name = "SshAttachError";
+    }
+  }
+
+  mock.module("maw-js/sdk", () => ({
+    listSessions: async () => [],
+    getAggregatedSessions: async () => opts.aggregated ?? [],
+    SshAttachError: FakeSshAttachError,
+    attachRemoteSession: (sshArgs: any) => {
+      sshCalls.push(sshArgs);
+      if (opts.sshThrows) {
+        throw new FakeSshAttachError(opts.sshThrows.kind, opts.sshThrows.message);
+      }
+    },
+  }));
+  mock.module("maw-js/commands/shared/fleet-load", () => ({
+    loadFleet: () => [],
+  }));
+  mock.module("maw-js/config", () => ({
+    loadConfig: () => ({ namedPeers: opts.namedPeers ?? [] }),
+  }));
+
+  const realSpawn = Bun.spawn;
+  (Bun as any).spawn = () => ({ exited: Promise.resolve(0) });
+
+  return {
+    sshCalls,
+    restore: () => {
+      (Bun as any).spawn = realSpawn;
+      mock.restore();
+    },
+  };
+}
+
+test("Tier 3 handler: happy path — calls attachRemoteSession with right args", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    await cmdAttach("homekeeper");
+    expect(ctx.sshCalls.length).toBe(1);
+    expect(ctx.sshCalls[0]).toEqual({
+      node: "mba",
+      sshAlias: "mba.wg",
+      sessionName: "24-homekeeper",
+    });
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: namedPeers.ssh override is used as sshAlias", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+    namedPeers: [{ name: "mba", url: "http://mba.wg:9090", ssh: "mba-tunnel" }],
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    await cmdAttach("homekeeper");
+    expect(ctx.sshCalls[0].sshAlias).toBe("mba-tunnel");
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: dry-run prints plan without calling SSH", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    await cmdAttach("homekeeper", { dryRun: true });
+    expect(ctx.sshCalls.length).toBe(0);
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: ssh exit 255 / Connection refused → throws UserError-ish", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+    sshThrows: { kind: "unreachable", message: "✗ can't reach mba via ssh — try: ssh mba.wg" },
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    let threw: Error | null = null;
+    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    expect(threw).not.toBeNull();
+    expect(threw!.message).toContain("can't reach mba");
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: Permission denied → auth-failed UserError", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+    sshThrows: { kind: "auth-failed", message: "✗ no SSH key for mba — ssh-add ~/.ssh/<your-key>" },
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    let threw: Error | null = null;
+    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    expect(threw).not.toBeNull();
+    expect(threw!.message).toContain("no SSH key for mba");
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: tmux not installed on remote → tmux-missing UserError", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+    sshThrows: { kind: "tmux-missing", message: "✗ tmux not installed on mba" },
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    let threw: Error | null = null;
+    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    expect(threw).not.toBeNull();
+    expect(threw!.message).toContain("tmux not installed on mba");
+  } finally {
+    ctx.restore();
+  }
+});
+
+test("Tier 3 handler: ambiguous across peers — refuses, prints pin hint", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+      { name: "30-homekeeper", windows: [{ name: "x" }], source: "http://white.wg:9090", node: "white" },
+    ],
+  });
+  try {
+    const { cmdAttach } = await import("./impl");
+    let threw: Error | null = null;
+    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    expect(threw).not.toBeNull();
+    expect(threw!.message).toMatch(/ambiguous/i);
+    expect(ctx.sshCalls.length).toBe(0);
   } finally {
     ctx.restore();
   }

--- a/plugins/attach/impl.ts
+++ b/plugins/attach/impl.ts
@@ -1,22 +1,37 @@
 /**
- * `maw attach <name>` cascade — Phase 1 (#25).
+ * `maw attach <name>` cascade — Phase 1 (#25) + Tier 3 (#1236).
  *
- *   Tier 1 (live):     attach immediately via `maw tmux attach <session>`
- *   Tier 2 (sleeping): prompt → `maw wake <fleet-name>` → attach
- *   no match:          error + list of available oracles
+ *   Tier 1 (live):        attach immediately via `maw tmux attach <session>`
+ *   Tier 2 (sleeping):    prompt → `maw wake <fleet-name>` → attach
+ *   Tier 3 (remote-live): SSH + tmux attach on the peer that owns it
+ *   no match:             error + list of available oracles
  *
- * Deferred to follow-up issues: T3 (ghq clone, no fleet), T4 (remote-only on
- * GitHub), T5 (nothing exists), and the non-interactive variant beyond -y.
+ * Tier 4 (remote-sleeping wake-then-attach) is the next follow-up — this
+ * iteration ships the 80% case ("remote is alive, attach me") only.
  */
-import { listSessions } from "maw-js/sdk";
+import { listSessions, getAggregatedSessions, attachRemoteSession, SshAttachError } from "maw-js/sdk";
 import { loadFleet } from "maw-js/commands/shared/fleet-load";
-import { resolveAttachTarget, type ResolveResult } from "./resolve-attach-target";
+import { loadConfig } from "maw-js/config";
+import {
+  resolveAttachTarget,
+  type ResolveResult,
+  type RemoteAlternate,
+} from "./resolve-attach-target";
 
 export interface AttachOpts {
   /** Skip the human-confirmation prompt on Tier 2 (agents / scripted). */
   yes?: boolean;
   /** Show what the cascade picked + planned action, no side effects. */
   dryRun?: boolean;
+  /** Pin the search to a specific node (`--node mba` or `node:agent` syntax). */
+  node?: string;
+  /** Skip Tier 1/2 entirely and only consider remote peers. */
+  remoteOnly?: boolean;
+  /**
+   * Test seam — swap the cross-node SSH attach with a stub. Defaults to the
+   * real `attachRemoteSession` from maw-js/sdk.
+   */
+  ssh?: typeof attachRemoteSession;
 }
 
 /**
@@ -51,12 +66,22 @@ function listAvailable(fleet: { name: string }[], sessions: { name: string }[]):
 
 export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<void> {
   if (!name) {
-    console.error("usage: maw attach <name> [--dry-run] [-y]");
+    console.error("usage: maw attach <name> [--dry-run] [-y] [--node <n>] [--remote-only]");
     throw new Error("name required");
   }
 
-  const deps = { listSessions, loadFleet };
-  const result: ResolveResult = await resolveAttachTarget(name, deps);
+  // Cascade deps — getAggregatedSessions + namedPeers are wired here so the
+  // resolver stays pure. Tests inject the whole `deps` block via mock.module.
+  const deps = {
+    listSessions,
+    loadFleet,
+    getAggregatedSessions,
+    namedPeers: () => loadConfig().namedPeers ?? [],
+  };
+  const result: ResolveResult = await resolveAttachTarget(name, deps, {
+    node: opts.node,
+    remoteOnly: opts.remoteOnly,
+  });
 
   if (!result) {
     const sessions = await listSessions();
@@ -67,7 +92,7 @@ export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<vo
 
   // Ambiguous match: list candidates, stop. User picks one and re-runs with
   // the full name. (Auto-prompt for selection can land in Phase 2.)
-  if (result.ambiguousCandidates && result.ambiguousCandidates.length > 1) {
+  if (result.tier !== 3 && result.ambiguousCandidates && result.ambiguousCandidates.length > 1) {
     console.error(`\x1b[33m⚠\x1b[0m '${name}' is ambiguous — ${result.ambiguousCandidates.length} matches:`);
     for (const c of result.ambiguousCandidates) console.error(`    • ${c}`);
     console.error(`  use the full name: \x1b[36mmaw attach <exact-name>\x1b[0m`);
@@ -77,30 +102,85 @@ export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<vo
   if (result.tier === 1) {
     if (opts.dryRun) {
       console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 1 (live) — would attach to ${result.sessionName}`);
+      if (result.remoteAlternates && result.remoteAlternates.length > 0) {
+        printRemoteAlternates(result.remoteAlternates, name);
+      }
       return;
+    }
+    if (result.remoteAlternates && result.remoteAlternates.length > 0) {
+      printRemoteAlternates(result.remoteAlternates, name);
     }
     console.log(`  \x1b[32m→\x1b[0m attaching to ${result.sessionName}`);
     await spawnMaw(["tmux", "attach", result.sessionName]);
     return;
   }
 
-  // Tier 2 — sleeping, prompt for wake.
-  if (opts.dryRun) {
-    console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 2 (sleeping) — would wake ${result.fleetName}, then attach`);
+  if (result.tier === 2) {
+    if (opts.dryRun) {
+      console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 2 (sleeping) — would wake ${result.fleetName}, then attach`);
+      return;
+    }
+
+    console.log(`  \x1b[33m○\x1b[0m '${result.fleetName}' is sleeping (fleet-registered, not running)`);
+    const promptable = !opts.yes && Boolean(process.stdin.isTTY);
+    if (promptable && !askYesNo(`  Wake "${result.fleetName}"? [y/N] `)) {
+      console.log("  aborted — no changes made.");
+      return;
+    }
+
+    console.log(`  \x1b[36m⚡\x1b[0m waking ${result.fleetName}...`);
+    await spawnMaw(["wake", result.fleetName]);
+    console.log(`  \x1b[32m→\x1b[0m attaching to ${result.fleetName}`);
+    await spawnMaw(["tmux", "attach", result.fleetName]);
     return;
   }
 
-  console.log(`  \x1b[33m○\x1b[0m '${result.fleetName}' is sleeping (fleet-registered, not running)`);
-  const promptable = !opts.yes && Boolean(process.stdin.isTTY);
-  if (promptable && !askYesNo(`  Wake \"${result.fleetName}\"? [y/N] `)) {
-    console.log("  aborted — no changes made.");
+  // Tier 3 — peer reports a live session, hand the TTY off via SSH.
+  if (result.tier === 3) {
+    // Ambiguity on Tier 3: two peers both expose a session with this name.
+    // Bail loudly — operator should disambiguate via `--node` or full name.
+    if (result.ambiguousCandidates && result.ambiguousCandidates.length > 1) {
+      console.error(`\x1b[33m⚠\x1b[0m '${name}' is ambiguous across peers — ${result.ambiguousCandidates.length} matches:`);
+      for (const c of result.ambiguousCandidates) {
+        console.error(`    • ${c.sessionName} on ${c.node}`);
+      }
+      console.error(`  pin it: \x1b[36mmaw attach <node>:${name}\x1b[0m`);
+      throw new Error(`ambiguous remote: ${name}`);
+    }
+
+    if (opts.dryRun) {
+      console.log(`  \x1b[36m·\x1b[0m [dry-run] Tier 3 (remote-live) — would ssh ${result.sshAlias} → tmux attach -t '${result.sessionName}'`);
+      return;
+    }
+
+    console.log(`  \x1b[36m→\x1b[0m '${result.sessionName}' is on ${result.node} (peer ${result.peerUrl})`);
+    console.log(`  \x1b[90m  ssh ${result.sshAlias} → tmux attach -t '${result.sessionName}'\x1b[0m`);
+    console.log(`  \x1b[90m  hint: detach with prefix+d to return to your local shell\x1b[0m`);
+    const ssh = opts.ssh ?? attachRemoteSession;
+    try {
+      ssh({
+        node: result.node,
+        sshAlias: result.sshAlias,
+        sessionName: result.sessionName,
+      });
+    } catch (err) {
+      if (err instanceof SshAttachError) {
+        // Surface the helper's friendly one-line message — never process.exit.
+        console.error(err.message);
+        throw new Error(err.message);
+      }
+      throw err;
+    }
     return;
   }
+}
 
-  console.log(`  \x1b[36m⚡\x1b[0m waking ${result.fleetName}...`);
-  await spawnMaw(["wake", result.fleetName]);
-  console.log(`  \x1b[32m→\x1b[0m attaching to ${result.fleetName}`);
-  await spawnMaw(["tmux", "attach", result.fleetName]);
+function printRemoteAlternates(alts: RemoteAlternate[], name: string): void {
+  console.log(`  \x1b[90mnote: '${name}' is also live on ${alts.length} peer(s):\x1b[0m`);
+  for (const a of alts) {
+    console.log(`  \x1b[90m    • ${a.sessionName} on ${a.node}\x1b[0m`);
+  }
+  console.log(`  \x1b[90m  pin remote: maw attach ${alts[0].node}:${name}\x1b[0m`);
 }
 
 /**

--- a/plugins/attach/index.ts
+++ b/plugins/attach/index.ts
@@ -4,10 +4,10 @@ import { cmdAttach } from "./impl";
 
 export const command = {
   name: "attach",
-  description: "Smart attach — running session, or wake from fleet and attach (#25).",
+  description: "Smart attach — local live, sleeping fleet, or remote-live peer (#25 + #1236).",
 };
 
-const USAGE = "usage: maw attach <name> [--dry-run] [-y|--yes]";
+const USAGE = "usage: maw attach <name> [--dry-run] [-y|--yes] [--node <n>] [--remote-only]";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -31,6 +31,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "--dry-run": Boolean,
           "--yes": Boolean,
           "-y": "--yes",
+          "--node": String,
+          "--remote-only": Boolean,
         },
         0,
       );
@@ -44,6 +46,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       await cmdAttach(name, {
         dryRun: flags["--dry-run"],
         yes: flags["--yes"],
+        node: flags["--node"],
+        remoteOnly: flags["--remote-only"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -53,6 +57,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       await cmdAttach(name, {
         dryRun: body.dryRun as boolean | undefined,
         yes: true,
+        node: body.node as string | undefined,
+        remoteOnly: body.remoteOnly as boolean | undefined,
       });
     }
 

--- a/plugins/attach/resolve-attach-target.ts
+++ b/plugins/attach/resolve-attach-target.ts
@@ -1,17 +1,27 @@
 /**
- * Resolve a `maw attach <target>` invocation into a tiered match. (#25 Phase 1)
+ * Resolve a `maw attach <target>` invocation into a tiered match. (#25 + #1236)
  *
- * Tier 1 — running:  tmux session matches (incl. slot prefix / stem suffix)
- *                    → attach immediately, no prompt
- * Tier 2 — sleeping: fleet entry matches but no live tmux session
- *                    → prompt to wake, then attach
- * null          — nothing matched: caller emits "available oracles" hint
+ * Tier 1 — running:   tmux session matches (incl. slot prefix / stem suffix)
+ *                     → attach immediately, no prompt
+ * Tier 2 — sleeping:  fleet entry matches but no live tmux session
+ *                     → prompt to wake, then attach
+ * Tier 3 — remote:    peer reports a live session matching this name
+ *                     → SSH + tmux attach on the remote node (#1236)
+ * null                — nothing matched: caller emits "available oracles" hint
  *
- * Phase 1 deliberately omits T3 (ghq clone without fleet), T4 (remote-only on
- * GitHub), and T5 (nothing exists). Those land in follow-up issues.
+ * Tier 4 (remote wake — peer is reachable, session sleeping there) is
+ * deferred to a follow-up per cross-node-attach-design's phasing.
  *
  * Deps are injected for testability — same shape as the sleep resolver.
  */
+
+import {
+  resolveRemoteAttachTarget,
+  resolveExplicitNodeTarget,
+  type AggregatedSessionLike,
+  type RemoteResolveDeps,
+  type RemoteMatch,
+} from "./resolve-remote-target";
 
 export interface SessionLike {
   name: string;
@@ -26,11 +36,36 @@ export interface FleetLike {
 export interface ResolveDeps {
   listSessions: () => Promise<SessionLike[]>;
   loadFleet: () => FleetLike[];
+  /** Tier 3 — aggregated sessions across federation peers. */
+  getAggregatedSessions?: RemoteResolveDeps["getAggregatedSessions"];
+  /** Tier 3 — namedPeers for sshAlias resolution. */
+  namedPeers?: RemoteResolveDeps["namedPeers"];
+}
+
+export interface RemoteAlternate {
+  sessionName: string;
+  node: string;
 }
 
 export type ResolveResult =
-  | { tier: 1; sessionName: string; windowName?: string; ambiguousCandidates?: string[] }
+  | {
+      tier: 1;
+      sessionName: string;
+      windowName?: string;
+      ambiguousCandidates?: string[];
+      /** Remote-live candidates with the same bare name — printed as a hint (#1236 §6). */
+      remoteAlternates?: RemoteAlternate[];
+    }
   | { tier: 2; fleetName: string; ambiguousCandidates?: string[] }
+  | {
+      tier: 3;
+      sessionName: string;
+      node: string;
+      peerUrl: string;
+      sshAlias: string;
+      /** When multiple peers expose a same-named session. */
+      ambiguousCandidates?: RemoteAlternate[];
+    }
   | null;
 
 const stripDash = (s: string) => s.replace(/-+$/, "");
@@ -50,16 +85,48 @@ function nameMatches(name: string, target: string): boolean {
   );
 }
 
+export interface ResolveOptions {
+  /** Skip Tier 1/2 entirely — go straight to Tier 3 (peer-only) lookup. */
+  remoteOnly?: boolean;
+  /** Pin the search to a specific node (e.g. `--node mba` or `node:agent` syntax). */
+  node?: string;
+}
+
 export async function resolveAttachTarget(
   target: string,
   deps: ResolveDeps,
+  opts: ResolveOptions = {},
 ): Promise<ResolveResult> {
+  // `node:agent` short-circuits past Tier 1/2 — operator explicitly wants
+  // a remote attach. Bare name (no colon) falls through to the cascade.
+  let explicitNode = opts.node;
+  let bare = target;
+  if (target.includes(":") && !opts.node) {
+    const [nodePart, agentPart] = target.split(":", 2);
+    if (nodePart && agentPart) {
+      explicitNode = nodePart;
+      bare = agentPart;
+    }
+  }
+
+  // Explicit node OR remote-only → skip Tier 1/2 and resolve Tier 3 directly.
+  if (explicitNode || opts.remoteOnly) {
+    return await tier3Only(bare, explicitNode, deps);
+  }
+
   const sessions = await deps.listSessions();
 
   // Tier 1 — live tmux session matches.
   const runningMatches = sessions.filter(s => nameMatches(s.name, target));
   if (runningMatches.length === 1) {
-    return { tier: 1, sessionName: runningMatches[0].name };
+    // Prefer-local: scan peers for same-named matches and surface as
+    // alternates so the operator knows the remote exists (design §6).
+    const remoteAlternates = await collectRemoteAlternates(target, deps).catch(() => []);
+    return {
+      tier: 1,
+      sessionName: runningMatches[0].name,
+      remoteAlternates: remoteAlternates.length > 0 ? remoteAlternates : undefined,
+    };
   }
   if (runningMatches.length > 1) {
     // Ambiguity in live sessions — surface every match for the caller's prompt.
@@ -84,5 +151,89 @@ export async function resolveAttachTarget(
     };
   }
 
+  // Tier 3 — peer-live (#1236). Only attempted when local cascade missed.
+  if (deps.getAggregatedSessions && deps.namedPeers) {
+    const remote = await resolveRemoteAttachTarget(target, {
+      getAggregatedSessions: deps.getAggregatedSessions,
+      namedPeers: deps.namedPeers,
+    });
+    if (remote && remote.kind === "match") {
+      return tier3From(remote.match);
+    }
+    if (remote && remote.kind === "ambiguous") {
+      return {
+        tier: 3,
+        sessionName: remote.candidates[0].sessionName,
+        node: remote.candidates[0].node,
+        peerUrl: remote.candidates[0].peerUrl,
+        sshAlias: remote.candidates[0].sshAlias,
+        ambiguousCandidates: remote.candidates.map(c => ({
+          sessionName: c.sessionName,
+          node: c.node,
+        })),
+      };
+    }
+  }
+
   return null;
 }
+
+async function tier3Only(
+  bare: string,
+  explicitNode: string | undefined,
+  deps: ResolveDeps,
+): Promise<ResolveResult> {
+  if (!deps.getAggregatedSessions || !deps.namedPeers) return null;
+
+  if (explicitNode) {
+    const m = await resolveExplicitNodeTarget(explicitNode, bare, {
+      getAggregatedSessions: deps.getAggregatedSessions,
+      namedPeers: deps.namedPeers,
+    });
+    return m ? tier3From(m) : null;
+  }
+
+  const r = await resolveRemoteAttachTarget(bare, {
+    getAggregatedSessions: deps.getAggregatedSessions,
+    namedPeers: deps.namedPeers,
+  });
+  if (!r) return null;
+  if (r.kind === "match") return tier3From(r.match);
+  return {
+    tier: 3,
+    sessionName: r.candidates[0].sessionName,
+    node: r.candidates[0].node,
+    peerUrl: r.candidates[0].peerUrl,
+    sshAlias: r.candidates[0].sshAlias,
+    ambiguousCandidates: r.candidates.map(c => ({
+      sessionName: c.sessionName,
+      node: c.node,
+    })),
+  };
+}
+
+function tier3From(m: RemoteMatch): ResolveResult {
+  return {
+    tier: 3,
+    sessionName: m.sessionName,
+    node: m.node,
+    peerUrl: m.peerUrl,
+    sshAlias: m.sshAlias,
+  };
+}
+
+async function collectRemoteAlternates(
+  target: string,
+  deps: ResolveDeps,
+): Promise<RemoteAlternate[]> {
+  if (!deps.getAggregatedSessions || !deps.namedPeers) return [];
+  const r = await resolveRemoteAttachTarget(target, {
+    getAggregatedSessions: deps.getAggregatedSessions,
+    namedPeers: deps.namedPeers,
+  });
+  if (!r) return [];
+  const candidates = r.kind === "match" ? [r.match] : r.candidates;
+  return candidates.map(c => ({ sessionName: c.sessionName, node: c.node }));
+}
+
+export type { AggregatedSessionLike };

--- a/plugins/attach/resolve-remote-target.ts
+++ b/plugins/attach/resolve-remote-target.ts
@@ -1,0 +1,165 @@
+/**
+ * Tier 3 resolver — cross-node attach via aggregated peer sessions (#1236).
+ *
+ * Consults `getAggregatedSessions()` (peers' tmux state) and the user's
+ * `namedPeers[]` config to figure out which remote node owns a name and how
+ * to SSH there. Pure logic — the deps are injected so tests can drive it
+ * without touching the federation layer.
+ *
+ * SSH alias resolution order (design §4):
+ *   1. `namedPeers[n].ssh`        — explicit override, preferred
+ *   2. URL hostname stripped of scheme/port  (`http://mba.wg:9090` → `mba.wg`)
+ *   3. literal node name          (last-resort fallback)
+ *
+ * Tier 4 (remote wake via /api/wake) is deliberately out of scope here —
+ * `resolveRemoteAttachTarget` only returns matches for sessions that are
+ * already LIVE on a peer. Sleeping-remote handling lands in a follow-up.
+ */
+
+import type { PeerConfig } from "maw-js/config/types";
+
+export interface AggregatedSessionLike {
+  name: string;
+  windows: Array<{ name: string }>;
+  /** "local" or the peer URL the session came from. */
+  source?: string;
+  /** Peer's logical node identity from /api/identity (when available). */
+  node?: string;
+}
+
+export interface RemoteResolveDeps {
+  getAggregatedSessions: (localSessions: AggregatedSessionLike[]) => Promise<AggregatedSessionLike[]>;
+  namedPeers: () => PeerConfig[];
+}
+
+export interface RemoteMatch {
+  sessionName: string;
+  /** Logical node identity for friendly messaging. Falls back to URL host. */
+  node: string;
+  /** Full peer URL (the `source` tag from getAggregatedSessions). */
+  peerUrl: string;
+  /** SSH host/alias to hand to `attachRemoteSession`. */
+  sshAlias: string;
+}
+
+/** Reuses the same loose name comparison as the local resolver. */
+const stripDash = (s: string) => s.replace(/-+$/, "");
+function nameMatches(name: string, target: string): boolean {
+  const n = name.toLowerCase();
+  const t = target.toLowerCase();
+  return (
+    n === t ||
+    n.endsWith(`-${t}`) ||
+    stripDash(n) === stripDash(t)
+  );
+}
+
+/**
+ * Extract a sane SSH alias for a peer URL using the design's resolution order.
+ *
+ * `null` means we have nothing better than "guess literally" — caller should
+ * still try, but error UX will be vague. Most named peers in practice carry
+ * a wireguard hostname inside the URL, which `ssh` resolves directly.
+ */
+export function resolveSshAlias(
+  peerUrl: string,
+  node: string | undefined,
+  namedPeers: PeerConfig[],
+): string {
+  // 1. namedPeers[n].ssh override
+  const named = namedPeers.find(p => p.url === peerUrl);
+  if (named?.ssh && named.ssh.length > 0) return named.ssh;
+
+  // 2. URL hostname stripped of scheme/port
+  try {
+    const u = new URL(peerUrl);
+    if (u.hostname) return u.hostname;
+  } catch {
+    /* fall through */
+  }
+
+  // 3. literal node name (will fail at ssh if not in ~/.ssh/config, but we
+  //    surface a helpful error message at the helper layer)
+  return node ?? peerUrl;
+}
+
+/**
+ * Resolve a bare name to a Tier 3 match across all peers.
+ *
+ * Returns:
+ *   - `match` (single hit)        — caller proceeds to attach
+ *   - `ambiguous` (multiple hits) — caller stops and lists candidates
+ *   - `null`                       — no peer has a live session matching
+ *
+ * Local sessions are filtered out — local matches belong to Tier 1.
+ */
+export async function resolveRemoteAttachTarget(
+  target: string,
+  deps: RemoteResolveDeps,
+): Promise<
+  | { kind: "match"; match: RemoteMatch }
+  | { kind: "ambiguous"; candidates: RemoteMatch[] }
+  | null
+> {
+  const aggregated = await deps.getAggregatedSessions([]);
+  const named = deps.namedPeers();
+
+  const hits: RemoteMatch[] = [];
+  for (const s of aggregated) {
+    // Tier 3 is peer-only. "local" tag (or absent source) means Tier 1's job.
+    if (!s.source || s.source === "local") continue;
+    if (!nameMatches(s.name, target)) continue;
+    const peerUrl = s.source;
+    const node = s.node ?? safeHost(peerUrl) ?? peerUrl;
+    hits.push({
+      sessionName: s.name,
+      node,
+      peerUrl,
+      sshAlias: resolveSshAlias(peerUrl, s.node, named),
+    });
+  }
+
+  if (hits.length === 0) return null;
+  if (hits.length === 1) return { kind: "match", match: hits[0] };
+  return { kind: "ambiguous", candidates: hits };
+}
+
+function safeHost(url: string): string | undefined {
+  try { return new URL(url).hostname || undefined; } catch { return undefined; }
+}
+
+/**
+ * Explicit `node:agent` syntax — caller specifies the node, we only look up
+ * the agent on THAT peer. Short-circuits past Tier 1/2 per design §6.
+ *
+ * The node may match either the peer's `/api/identity.node` OR the URL host
+ * (so `mba:homekeeper` works whether the federation knows the node as
+ * "mba" or just has `http://mba.wg:9090` configured).
+ */
+export async function resolveExplicitNodeTarget(
+  nodePart: string,
+  agentPart: string,
+  deps: RemoteResolveDeps,
+): Promise<RemoteMatch | null> {
+  const aggregated = await deps.getAggregatedSessions([]);
+  const named = deps.namedPeers();
+  const want = nodePart.toLowerCase();
+
+  for (const s of aggregated) {
+    if (!s.source || s.source === "local") continue;
+    if (!nameMatches(s.name, agentPart)) continue;
+    const host = safeHost(s.source) ?? "";
+    const nodeMatches =
+      (s.node && s.node.toLowerCase() === want) ||
+      host.toLowerCase() === want ||
+      host.toLowerCase().startsWith(`${want}.`);
+    if (!nodeMatches) continue;
+    return {
+      sessionName: s.name,
+      node: s.node ?? host ?? nodePart,
+      peerUrl: s.source,
+      sshAlias: resolveSshAlias(s.source, s.node, named),
+    };
+  }
+  return null;
+}

--- a/plugins/view/impl.ts
+++ b/plugins/view/impl.ts
@@ -1,5 +1,6 @@
 import { listSessions } from "maw-js/sdk";
-import { Tmux, tmuxCmd, resolveSocket } from "maw-js/sdk";
+import { Tmux, resolveSocket } from "maw-js/sdk";
+import { attachRemoteSession } from "maw-js/sdk";
 import { loadConfig } from "maw-js/config";
 import { resolveSessionTarget } from "maw-js/core/matcher/resolve-target";
 import { logAnomaly } from "maw-js/core/fleet/audit";
@@ -348,12 +349,18 @@ async function resolveAnchorPane(anchor: string): Promise<string> {
   return `${viewName}:0`;
 }
 
-// Reject tmux session names that contain anything a remote shell could parse.
-// Tmux itself accepts only a restricted set, and our fleet validators
-// (src/core/fleet/validate.ts) tighten that further — but defense in depth
-// protects the ssh branch, where the remote command is shell-interpreted.
-const SAFE_SESSION_NAME = /^[A-Za-z0-9._-]+$/;
-
+/**
+ * Attach to a local OR remote tmux session, picking transport from `isLocal`.
+ *
+ * For the local path we still call `execFileSync("tmux", …)` directly — the
+ * socket-aware argv has no SSH counterpart and stays in view's purview.
+ *
+ * For the remote path we delegate to `attachRemoteSession` (maw-js/sdk), the
+ * shared helper extracted in #1236 Tier 3 prep. That helper carries the
+ * `SAFE_SESSION_NAME` guard plus the structured `SshAttachError` failure UX,
+ * so view inherits both for free. Behavior is unchanged for view — same
+ * `ssh -tt <host> "tmux attach-session -t '<safe>'"` invocation.
+ */
 function attachViaTmux(opts: {
   isLocal: boolean;
   socket: string | undefined;
@@ -368,9 +375,8 @@ function attachViaTmux(opts: {
     execFileSync("tmux", args, { stdio: "inherit" });
     return;
   }
-  if (!SAFE_SESSION_NAME.test(target)) {
-    throw new Error(`refusing ssh attach: unsafe session name '${target}'`);
-  }
-  const remoteCmd = `${tmuxCmd()} attach-session -t '${target}'`;
-  execFileSync("ssh", ["-tt", host, remoteCmd], { stdio: "inherit" });
+  // Remote — funnel through the shared helper. `host` doubles as both the
+  // logical node label and the SSH alias for view's case (config.host is the
+  // operator's existing alias, e.g. "homekeeper.wg").
+  attachRemoteSession({ node: host, sshAlias: host, sessionName: target });
 }


### PR DESCRIPTION
## Summary

Wires `maw a <remote-oracle>` to the shared SSH-attach helper landing in maw-js. Bare-name auto-locates across local + peer sessions, remote-live match becomes a Tier 3 SSH+tmux attach on the peer that owns the session. Implements [Tier 3 ONLY](https://github.com/Soul-Brews-Studio/maw-js/issues/1236) per the cross-node-attach-design phasing recommendation — Tier 4 (remote wake) deferred.

- `plugins/attach/resolve-remote-target.ts` (NEW) — consults `getAggregatedSessions()` + `namedPeers` for sshAlias resolution (`namedPeers.ssh > URL hostname > node`). Drops local-tagged rows so Tier 1 keeps precedence.
- `plugins/attach/resolve-attach-target.ts` — `ResolveResult` gains a `tier: 3` variant with `{ sessionName, node, peerUrl, sshAlias }`. Cascade is now 1 → 2 → 3. Surfaces `remoteAlternates` on Tier 1 hits so the operator knows the remote also has a same-named session. Adds `--remote-only` and `node:agent` short-circuit paths.
- `plugins/attach/impl.ts` — Tier 3 branch invokes `attachRemoteSession`. `SshAttachError` bubbles as UserError (never `process.exit`). Ambiguous-remote prints a `pin it: node:name` hint.
- `plugins/view/impl.ts` — remote branch of `attachViaTmux` now delegates to the shared `attachRemoteSession` helper. Local branch unchanged. Same on-the-wire behavior (`ssh -tt <host> "tmux attach …"`), now with structured failure classification for free.

## Test plan

- [x] `bun test plugins/attach/` — 34 pass (16 original + 18 new Tier 3 cases)
- [x] Resolver covers: Tier 3 single match, ambiguous across peers, prefer-local + remoteAlternates, `--remote-only`, `node:agent` short-circuit, null fall-through
- [x] Handler covers: happy path / namedPeers.ssh override / dry-run / ssh unreachable / Permission denied / tmux missing / ambiguous remote
- [x] view + attach plugin sources import cleanly

## Companion

Depends on maw-js PR https://github.com/Soul-Brews-Studio/maw-js/pull/1260 — `attachRemoteSession`, `getAggregatedSessions` (now surfacing `node`), `PeerConfig.ssh?` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)