### PR TITLE
feat(peers): list --discovered + accept (#1237, slice 1)

### DIFF
--- a/plugins/peers/discovered.ts
+++ b/plugins/peers/discovered.ts
@@ -1,0 +1,151 @@
+/**
+ * maw peers — discovery client (#1237, slice 1).
+ *
+ * Thin HTTP client over the maw-js daemon's `/api/peers/discoveries` +
+ * `/api/peers/accept` endpoints. CLI-facing — no store mutation here;
+ * the daemon owns the canonical write path (cmdAdd + impersonation
+ * guard). This module just renders responses and surfaces errors.
+ *
+ * Daemon URL: derived from `loadConfig().port` per the same pattern
+ * `plugins/health` uses. Open question #1 from the design: when the
+ * daemon is down we report `daemon_unreachable` — no stale fallback.
+ */
+import { loadConfig } from "maw-js/config";
+
+export interface DiscoveryRow {
+  zid: string;
+  node: string;
+  oracle: string;
+  host: string;
+  locators: string[];
+  capabilities: string[];
+  oracles: string[];
+  firstSeen: string;
+  lastSeen: string;
+  seenRel: string;
+  paired: boolean;
+}
+
+export interface DiscoveryResponse {
+  ok: true;
+  total: number;
+  shown: number;
+  filtered: boolean;
+  peers: DiscoveryRow[];
+}
+
+export interface DiscoveryError {
+  ok: false;
+  /** "daemon_unreachable" — daemon not running. "scout_unavailable" — daemon up but multicast unbound. */
+  error: string;
+  hint?: string;
+  /** HTTP status if the daemon responded but with an error. */
+  status?: number;
+}
+
+function daemonBase(): string {
+  const port = loadConfig().port ?? 3456;
+  return `http://localhost:${port}`;
+}
+
+const TIMEOUT_MS = 5_000;
+
+export async function fetchDiscoveries(opts: { all?: boolean; limit?: number } = {}): Promise<DiscoveryResponse | DiscoveryError> {
+  const qs = new URLSearchParams();
+  if (opts.all) qs.set("all", "1");
+  if (opts.limit) qs.set("limit", String(opts.limit));
+  const url = `${daemonBase()}/api/peers/discoveries${qs.toString() ? "?" + qs : ""}`;
+  let res: Response;
+  try {
+    res = await fetch(url, { signal: AbortSignal.timeout(TIMEOUT_MS) });
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      error: "daemon_unreachable",
+      hint: `${e instanceof Error ? e.message : String(e)} — is \`maw serve\` running?`,
+    };
+  }
+  if (!res.ok) {
+    const body = await safeJson(res);
+    return {
+      ok: false,
+      error: body?.error ?? `http_${res.status}`,
+      hint: body?.hint,
+      status: res.status,
+    };
+  }
+  return (await res.json()) as DiscoveryResponse;
+}
+
+export interface AcceptResponse {
+  ok: true;
+  alias?: string;
+  node?: string;
+  url?: string;
+  accepted?: Array<{ alias?: string; ok: true }>;
+  skipped?: Array<{ id: string; error: string; hint?: string }>;
+  message?: string;
+}
+
+export async function acceptPeer(opts: { id?: string; alias?: string; all?: boolean }): Promise<AcceptResponse | DiscoveryError> {
+  const url = `${daemonBase()}/api/peers/accept`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(opts),
+      signal: AbortSignal.timeout(TIMEOUT_MS),
+    });
+  } catch (e: unknown) {
+    return {
+      ok: false,
+      error: "daemon_unreachable",
+      hint: `${e instanceof Error ? e.message : String(e)} — is \`maw serve\` running?`,
+    };
+  }
+  if (!res.ok) {
+    const body = await safeJson(res);
+    return {
+      ok: false,
+      error: body?.error ?? `http_${res.status}`,
+      hint: body?.hint,
+      status: res.status,
+      ...(body?.candidates ? { candidates: body.candidates } : {}),
+    } as DiscoveryError;
+  }
+  return (await res.json()) as AcceptResponse;
+}
+
+async function safeJson(res: Response): Promise<any> {
+  try { return await res.json(); } catch { return null; }
+}
+
+/**
+ * Render a discoveries response as a fixed-width table matching decision #5
+ * of the design: `zid | node | oracle | host | seen | paired | caps`.
+ */
+export function formatDiscoveries(resp: DiscoveryResponse): string {
+  if (resp.peers.length === 0) {
+    return resp.filtered
+      ? "no unpaired discoveries (pass --all to include already-paired)"
+      : "no discoveries";
+  }
+  const header = ["zid", "node", "oracle", "host", "seen", "paired", "caps"];
+  const rows = resp.peers.map(p => [
+    p.zid.slice(0, 8) + "…",
+    p.node ?? "-",
+    p.oracle ?? "-",
+    p.host,
+    p.seenRel,
+    p.paired ? "✓" : "-",
+    p.capabilities.join(",") || "-",
+  ]);
+  const widths = header.map((h, i) => Math.max(h.length, ...rows.map(r => r[i].length)));
+  const fmt = (cols: string[]) => cols.map((c, i) => c.padEnd(widths[i])).join("  ");
+  const lines = [fmt(header), fmt(widths.map(w => "-".repeat(w))), ...rows.map(fmt)];
+  if (resp.total > resp.shown) {
+    lines.push("", `(${resp.shown}/${resp.total} shown — pass --limit N to widen)`);
+  }
+  return lines.join("\n");
+}

