### PR TITLE
fix(doctor): skip auto-reinstall when maw is bun-linked to dev checkout (#1281)

### DIFF
--- a/plugins/doctor/impl.ts
+++ b/plugins/doctor/impl.ts
@@ -11,6 +11,7 @@ import { findGaps, summarizeGaps } from "./cross-source-detect";
 import { checkMawJsBranch } from "./internal/maw-js-branch-check";
 import { checkStillbornWorktrees } from "./internal/stillborn-worktrees";
 import { checkStalePeers, cmdFixStalePeers } from "./internal/stale-peers";
+import { detectBunLinkedCheckout } from "./internal/bun-link-detect";
 
 export interface DoctorResult {
   ok: boolean;
@@ -70,6 +71,20 @@ async function checkInstall(): Promise<{ name: string; ok: boolean; message: str
   const exists = existsSync(binPath);
   if (!exists) {
     console.log(`  ${C.yellow}⚠${C.reset} maw binary missing at ${binPath}`);
+    // #1281 — Skip auto-reinstall when maw-js is bun-linked to a local dev
+    // checkout. `bun add -g github:…` would silently replace the symlink
+    // with a fresh clone, blowing away the dev workflow. Tell the operator
+    // how to restore the link instead.
+    const localCheckout = detectBunLinkedCheckout();
+    if (localCheckout) {
+      console.log(`  ${C.yellow}⚠${C.reset} maw is bun-linked to dev checkout: ${localCheckout}`);
+      console.log(`  ${C.gray}run: cd ${localCheckout} && bun link${C.reset}`);
+      return {
+        name: "install",
+        ok: false,
+        message: `dev bun-link at ${localCheckout} — run bun link to restore`,
+      };
+    }
     console.log(`  ${C.gray}attempting reinstall…${C.reset}`);
     try {
       execSync("bun add -g github:Soul-Brews-Studio/maw-js", { stdio: "inherit" });

--- a/plugins/doctor/internal/bun-link-detect.test.ts
+++ b/plugins/doctor/internal/bun-link-detect.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { detectBunLinkedCheckout } from "./bun-link-detect";
+
+// We exercise the helper with real symlinks in a tmp dir, mirroring the
+// pattern used elsewhere in the doctor plugin (maw-js-branch-check.test.ts
+// uses real git repos). Real symlinks make readlinkSync behave naturally
+// without monkey-patching node:fs.
+
+describe("detectBunLinkedCheckout (#1281)", () => {
+  let tmp: string;
+  let globalNm: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "bun-link-test-"));
+    globalNm = join(tmp, "global-node-modules");
+    mkdirSync(globalNm, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("returns the checkout path when maw-js is symlinked to a local checkout", () => {
+    const checkout = join(tmp, "maw-js-checkout");
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(
+      join(checkout, "package.json"),
+      JSON.stringify({ name: "maw-js", version: "1.0.0" }),
+    );
+    symlinkSync(checkout, join(globalNm, "maw-js"));
+
+    expect(detectBunLinkedCheckout(globalNm)).toBe(checkout);
+  });
+
+  it("returns null when maw-js is not present at all (not installed/linked)", () => {
+    expect(detectBunLinkedCheckout(globalNm)).toBeNull();
+  });
+
+  it("returns null when maw-js is a real directory (npm/bun install — not a link)", () => {
+    const realDir = join(globalNm, "maw-js");
+    mkdirSync(realDir, { recursive: true });
+    writeFileSync(
+      join(realDir, "package.json"),
+      JSON.stringify({ name: "maw-js", version: "1.0.0" }),
+    );
+
+    expect(detectBunLinkedCheckout(globalNm)).toBeNull();
+  });
+
+  it("returns null when symlink target is not a maw-js checkout", () => {
+    const otherPkg = join(tmp, "other-pkg");
+    mkdirSync(otherPkg, { recursive: true });
+    writeFileSync(
+      join(otherPkg, "package.json"),
+      JSON.stringify({ name: "some-other-pkg", version: "1.0.0" }),
+    );
+    symlinkSync(otherPkg, join(globalNm, "maw-js"));
+
+    expect(detectBunLinkedCheckout(globalNm)).toBeNull();
+  });
+
+  it("returns null when symlink target has no package.json", () => {
+    const emptyDir = join(tmp, "empty");
+    mkdirSync(emptyDir, { recursive: true });
+    symlinkSync(emptyDir, join(globalNm, "maw-js"));
+
+    expect(detectBunLinkedCheckout(globalNm)).toBeNull();
+  });
+});

--- a/plugins/doctor/internal/bun-link-detect.ts
+++ b/plugins/doctor/internal/bun-link-detect.ts
@@ -1,0 +1,45 @@
+import { readlinkSync, readFileSync, existsSync } from "fs";
+import { homedir } from "os";
+import { join, dirname, resolve } from "path";
+
+/**
+ * #1281 — Detect whether `maw` is bun-linked to a local maw-js dev checkout.
+ *
+ * When `bun link` has been run inside a maw-js checkout, bun creates a
+ * symlink at `~/.bun/install/global/node_modules/maw-js` pointing to that
+ * checkout. If `maw doctor` then auto-reinstalls via
+ * `bun add -g github:Soul-Brews-Studio/maw-js`, bun silently replaces the
+ * symlink with a fresh clone — blowing away the dev workflow and confusing
+ * the operator. Doctor's auto-reinstall path must skip when a link is
+ * present.
+ *
+ * Returns the absolute path of the linked checkout if the symlink exists
+ * AND resolves to a directory whose `package.json` declares `name: maw-js`.
+ * Returns null in every other case (no symlink, broken symlink, missing
+ * or wrong-named package.json, unreadable JSON).
+ *
+ * @param globalNodeModules base path of bun's global `node_modules`.
+ *   Defaults to `~/.bun/install/global/node_modules`. Override in tests.
+ */
+export function detectBunLinkedCheckout(
+  globalNodeModules: string = join(homedir(), ".bun/install/global/node_modules"),
+): string | null {
+  const link = join(globalNodeModules, "maw-js");
+  let target: string;
+  try {
+    target = readlinkSync(link);
+  } catch {
+    // Not a symlink, or doesn't exist — either way, no dev link to protect.
+    return null;
+  }
+  const abs = target.startsWith("/") ? target : resolve(dirname(link), target);
+  const pkgPath = join(abs, "package.json");
+  if (!existsSync(pkgPath)) return null;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    if (pkg?.name !== "maw-js") return null;
+    return abs;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `detectBunLinkedCheckout()` to detect when `~/.bun/install/global/node_modules/maw-js` is a symlink into a real maw-js dev checkout.
- Guards the `checkInstall()` auto-reinstall path: when a dev link is detected, return `ok:false` with a hint to re-run `bun link` instead of running `bun add -g github:Soul-Brews-Studio/maw-js` (which would silently replace the link with a fresh clone).
- Non-linked installs still flow through the original reinstall path — backward compat preserved.

Fixes #1281.

## Test plan

- [x] `bun test plugins/doctor/internal/bun-link-detect.test.ts` — 5 passes covering linked, missing, real-dir, wrong-name, no-package.json scenarios.
- [x] `bun test plugins/doctor/` — 32/32 passes across all 4 doctor test files (no regressions).
- [ ] Manual: delete `~/.bun/bin/maw`, run `maw doctor` against a bun-linked dev checkout, confirm reinstall is skipped and the hint message appears.
- [ ] Manual: delete `~/.bun/bin/maw` on a non-linked install, confirm the original reinstall path still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)