### PR TITLE
feat(#1): bootstrap PR validator workflow + script (cheap steps only)

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -1,0 +1,99 @@
+# Deep validation for plugin-registry PRs.
+#
+# Complements .github/workflows/validate.yml (fast JSONSchema check on
+# registry.json) with per-plugin checks: regenerate-and-clean, plugin manifest
+# schema, SPDX license allowlist, and source-format regex.
+#
+# Network-dependent checks (gh repo view, gh release view, tarball sha256) are
+# deferred to a follow-up — see issue #1 defense-in-depth.
+
+name: validate-pr
+
+on:
+  pull_request:
+    paths:
+      - "registry.json"
+      - "plugins/**"
+      - "schema/**"
+      - "scripts/validate-registry.ts"
+      - ".github/workflows/validate-pr.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deep-validate:
+    name: deep validate PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: setup-bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: detect changed plugins
+        id: changed
+        run: bun scripts/validate-registry.ts --emit-changed --base "${{ github.event.pull_request.base.sha }}"
+
+      - name: regenerate registry & clean-check
+        id: regen
+        run: |
+          python3 scripts/build-registry.py
+          # Any drift means contributor forgot to run the build script.
+          # Ignore the regenerated `updated` timestamp (always changes per run).
+          git diff --exit-code -I '"updated":' registry.json
+
+      - name: validate plugin manifests
+        id: plugin_json
+        if: steps.changed.outputs.plugins != ''
+        run: bun scripts/validate-registry.ts --step plugin-json --plugins "${{ steps.changed.outputs.plugins }}"
+
+      - name: validate licenses
+        id: license
+        if: steps.changed.outputs.plugins != ''
+        run: bun scripts/validate-registry.ts --step license --plugins "${{ steps.changed.outputs.plugins }}"
+
+      - name: validate source format
+        id: source_format
+        # Pass --plugins so we hard-fail on `monorepo:` only for plugins
+        # touched by this PR. Legacy entries are warning-only during scan-all
+        # (migration in progress via scripts/migrate-source-format.ts).
+        run: bun scripts/validate-registry.ts --step source-format --plugins "${{ steps.changed.outputs.plugins }}"
+
+      - name: comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = '.tmp-validate-failure.md';
+            let body;
+            if (fs.existsSync(path)) {
+              body = fs.readFileSync(path, 'utf8');
+            } else {
+              body = [
+                "### ❌ PR validation failed",
+                "",
+                "One of the deep-validation checks failed but didn't write a structured failure report.",
+                "Open the failed job's logs above for details, then see",
+                "[CONTRIBUTING.md → Validation Checks](../blob/main/CONTRIBUTING.md#validation-checks)",
+                "for the recovery commands.",
+              ].join("\n");
+            }
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules/
 .wrangler/
 .env
 .env.*
+# transient PR-failure report written by scripts/validate-registry.ts
+.tmp-validate-failure.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,48 @@ which fails on any unknown source shape.
 
 ## What CI checks
 
-Every PR runs a JSONSchema validation against
-[`schema/registry.json`](./schema/registry.json). Keep your entry valid and the
-check turns green.
+Two workflows run on every PR:
+
+### Validation Checks
+
+**Fast checks** ([`.github/workflows/validate.yml`](./.github/workflows/validate.yml))
+— always run, seconds to complete:
+
+| check | what it does |
+|-------|--------------|
+| JSONSchema validate | `registry.json` validates against [`schema/registry.json`](./schema/registry.json) |
+| source-format guard | `bun scripts/migrate-source-format.ts --check` — rejects any unknown source shape |
+| source-format self-test | `bun scripts/migrate-source-format.ts --self-test` |
+
+**Deep PR checks** ([`.github/workflows/validate-pr.yml`](./.github/workflows/validate-pr.yml))
+— run when `registry.json`, `plugins/**`, or `schema/**` change:
+
+| step | what it does |
+|------|--------------|
+| detect changed plugins | scopes downstream checks to plugins touched by your PR |
+| regenerate-and-clean | runs `python3 scripts/build-registry.py` and asserts no `registry.json` drift — catches "forgot to run the build script" |
+| plugin-json | per-plugin JSONSchema validation of `plugins/<name>/plugin.json` against [`schema/plugin.json`](./schema/plugin.json) |
+| license | each touched plugin's `license` field must be one of: `MIT`, `Apache-2.0`, `BUSL-1.1`, `ISC`, `BSD-2-Clause`, `BSD-3-Clause` |
+| source-format | each touched plugin's `source` field matches the schema regex; legacy `monorepo:` prefix is rejected with a recovery hint |
+
+When a deep check fails, the workflow posts a comment on your PR with the
+expected/actual values and the exact recovery commands.
+
+**Deferred to a follow-up PR** (network-dependent, slow): `gh repo view` to
+prove the source repo exists, `gh release view` to prove the pinned ref is a
+GitHub release tag, and `sha256` verification of the resolved tarball. Tracked
+under defense-in-depth in issue #1.
+
+### Run the deep checks locally
+
+```bash
+# scan all plugins, warning-only on legacy entries
+bun scripts/validate-registry.ts --step source-format
+
+# scope to specific plugins (PR-equivalent — hard-fails on legacy)
+bun scripts/validate-registry.ts --step license --plugins my-plugin
+bun scripts/validate-registry.ts --step plugin-json --plugins my-plugin
+```
 
 ## Plugin side
 

--- a/scripts/validate-registry.ts
+++ b/scripts/validate-registry.ts
@@ -1,0 +1,309 @@
+#!/usr/bin/env bun
+/**
+ * Deep PR validator for the maw plugin registry.
+ *
+ * Bun stdlib only — no new npm deps. Pairs with .github/workflows/validate-pr.yml.
+ *
+ * Steps (cheap subset — network checks deferred to follow-up):
+ *   --emit-changed                  Detect changed plugins between base..HEAD
+ *                                   Writes `plugins=...` to $GITHUB_OUTPUT.
+ *   --step plugin-json              JSONSchema-validate each plugin's plugin.json
+ *                                   (or registry.meta.json) against schema/.
+ *   --step license                  Check each changed plugin's license against
+ *                                   the SPDX allowlist.
+ *   --step source-format            Regex-check every registry.meta.json source
+ *                                   field against schema/registry.json pattern.
+ *                                   Reject `monorepo:` prefix explicitly with a
+ *                                   friendly recovery hint.
+ *
+ * On any failure we also write a markdown report to `.tmp-validate-failure.md`
+ * which the GH Actions step uploads as a PR comment.
+ */
+
+import { $ } from "bun";
+import { existsSync } from "node:fs";
+import { readFile, writeFile, appendFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const PLUGINS_DIR = join(ROOT, "plugins");
+const SCHEMA_DIR = join(ROOT, "schema");
+
+const SPDX_ALLOWLIST = new Set([
+  "MIT",
+  "Apache-2.0",
+  "BUSL-1.1",
+  "ISC",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+]);
+
+// Mirrors schema/registry.json `$defs.entry.properties.source.pattern` (line ~60).
+// Keep in sync with the schema by hand — single source of truth lives in the schema.
+const SOURCE_FORMAT_RE =
+  /^[a-z0-9][a-z0-9-]*\/[a-z0-9][a-z0-9._-]*(\/[a-z0-9][a-z0-9._-]*)*(@[a-zA-Z0-9._-]+)?$/;
+
+type Failure = { step: string; plugin?: string; expected: string; actual: string; recovery: string };
+
+// ─── arg parsing ────────────────────────────────────────────────────────────
+
+function getFlag(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 ? process.argv[i + 1] : undefined;
+}
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+// ─── step: emit-changed ─────────────────────────────────────────────────────
+
+async function emitChanged(baseRef?: string): Promise<void> {
+  // `--base` lets the workflow pass the PR's base SHA. Local fallback is `main`.
+  const base = baseRef ?? process.env.GITHUB_BASE_REF ?? "main";
+  let diff: string;
+  try {
+    diff = (await $`git diff --name-only ${base}...HEAD`.text()).trim();
+  } catch {
+    // Local fallback when base isn't fetched (e.g. shallow checkout, no main locally).
+    diff = (await $`git diff --name-only HEAD`.text()).trim();
+  }
+  const lines = diff.split("\n").filter(Boolean);
+  const pluginSet = new Set<string>();
+  for (const f of lines) {
+    const m = f.match(/^plugins\/([^/]+)\//);
+    if (m) pluginSet.add(m[1]);
+  }
+  const plugins = [...pluginSet].sort();
+  const out = plugins.join(",");
+  console.log(`changed plugins: ${plugins.length === 0 ? "(none)" : out}`);
+  if (process.env.GITHUB_OUTPUT) {
+    await appendFile(process.env.GITHUB_OUTPUT, `plugins=${out}\n`);
+  }
+}
+
+// ─── step: plugin-json ──────────────────────────────────────────────────────
+
+async function validatePluginJson(plugins: string[]): Promise<Failure[]> {
+  const fails: Failure[] = [];
+  const pluginSchemaPath = join(SCHEMA_DIR, "plugin.json");
+  const hasPluginSchema = existsSync(pluginSchemaPath);
+  if (!hasPluginSchema) {
+    console.warn(
+      `⚠️  schema/plugin.json not found — skipping plugin-json validation (warning only).`,
+    );
+    return fails;
+  }
+  // Use ajv-cli via npx; matches what the fast workflow already does.
+  // Each plugin should have a plugin.json (preferred) or registry.meta.json.
+  for (const name of plugins) {
+    const dir = join(PLUGINS_DIR, name);
+    if (!existsSync(dir)) {
+      // Deletion — not our problem for this step.
+      continue;
+    }
+    const pluginJson = join(dir, "plugin.json");
+    if (!existsSync(pluginJson)) {
+      console.log(`· ${name}: no plugin.json — skipping (registry.meta.json checked elsewhere)`);
+      continue;
+    }
+    const proc = Bun.spawnSync({
+      cmd: [
+        "bunx",
+        "ajv-cli@5",
+        "validate",
+        "--spec=draft2020",
+        "-c",
+        "ajv-formats",
+        "-s",
+        pluginSchemaPath,
+        "-d",
+        pluginJson,
+        "--strict=false",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    if (proc.exitCode !== 0) {
+      const stderr = new TextDecoder().decode(proc.stderr);
+      const stdout = new TextDecoder().decode(proc.stdout);
+      fails.push({
+        step: "plugin-json",
+        plugin: name,
+        expected: "plugin.json valid against schema/plugin.json",
+        actual: (stdout + stderr).trim().slice(0, 600),
+        recovery: `Fix plugins/${name}/plugin.json. Validate locally:\n  bunx ajv-cli@5 validate --spec=draft2020 -c ajv-formats -s schema/plugin.json -d plugins/${name}/plugin.json --strict=false`,
+      });
+    } else {
+      console.log(`✓ ${name}: plugin.json valid`);
+    }
+  }
+  return fails;
+}
+
+// ─── step: license ─────────────────────────────────────────────────────────
+
+async function validateLicense(plugins: string[]): Promise<Failure[]> {
+  const fails: Failure[] = [];
+  for (const name of plugins) {
+    const metaPath = join(PLUGINS_DIR, name, "registry.meta.json");
+    if (!existsSync(metaPath)) continue; // plugin removed
+    let meta: { license?: string };
+    try {
+      meta = JSON.parse(await readFile(metaPath, "utf8"));
+    } catch (e) {
+      fails.push({
+        step: "license",
+        plugin: name,
+        expected: "valid JSON",
+        actual: String(e).slice(0, 300),
+        recovery: `Fix plugins/${name}/registry.meta.json — it failed to parse.`,
+      });
+      continue;
+    }
+    const lic = meta.license?.trim();
+    if (!lic) {
+      fails.push({
+        step: "license",
+        plugin: name,
+        expected: "non-empty SPDX identifier",
+        actual: JSON.stringify(meta.license),
+        recovery: `Set "license" in plugins/${name}/registry.meta.json to one of: ${[...SPDX_ALLOWLIST].join(", ")}.`,
+      });
+      continue;
+    }
+    if (!SPDX_ALLOWLIST.has(lic)) {
+      fails.push({
+        step: "license",
+        plugin: name,
+        expected: `one of: ${[...SPDX_ALLOWLIST].join(", ")}`,
+        actual: lic,
+        recovery: `Change "license" in plugins/${name}/registry.meta.json to an allowed SPDX id, or open an issue to discuss adding "${lic}" to the allowlist.`,
+      });
+    } else {
+      console.log(`✓ ${name}: license ${lic} OK`);
+    }
+  }
+  return fails;
+}
+
+// ─── step: source-format ───────────────────────────────────────────────────
+
+async function validateSourceFormat(filter: string[]): Promise<Failure[]> {
+  // When `filter` is provided (PR mode, --plugins set), hard-fail on any
+  // non-matching source — including `monorepo:` — for those plugins.
+  //
+  // When `filter` is empty (local full-scan mode, or PRs that don't touch any
+  // plugins), we still scan all plugins but treat legacy `monorepo:` prefix as
+  // a WARNING. Those entries are scheduled for migration via
+  // scripts/migrate-source-format.ts (see CONTRIBUTING.md → Source format) —
+  // failing CI on every PR until migration lands would be hostile. New
+  // contributors still can't introduce them in PR mode.
+  const fails: Failure[] = [];
+  const targetSet = new Set(filter);
+  const scanAll = filter.length === 0;
+  const entries = await readdir(PLUGINS_DIR, { withFileTypes: true });
+  let warnedLegacy = 0;
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    if (!scanAll && !targetSet.has(e.name)) continue;
+    const metaPath = join(PLUGINS_DIR, e.name, "registry.meta.json");
+    if (!existsSync(metaPath)) continue;
+    const meta: { source?: string } = JSON.parse(await readFile(metaPath, "utf8"));
+    const src = meta.source ?? "";
+    if (src.startsWith("monorepo:")) {
+      if (scanAll) {
+        console.warn(
+          `⚠️  ${e.name}: legacy "monorepo:" source — migration pending (scripts/migrate-source-format.ts). Skipped.`,
+        );
+        warnedLegacy++;
+        continue;
+      }
+      fails.push({
+        step: "source-format",
+        plugin: e.name,
+        expected: "bare owner/repo[/subpath][@ref] (see schema/registry.json $defs.entry.source)",
+        actual: src,
+        recovery: `Rewrite plugins/${e.name}/registry.meta.json source from legacy "monorepo:plugins/<name>@<tag>" to "owner/repo/<subpath>@<tag>". Run:\n  bun scripts/migrate-source-format.ts`,
+      });
+      continue;
+    }
+    if (!SOURCE_FORMAT_RE.test(src)) {
+      fails.push({
+        step: "source-format",
+        plugin: e.name,
+        expected: SOURCE_FORMAT_RE.source,
+        actual: src,
+        recovery: `Use bare github locator: owner/repo[/subpath][@ref] — e.g. "soul-brews-studio/maw-plugin-registry/${e.name}@v0.1.0".\nSee CONTRIBUTING.md → Source format.`,
+      });
+    }
+  }
+  if (fails.length === 0) {
+    const scope = scanAll ? `all (${entries.length})` : `${filter.length} changed`;
+    console.log(`✓ source-format: ${scope} plugin(s) clean${warnedLegacy ? ` (${warnedLegacy} legacy warning${warnedLegacy === 1 ? "" : "s"})` : ""}`);
+  }
+  return fails;
+}
+
+// ─── failure report ────────────────────────────────────────────────────────
+
+async function writeFailureReport(fails: Failure[]): Promise<void> {
+  const lines = ["### ❌ PR validation failed", ""];
+  for (const f of fails) {
+    lines.push(`#### \`${f.step}\`${f.plugin ? ` — \`${f.plugin}\`` : ""}`);
+    lines.push("");
+    lines.push(`**Expected:** ${f.expected}`);
+    lines.push("");
+    lines.push("**Actual:**");
+    lines.push("```");
+    lines.push(f.actual);
+    lines.push("```");
+    lines.push("");
+    lines.push("**Recovery:**");
+    lines.push("```");
+    lines.push(f.recovery);
+    lines.push("```");
+    lines.push("");
+  }
+  lines.push("---");
+  lines.push("See [CONTRIBUTING.md → Validation Checks](../blob/main/CONTRIBUTING.md#validation-checks) for the full list of PR checks.");
+  await writeFile(join(ROOT, ".tmp-validate-failure.md"), lines.join("\n"));
+}
+
+// ─── main ──────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  if (hasFlag("emit-changed")) {
+    await emitChanged(getFlag("base"));
+    return;
+  }
+  const step = getFlag("step");
+  if (!step) {
+    console.error("usage: validate-registry.ts --step <plugin-json|license|source-format> [--plugins a,b,c]");
+    console.error("       validate-registry.ts --emit-changed [--base <ref>]");
+    process.exit(2);
+  }
+  const plugins = (getFlag("plugins") ?? "").split(",").filter(Boolean);
+  let fails: Failure[] = [];
+  switch (step) {
+    case "plugin-json":
+      fails = await validatePluginJson(plugins);
+      break;
+    case "license":
+      fails = await validateLicense(plugins);
+      break;
+    case "source-format":
+      fails = await validateSourceFormat(plugins);
+      break;
+    default:
+      console.error(`unknown step: ${step}`);
+      process.exit(2);
+  }
+  if (fails.length > 0) {
+    await writeFailureReport(fails);
+    console.error(`✗ ${step}: ${fails.length} failure(s)`);
+    for (const f of fails) console.error(`  - ${f.plugin ?? "(global)"}: ${f.actual.split("\n")[0]}`);
+    process.exit(1);
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary

Layers a per-PR deep-validation workflow on top of the existing fast schema check, shipping only the **cheap (no-network) subset** from issue #1's 8-step validation plan. Network-dependent steps are deferred to a follow-up.

Adds:
- `.github/workflows/validate-pr.yml` — runs on PRs that touch `registry.json`, `plugins/**`, `schema/**`, the new script, or the workflow itself. `permissions: contents:read, pull-requests:write` so failures post a structured comment.
- `scripts/validate-registry.ts` (Bun, stdlib only — no new deps) with subcommands:
  - `--emit-changed` — diff `base..HEAD`, emit `plugins=a,b,c` to `$GITHUB_OUTPUT`
  - `--step plugin-json --plugins …` — per-plugin JSONSchema validate via `bunx ajv-cli@5`
  - `--step license --plugins …` — SPDX allowlist: `MIT`, `Apache-2.0`, `BUSL-1.1`, `ISC`, `BSD-2-Clause`, `BSD-3-Clause`
  - `--step source-format [--plugins …]` — regex mirroring `schema/registry.json:60`; rejects `monorepo:` with recovery hint. Full-scan mode warns on legacy entries; PR-scoped mode hard-fails.
- Post-failure GH Actions step that uploads `.tmp-validate-failure.md` as a PR comment with expected / actual / recovery for every failed check.
- CONTRIBUTING.md → new "Validation Checks" section walking through both workflows and documenting how to run the deep checks locally.
- Pre-existing fast check (`.github/workflows/validate.yml`) is **untouched**.

## What's deferred (network-dependent — follow-up PR)

Per issue #1 defense-in-depth, these are not in this PR:
- `gh repo view` — assert the source repo exists and is public
- `gh release view` — assert the pinned `@ref` is a real GitHub release tag
- `sha256` tarball verification against `registry.meta.json.sha256`

These need network access (rate-limit budgeting) and a release-cut to populate `sha256` for new plugins. They'll land as a follow-up once we decide on caching strategy.

## Design notes / open questions

1. **`monorepo:` legacy handling.** The script warns-only on `monorepo:` entries when run in full-scan mode (`--step source-format` with no `--plugins`), so it can run clean locally. In PR-scoped mode (`--plugins a,b,c`) it hard-fails. After PR #51 landed there are currently zero `monorepo:` entries on main; the soft-warn path is defense against re-introduction.
2. **`regenerate-and-clean` ignores the `updated` timestamp** via `git diff --exit-code -I '"updated":'` since `build-registry.py` always rewrites it. Alternative: make the build script preserve the timestamp on no-op runs. Left as-is to avoid touching shared scripts. Open to either path.
3. **Failure-comment style.** Currently one comment per failed run. Could dedupe / edit-in-place via `actions/github-script` if comment spam becomes an issue.
4. **`plugin-json` step uses `bunx ajv-cli@5`** for parity with the existing fast workflow rather than a JS validator dep. Slightly slower but zero new lockfile entries.

## Test plan

- [x] `bun scripts/validate-registry.ts --step source-format` — passes clean on rebased main (75 plugin dirs, 0 failures, 0 warnings after #51)
- [x] `bun scripts/validate-registry.ts --step source-format --plugins swarm,about` — verified hard-fail behavior pre-#51 when a `monorepo:` entry was in scope
- [x] `bun scripts/validate-registry.ts --step license --plugins about,bg` — validates SPDX allowlist hit
- [x] `bun scripts/validate-registry.ts --emit-changed --base main` — emits empty plugin list on clean tree, writes to `$GITHUB_OUTPUT` when set
- [x] `python3 scripts/build-registry.py && git diff --exit-code -I '"updated":' registry.json` — clean
- [ ] Watch first PR-mode CI run (this PR — only touches `.github/`, `scripts/`, `CONTRIBUTING.md`, `.gitignore` so `validate-pr.yml` itself triggers; expect the `changed plugins: (none)` branch end-to-end)
- [ ] Follow-up PR with intentionally bad license / bad source to exercise the failure-comment path

🤖 Generated with [Claude Code](https://claude.com/claude-code)