--- a/plugins/peers/index.ts
+++ b/plugins/peers/index.ts
@@ -34,16 +34,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
   const out = () => logs.join("\n");
   const help = () => [
-    "usage: maw peers <add|list|info|probe|probe-all|remove|forget> [...]",
+    "usage: maw peers <add|list|info|probe|probe-all|accept|remove|forget> [...]",
     "  add       <alias> <url> [--node <name>] [--allow-unreachable]",
     "            — register alias (auto-probes /info). Exits non-zero on handshake failure:",
     "              2=UNKNOWN/BAD_BODY/TLS  3=DNS  4=REFUSED  5=TIMEOUT  6=HTTP_4XX/5XX",
     "            --allow-unreachable keeps exit 0 even when the probe fails (CI/bootstrap).",
-    "  list                                      — tabular list of all peers",
+    "  list      [--discovered] [--all] [--json] [--limit N]",
+    "            — tabular list of all peers. --discovered: LAN candidates from Scout (#1237).",
+    "              --all: include already-paired (default hides). --limit: cap rows (default 50).",
     "  info      <alias>                         — JSON details for one peer (includes lastError if set)",
     "  probe     <alias>                         — re-run /info handshake; updates lastSeen / lastError (#565)",
     "  probe-all [--timeout <ms>] [--allow-unreachable]",
     "            — probe every peer in parallel; prints liveness table. Exit = worst PROBE_EXIT_CODE (#669).",
+    "  accept    <node|zid-prefix> [--alias X] | --all (#1237)",
+    "            — pair with a Scout-discovered peer. Shortest unambiguous prefix wins.",
+    "              Refuses if pubkey already pins under a different alias (impersonation guard).",
     "  remove    <alias>                         — remove (idempotent)",
     "  forget    <alias>                         — clear cached pubkey so next contact re-TOFUs (#804 Step 2)",
     "",
@@ -151,7 +156,78 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       }
       case "list":
       case "ls": {
+        // #1237 — `--discovered` swaps the data source from peers.json
+        // (paired aliases) to the daemon's in-memory Scout snapshot
+        // (LAN candidates). Renderers differ; everything else flows
+        // through the same dispatcher.
+        if (args.includes("--discovered")) {
+          const all = args.includes("--all");
+          const json = args.includes("--json");
+          const limitIdx = args.indexOf("--limit");
+          let limit: number | undefined;
+          if (limitIdx >= 0) {
+            const parsed = Number(args[limitIdx + 1]);
+            if (!Number.isFinite(parsed) || parsed <= 0) {
+              return { ok: false, error: `usage: maw peers list --discovered [--all] [--json] [--limit N] (got --limit ${args[limitIdx + 1] ?? ""})` };
+            }
+            limit = parsed;
+          }
+          const { fetchDiscoveries, formatDiscoveries } = await import("./discovered");
+          const resp = await fetchDiscoveries({ all, limit });
+          if (!resp.ok) {
+            console.error(`\x1b[31m✗\x1b[0m ${resp.error}${resp.hint ? ` — ${resp.hint}` : ""}`);
+            return { ok: false, output: out(), error: resp.error };
+          }
+          if (json) {
+            console.log(JSON.stringify(resp, null, 2));
+          } else {
+            console.log(formatDiscoveries(resp));
+          }
+          return { ok: true, output: out() };
+        }
         console.log(impl.formatList(impl.cmdList()));
+        return { ok: true, output: out() };
+      }
+      case "accept": {
+        // #1237 — accept a Scout-discovered peer via the daemon's accept
+        // endpoint. CLI is pure dispatcher: validation + impersonation
+        // guard happen daemon-side so behaviour is consistent regardless
+        // of caller (CLI / UI / cron / federation peer).
+        const { acceptPeer } = await import("./discovered");
+        const aliasIdx = args.indexOf("--alias");
+        const alias = aliasIdx >= 0 ? args[aliasIdx + 1] : undefined;
+        const all = args.includes("--all");
+        if (!all) {
+          const id = positional[1];
+          if (!id) return { ok: false, error: "usage: maw peers accept <node|zid-prefix> [--alias X] | --all" };
+          const r = await acceptPeer({ id, alias });
+          if (!r.ok) {
+            console.error(`\x1b[31m✗\x1b[0m ${r.error}${r.hint ? ` — ${r.hint}` : ""}`);
+            const anyR = r as any;
+            if (Array.isArray(anyR.candidates)) {
+              console.error("  candidates:");
+              for (const c of anyR.candidates) {
+                console.error(`    ${c.zid.slice(0, 12)}… ${c.node} (${c.host})`);
+              }
+            }
+            return { ok: false, output: out(), error: r.error };
+          }
+          console.log(`\x1b[32m✓\x1b[0m accepted ${r.alias}${r.node && r.node !== r.alias ? ` (${r.node})` : ""}${r.url ? ` → ${r.url}` : ""}`);
+          return { ok: true, output: out() };
+        }
+        const r = await acceptPeer({ all: true });
+        if (!r.ok) {
+          console.error(`\x1b[31m✗\x1b[0m ${r.error}${r.hint ? ` — ${r.hint}` : ""}`);
+          return { ok: false, output: out(), error: r.error };
+        }
+        const accepted = r.accepted ?? [];
+        const skipped = r.skipped ?? [];
+        if (accepted.length === 0 && skipped.length === 0) {
+          console.log(r.message ?? "no unpaired discoveries");
+        } else {
+          for (const a of accepted) console.log(`\x1b[32m✓\x1b[0m accepted ${a.alias}`);
+          for (const s of skipped) console.error(`\x1b[33m⚠\x1b[0m skipped ${s.id}: ${s.error}${s.hint ? ` — ${s.hint}` : ""}`);
+        }
         return { ok: true, output: out() };
       }
       case "info": {
@@ -190,7 +266,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         console.log(help());
         return {
           ok: false,
-          error: `maw peers: unknown subcommand "${sub}" (expected add|list|info|probe|probe-all|remove|forget)`,
+          error: `maw peers: unknown subcommand "${sub}" (expected add|list|info|probe|probe-all|accept|remove|forget)`,
           output: out() || help(),
         };
       }

