### PR TITLE
fix(#4): finish source-format migration — federation + swarm stragglers + CI guard

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,13 +4,17 @@ on:
   pull_request:
     paths:
       - "registry.json"
+      - "plugins/**/registry.meta.json"
       - "schema/**"
+      - "scripts/migrate-source-format.ts"
       - ".github/workflows/validate.yml"
   push:
     branches: [main]
     paths:
       - "registry.json"
+      - "plugins/**/registry.meta.json"
       - "schema/**"
+      - "scripts/migrate-source-format.ts"
       - ".github/workflows/validate.yml"
 
 jobs:
@@ -41,3 +45,13 @@ jobs:
           node -e "JSON.parse(require('fs').readFileSync('registry.json','utf8'))"
           node -e "JSON.parse(require('fs').readFileSync('schema/registry.json','utf8'))"
           node -e "JSON.parse(require('fs').readFileSync('schema/plugin.json','utf8'))"
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Source-format guard (migrate-source-format --check)
+        run: bun scripts/migrate-source-format.ts --check
+
+      - name: Source-format self-test
+        run: bun scripts/migrate-source-format.ts --self-test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,10 +86,13 @@ The `source` field is a bare github-style locator: `owner/repo[/subpath][@ref]`.
 "source": "soul-brews-studio/maw-plugin-registry/bg@v0.1.2-bg"
 ```
 
-The legacy `github:owner/repo#ref` form is being phased out — see
-[`scripts/migrate-source-format.ts`](./scripts/migrate-source-format.ts). Once
-the github: resolver in maw-js ships (maw-js#939), that script will rewrite all
-existing `monorepo:plugins/<name>@<tag>` entries to the bare form above.
+The migration from `monorepo:plugins/<name>@<tag>` to the bare
+`owner/repo/<name>@<tag>` form has shipped — all 72 entries now use the bare
+github form (see PR #6 + the federation/swarm finisher). The legacy
+`github:owner/repo#ref` form remains accepted for third-party entries but is
+being phased out. CI enforces this via
+[`scripts/migrate-source-format.ts --check`](./scripts/migrate-source-format.ts),
+which fails on any unknown source shape.
 
 ### Optional fields
 

--- a/plugins/federation/registry.meta.json
+++ b/plugins/federation/registry.meta.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "source": "monorepo:plugins/federation@v1.0.0-federation",
+  "source": "soul-brews-studio/maw-plugin-registry/federation@v1.0.0-federation",
   "sha256": "5ac5e61d13aa3862d357eaf0d687f8988cb836994164fd24a484489bfc7a5f9f",
   "summary": "Multi-node federation status and sync \u2014 peer reachability, identity, symmetric verify.",
   "author": "Soul-Brews-Studio",

--- a/plugins/swarm/registry.meta.json
+++ b/plugins/swarm/registry.meta.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "source": "monorepo:plugins/swarm@v1.0.0-swarm",
+  "source": "soul-brews-studio/maw-plugin-registry/swarm@v1.0.0-swarm",
   "sha256": "4bbe45a067be8c17accca049a0e5ee509a9e97342a6615b58403794b8989d18d",
   "summary": "Spawn multi-AI agent panes \u2014 claude, codex, opencode, aider side by side in colored tmux.",
   "author": "Soul-Brews-Studio",

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-01T21:12:35Z",
+  "updated": "2026-05-12T20:38:02Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -212,7 +212,7 @@
     },
     "federation": {
       "version": "1.0.0",
-      "source": "monorepo:plugins/federation@v1.0.0-federation",
+      "source": "soul-brews-studio/maw-plugin-registry/federation@v1.0.0-federation",
       "sha256": "5ac5e61d13aa3862d357eaf0d687f8988cb836994164fd24a484489bfc7a5f9f",
       "summary": "Multi-node federation status and sync \u2014 peer reachability, identity, symmetric verify.",
       "author": "Soul-Brews-Studio",
@@ -627,7 +627,7 @@
     },
     "swarm": {
       "version": "1.0.0",
-      "source": "monorepo:plugins/swarm@v1.0.0-swarm",
+      "source": "soul-brews-studio/maw-plugin-registry/swarm@v1.0.0-swarm",
       "sha256": "4bbe45a067be8c17accca049a0e5ee509a9e97342a6615b58403794b8989d18d",
       "summary": "Spawn multi-AI agent panes \u2014 claude, codex, opencode, aider side by side in colored tmux.",
       "author": "Soul-Brews-Studio",


### PR DESCRIPTION
Closes the source-format migration started in #6 / 7541be6.

## Summary

- **Stragglers**: `federation` and `swarm` were the last 2 of 72 plugins still on the legacy `monorepo:plugins/<name>@<tag>` shape. Both meta files now use the bare `soul-brews-studio/maw-plugin-registry/<name>@<tag>` form, and `registry.json` has been regenerated via `python3 scripts/build-registry.py`.
- **CI guard**: `.github/workflows/validate.yml` now runs `bun scripts/migrate-source-format.ts --check` and `--self-test` after schema validation. The ajv step runs with `--strict=false`, so unknown source shapes were at risk of silent-failing — the new step fails loud on any non-`monorepo:*` / non-bare-github form.
- **Docs**: `CONTRIBUTING.md` flipped from "once the github: resolver ships, the script will rewrite…" to past-tense: migration has shipped, CI now enforces it.

## Verification

```
$ python3 scripts/build-registry.py
✓ registry.json built — 72 plugins

$ bun scripts/migrate-source-format.ts --check
[check] ok — 72 plugins

$ bun scripts/migrate-source-format.ts --self-test
self-test: ok
```

`grep monorepo: registry.json` is now empty.

## Commits

1. `fix(#4)` — federation + swarm meta files + regenerated registry.json
2. `ci(#4)` — guard step + self-test in validate.yml, broader trigger paths
3. `docs(#4)` — CONTRIBUTING.md migration note

## Test plan

- [x] `python3 scripts/build-registry.py` produces 72-plugin registry
- [x] `bun scripts/migrate-source-format.ts --check` passes
- [x] `bun scripts/migrate-source-format.ts --self-test` passes
- [ ] CI runs new `Source-format guard` + `Source-format self-test` steps on this PR
- [ ] ajv schema validation continues to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)