--- a/plugins/peers/peers-discovered.test.ts
+++ b/plugins/peers/peers-discovered.test.ts
@@ -1,0 +1,293 @@
+/**
+ * maw peers list --discovered + accept (#1237, slice 1) — CLI tests.
+ *
+ * The data layer lives in maw-js (`/api/peers/discoveries` + `/api/peers/accept`)
+ * — these tests stub fetch() so we exercise the CLI dispatcher in isolation:
+ *   - argument parsing (--all, --limit, --alias, --json, --discovered, --all)
+ *   - render of fixed-width table from a mocked response
+ *   - error surfacing (daemon down, ambiguous prefix, impersonation guard)
+ *
+ * The on-disk store is not touched (writes happen daemon-side).
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+mock.module("maw-js/config", () => ({
+  loadConfig: () => ({ port: 3456 }),
+}));
+
+let lastRequest: { url: string; init?: RequestInit } | null = null;
+let nextResponse: { status: number; body: any } = { status: 200, body: {} };
+const ORIGINAL_FETCH = globalThis.fetch;
+
+beforeEach(() => {
+  lastRequest = null;
+  nextResponse = { status: 200, body: {} };
+  // Mock global fetch — every test sets `nextResponse` to drive behavior.
+  // We can't use Bun's mock.module for `fetch` (it's a global), so reassign.
+  // @ts-expect-error — overwrite global
+  globalThis.fetch = async (url: string, init?: RequestInit) => {
+    lastRequest = { url: String(url), init };
+    return new Response(JSON.stringify(nextResponse.body), {
+      status: nextResponse.status,
+      headers: { "content-type": "application/json" },
+    });
+  };
+});
+
+afterEach(() => {
+  // Restore — otherwise our mock leaks into peers.test.ts / peers-probe.test.ts
+  // and causes their network-dependent tests to time out.
+  globalThis.fetch = ORIGINAL_FETCH;
+});
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "maw-peers-discov-"));
+  process.env.PEERS_FILE = join(dir, "peers.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+});
+
+// ─── discovered.ts unit tests ─────────────────────────────────────────────
+
+describe("discovered.ts — HTTP client", () => {
+  it("fetchDiscoveries → calls GET /api/peers/discoveries on configured port", async () => {
+    nextResponse = { status: 200, body: { ok: true, total: 0, shown: 0, filtered: true, peers: [] } };
+    const { fetchDiscoveries } = await import("./discovered");
+    const r = await fetchDiscoveries({});
+    expect(r.ok).toBe(true);
+    expect(lastRequest?.url).toBe("http://localhost:3456/api/peers/discoveries");
+  });
+
+  it("fetchDiscoveries → forwards --all and --limit as query params", async () => {
+    nextResponse = { status: 200, body: { ok: true, total: 0, shown: 0, filtered: false, peers: [] } };
+    const { fetchDiscoveries } = await import("./discovered");
+    await fetchDiscoveries({ all: true, limit: 25 });
+    expect(lastRequest?.url).toContain("all=1");
+    expect(lastRequest?.url).toContain("limit=25");
+  });
+
+  it("fetchDiscoveries → returns daemon_unreachable when fetch throws", async () => {
+    // @ts-expect-error
+    globalThis.fetch = async () => { throw new Error("ECONNREFUSED 127.0.0.1:3456"); };
+    const { fetchDiscoveries } = await import("./discovered");
+    const r = await fetchDiscoveries({});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe("daemon_unreachable");
+      expect(r.hint).toContain("maw serve");
+    }
+  });
+
+  it("fetchDiscoveries → surfaces daemon-side error body when status >= 400", async () => {
+    nextResponse = { status: 503, body: { ok: false, error: "scout_unavailable", hint: "rebind multicast" } };
+    const { fetchDiscoveries } = await import("./discovered");
+    const r = await fetchDiscoveries({});
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBe("scout_unavailable");
+      expect(r.status).toBe(503);
+    }
+  });
+
+  it("acceptPeer → POSTs id+alias as JSON body", async () => {
+    nextResponse = { status: 200, body: { ok: true, alias: "mba", node: "mba", url: "http://1.2.3.4:3456" } };
+    const { acceptPeer } = await import("./discovered");
+    const r = await acceptPeer({ id: "mba", alias: "snow" });
+    expect(r.ok).toBe(true);
+    expect(lastRequest?.init?.method).toBe("POST");
+    expect(JSON.parse(String(lastRequest?.init?.body))).toEqual({ id: "mba", alias: "snow" });
+  });
+
+  it("formatDiscoveries → renders a table with the design's columns", async () => {
+    const { formatDiscoveries } = await import("./discovered");
+    const out = formatDiscoveries({
+      ok: true,
+      total: 1,
+      shown: 1,
+      filtered: true,
+      peers: [{
+        zid: "abcdef1234567890" + "0".repeat(16),
+        node: "mba",
+        oracle: "neo",
+        host: "192.168.1.5",
+        locators: ["http://192.168.1.5:3456"],
+        capabilities: ["pair", "feed"],
+        oracles: [],
+        firstSeen: new Date().toISOString(),
+        lastSeen: new Date().toISOString(),
+        seenRel: "2s ago",
+        paired: false,
+      }],
+    });
+    for (const col of ["zid", "node", "oracle", "host", "seen", "paired", "caps"]) {
+      expect(out).toContain(col);
+    }
+    expect(out).toContain("abcdef12");
+    expect(out).toContain("mba");
+    expect(out).toContain("2s ago");
+    expect(out).toContain("pair,feed");
+  });
+
+  it("formatDiscoveries → empty filtered set renders helpful hint", async () => {
+    const { formatDiscoveries } = await import("./discovered");
+    const out = formatDiscoveries({ ok: true, total: 0, shown: 0, filtered: true, peers: [] });
+    expect(out).toContain("--all");
+  });
+});
+
+// ─── Dispatcher integration ───────────────────────────────────────────────
+
+describe("dispatcher — list --discovered (#1237)", () => {
+  it("list --discovered → fetches from daemon and renders table", async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        ok: true, total: 1, shown: 1, filtered: true,
+        peers: [{
+          zid: "aa".repeat(16), node: "mba", oracle: "neo", host: "10.0.0.5",
+          locators: ["http://10.0.0.5:3456"], capabilities: ["pair"], oracles: [],
+          firstSeen: new Date().toISOString(), lastSeen: new Date().toISOString(),
+          seenRel: "1s ago", paired: false,
+        }],
+      },
+    };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["list", "--discovered"] });
+    expect(r.ok).toBe(true);
+    expect(r.output).toContain("mba");
+    expect(r.output).toContain("10.0.0.5");
+    expect(lastRequest?.url).toContain("/api/peers/discoveries");
+  });
+
+  it("list --discovered --all --limit 25 → passes both query params through", async () => {
+    nextResponse = { status: 200, body: { ok: true, total: 0, shown: 0, filtered: false, peers: [] } };
+    const { default: handler } = await import("./index");
+    await handler({ source: "cli", args: ["list", "--discovered", "--all", "--limit", "25"] });
+    expect(lastRequest?.url).toContain("all=1");
+    expect(lastRequest?.url).toContain("limit=25");
+  });
+
+  it("list --discovered --json → emits JSON not table", async () => {
+    nextResponse = { status: 200, body: { ok: true, total: 0, shown: 0, filtered: true, peers: [] } };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["list", "--discovered", "--json"] });
+    expect(r.ok).toBe(true);
+    expect(r.output).toContain('"peers"');
+  });
+
+  it("list --discovered surfaces daemon_unreachable (open question #1: hard error)", async () => {
+    // @ts-expect-error
+    globalThis.fetch = async () => { throw new Error("ECONNREFUSED 127.0.0.1:3456"); };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["list", "--discovered"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_unreachable");
+  });
+});
+
+describe("dispatcher — accept (#1237)", () => {
+  it("accept <node> → POSTs to daemon and reports success", async () => {
+    nextResponse = { status: 200, body: { ok: true, alias: "mba", node: "mba", url: "http://10.0.0.5:3456" } };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "mba"] });
+    expect(r.ok).toBe(true);
+    expect(r.output).toMatch(/accepted mba/);
+    expect(JSON.parse(String(lastRequest?.init?.body))).toEqual({ id: "mba", alias: undefined });
+  });
+
+  it("accept <prefix> --alias snow → forwards alias override", async () => {
+    nextResponse = { status: 200, body: { ok: true, alias: "snow", node: "mba", url: "http://10.0.0.5:3456" } };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "ab12", "--alias", "snow"] });
+    expect(r.ok).toBe(true);
+    expect(JSON.parse(String(lastRequest?.init?.body))).toEqual({ id: "ab12", alias: "snow" });
+    expect(r.output).toMatch(/accepted snow/);
+  });
+
+  it("accept --all → POSTs { all: true } and renders accepted + skipped", async () => {
+    nextResponse = {
+      status: 200,
+      body: {
+        ok: true,
+        accepted: [{ ok: true, alias: "n1" }, { ok: true, alias: "n2" }],
+        skipped: [{ id: "zid-ghost", ok: false, error: "impersonation_guard", hint: "alias collides" }],
+      },
+    };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "--all"] });
+    expect(r.ok).toBe(true);
+    expect(JSON.parse(String(lastRequest?.init?.body))).toEqual({ all: true });
+    expect(r.output).toContain("accepted n1");
+    expect(r.output).toContain("accepted n2");
+    expect(r.output).toContain("impersonation_guard");
+  });
+
+  it("accept missing args → usage error", async () => {
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("usage:");
+  });
+
+  it("accept ambiguous prefix → surfaces candidate list (decision #3)", async () => {
+    nextResponse = {
+      status: 409,
+      body: {
+        ok: false,
+        error: "ambiguous",
+        candidates: [
+          { zid: "ab" + "1".repeat(30), node: "a1", host: "10.0.0.1" },
+          { zid: "ab" + "2".repeat(30), node: "a2", host: "10.0.0.2" },
+        ],
+        hint: "Disambiguate.",
+      },
+    };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "ab"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("ambiguous");
+    expect(r.output).toContain("a1");
+    expect(r.output).toContain("a2");
+  });
+
+  it("accept refused by impersonation_guard → fails loudly, no rewrite", async () => {
+    nextResponse = {
+      status: 409,
+      body: {
+        ok: false, error: "impersonation_guard",
+        hint: "pubkey already pins under alias \"ghost\".",
+      },
+    };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "evil", "--alias", "twin"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("impersonation_guard");
+    expect(r.output).toContain("ghost");
+  });
+
+  it("accept surfaces daemon_unreachable when daemon is down", async () => {
+    // @ts-expect-error
+    globalThis.fetch = async () => { throw new Error("ECONNREFUSED 127.0.0.1:3456"); };
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: ["accept", "mba"] });
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe("daemon_unreachable");
+  });
+});
+
+describe("help text (#1237)", () => {
+  it("help mentions accept + list --discovered", async () => {
+    const { default: handler } = await import("./index");
+    const r = await handler({ source: "cli", args: [] });
+    expect(r.ok).toBe(true);
+    expect(r.output).toMatch(/list\s+\[--discovered\]/);
+    expect(r.output).toMatch(/accept\s+<node\|zid-prefix>/);
+    expect(r.output).toContain("impersonation guard");
+  });
+});


### PR DESCRIPTION
## Summary

CLI slice for opt-in peer pairing per the design at \`ψ/learn/peers-discovered-design.md\`. Pairs with maw-js PR #1261 (already merged) which adds the daemon-side scout exposure + \`/api/peers/discoveries\` + \`/api/peers/accept\` endpoints.

## Adds

- **\`maw peers list --discovered [--all] [--json] [--limit N]\`** — lists peers seen via Scout multicast Hello packets, not yet paired. Sort by lastSeen desc. Default hides already-paired; \`--all\` shows them.
- **\`maw peers accept <node|zid-prefix> [--alias X]\`** (+ \`--all\` for bulk) — promotes a discovered candidate to an entry. Daemon-side enforces the impersonation guard (decision #4): refuses if candidate pubkey already pins under a different alias.

## Implementation

- \`plugins/peers/discovered.ts\` (NEW, 151 LOC) — thin HTTP client over the maw-js endpoints. No store mutation here; daemon owns the canonical write path.
- \`plugins/peers/index.ts\` (+82/-3) — wires \`--discovered\` + \`accept\` subcommands into dispatcher.
- \`plugins/peers/peers-discovered.test.ts\` (NEW, 293 LOC) — 19 CLI tests covering arg parsing, table render, error surfacing, daemon-down, impersonation refusal.

## Deferred

- Auto-pair flag (decision #6) — punted per design's \"ship list+accept first\" recommendation. Follow-up needed for \`maw peers auto-pair on|off|status\` + \`peers.autoAccept\` config field.

## Provenance

Continues partial work from the feat-1237 agent (team \`fix-it\`) which died mid-session on the plugin-registry side. The maw-js scaffolding shipped via #1261; this PR recovers the agent's surviving 524 lines from the worktree, runs the tests (19/19 pass), and ships the slice.

## Test plan

- [x] \`MAW_TEST_MODE=1 bun test plugins/peers/peers-discovered.test.ts\` — 19/19 pass
- [ ] Manual smoke: \`maw peers list --discovered\` (requires running \`maw serve\` with scout transport bound)

## Related

- Design: \`/opt/Code/github.com/Soul-Brews-Studio/mawjs-oracle/ψ/learn/peers-discovered-design.md\`
- Daemon-side: maw-js PR #1261 (merged)

Closes #1237 (slice 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)