### PR TITLE
feat(attach): Tier 3 strategy hints + --no-ssh (closes #1289)

### DIFF
--- a/plugins/attach/attach.test.ts
+++ b/plugins/attach/attach.test.ts
@@ -500,7 +500,7 @@ test("Tier 3 handler: happy path — calls attachRemoteSession with right args",
   });
   try {
     const { cmdAttach } = await import("./impl");
-    await cmdAttach("homekeeper");
+    await cmdAttach("homekeeper", { sleep: async () => {} });
     expect(ctx.sshCalls.length).toBe(1);
     expect(ctx.sshCalls[0]).toEqual({
       node: "mba",
@@ -521,7 +521,7 @@ test("Tier 3 handler: namedPeers.ssh override is used as sshAlias", async () => 
   });
   try {
     const { cmdAttach } = await import("./impl");
-    await cmdAttach("homekeeper");
+    await cmdAttach("homekeeper", { sleep: async () => {} });
     expect(ctx.sshCalls[0].sshAlias).toBe("mba-tunnel");
   } finally {
     ctx.restore();
@@ -553,7 +553,7 @@ test("Tier 3 handler: ssh exit 255 / Connection refused → throws UserError-ish
   try {
     const { cmdAttach } = await import("./impl");
     let threw: Error | null = null;
-    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    try { await cmdAttach("homekeeper", { sleep: async () => {} }); } catch (e) { threw = e as Error; }
     expect(threw).not.toBeNull();
     expect(threw!.message).toContain("can't reach mba");
   } finally {
@@ -571,7 +571,7 @@ test("Tier 3 handler: Permission denied → auth-failed UserError", async () => 
   try {
     const { cmdAttach } = await import("./impl");
     let threw: Error | null = null;
-    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    try { await cmdAttach("homekeeper", { sleep: async () => {} }); } catch (e) { threw = e as Error; }
     expect(threw).not.toBeNull();
     expect(threw!.message).toContain("no SSH key for mba");
   } finally {
@@ -589,7 +589,7 @@ test("Tier 3 handler: tmux not installed on remote → tmux-missing UserError", 
   try {
     const { cmdAttach } = await import("./impl");
     let threw: Error | null = null;
-    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    try { await cmdAttach("homekeeper", { sleep: async () => {} }); } catch (e) { threw = e as Error; }
     expect(threw).not.toBeNull();
     expect(threw!.message).toContain("tmux not installed on mba");
   } finally {
@@ -607,11 +607,72 @@ test("Tier 3 handler: ambiguous across peers — refuses, prints pin hint", asyn
   try {
     const { cmdAttach } = await import("./impl");
     let threw: Error | null = null;
-    try { await cmdAttach("homekeeper"); } catch (e) { threw = e as Error; }
+    try { await cmdAttach("homekeeper", { sleep: async () => {} }); } catch (e) { threw = e as Error; }
     expect(threw).not.toBeNull();
     expect(threw!.message).toMatch(/ambiguous/i);
     expect(ctx.sshCalls.length).toBe(0);
   } finally {
+    ctx.restore();
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5. Tier 3 strategy hints (#1289) — print alternatives before auto-SSH
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("Tier 3 hints: hint lines print BEFORE the SSH call", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  });
+  const lines: string[] = [];
+  const origLog = console.log;
+  let sshCalledAfterHints = false;
+  console.log = (...a: any[]) => { lines.push(a.map(String).join(" ")); };
+  try {
+    const { cmdAttach } = await import("./impl");
+    await cmdAttach("homekeeper", {
+      sleep: async () => {
+        // At sleep time, hints must already be in the buffer and SSH must not
+        // have been called yet — proves ordering.
+        sshCalledAfterHints = ctx.sshCalls.length === 0;
+      },
+    });
+    console.log = origLog;
+
+    const all = lines.join("\n");
+    expect(all).toMatch(/maw clone homekeeper/);
+    expect(all).toMatch(/maw sync homekeeper/);
+    expect(all).toMatch(/auto-attaching via SSH in 1s/);
+    expect(sshCalledAfterHints).toBe(true);
+    expect(ctx.sshCalls.length).toBe(1);
+  } finally {
+    console.log = origLog;
+    ctx.restore();
+  }
+});
+
+test("Tier 3 --no-ssh: prints hints and exits without SSH-attaching", async () => {
+  const ctx = setupTier3Mocks({
+    aggregated: [
+      { name: "24-homekeeper", windows: [{ name: "x" }], source: "http://mba.wg:9090", node: "mba" },
+    ],
+  });
+  const lines: string[] = [];
+  const origLog = console.log;
+  console.log = (...a: any[]) => { lines.push(a.map(String).join(" ")); };
+  try {
+    const { cmdAttach } = await import("./impl");
+    await cmdAttach("homekeeper", { noSsh: true, sleep: async () => {} });
+    console.log = origLog;
+    const all = lines.join("\n");
+    expect(all).toMatch(/maw clone homekeeper/);
+    expect(all).toMatch(/maw sync homekeeper/);
+    expect(all).toMatch(/not attaching/);
+    expect(ctx.sshCalls.length).toBe(0);
+  } finally {
+    console.log = origLog;
     ctx.restore();
   }
 });

--- a/plugins/attach/impl.ts
+++ b/plugins/attach/impl.ts
@@ -28,10 +28,20 @@ export interface AttachOpts {
   /** Skip Tier 1/2 entirely and only consider remote peers. */
   remoteOnly?: boolean;
   /**
+   * Tier 3 only: print strategy hints (ssh / clone / sync) and exit without
+   * SSH-attaching. Scripts that don't want the auto-attach can pass this.
+   * Closes part of #1289 — additive, doesn't change the default. */
+  noSsh?: boolean;
+  /**
    * Test seam — swap the cross-node SSH attach with a stub. Defaults to the
    * real `attachRemoteSession` from maw-js/sdk.
    */
   ssh?: typeof attachRemoteSession;
+  /**
+   * Test seam — pause helper used before auto-SSH-attach so the hint is
+   * visible. Defaults to a 1s sleep; tests pass a no-op.
+   */
+  sleep?: (ms: number) => Promise<void>;
 }
 
 /**
@@ -153,9 +163,22 @@ export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<vo
       return;
     }
 
+    // Strategy-hint block (closes #1289 — additive, default still auto-SSH).
+    // Shown BEFORE the SSH call so the user has a beat to Ctrl-C and pick a
+    // different verb. `--no-ssh` exits after the hints (scripts opt out).
     console.log(`  \x1b[36m→\x1b[0m '${result.sessionName}' is on ${result.node} (peer ${result.peerUrl})`);
     console.log(`  \x1b[90m  ssh ${result.sshAlias} → tmux attach -t '${result.sessionName}'\x1b[0m`);
+    console.log(`  \x1b[90m  hint: alternatives:\x1b[0m`);
+    console.log(`  \x1b[90m    maw clone ${name}   — clone repo + wake locally  (future)\x1b[0m`);
+    console.log(`  \x1b[90m    maw sync ${name}    — sync session, continue here (future)\x1b[0m`);
+    if (opts.noSsh) {
+      console.log(`  \x1b[90m  (--no-ssh: not attaching; pick a strategy and re-run)\x1b[0m`);
+      return;
+    }
+    console.log(`  \x1b[90m  (auto-attaching via SSH in 1s, Ctrl-C to choose)\x1b[0m`);
     console.log(`  \x1b[90m  hint: detach with prefix+d to return to your local shell\x1b[0m`);
+    const sleep = opts.sleep ?? ((ms: number) => new Promise(r => setTimeout(r, ms)));
+    await sleep(1000);
     const ssh = opts.ssh ?? attachRemoteSession;
     try {
       ssh({

--- a/plugins/attach/index.ts
+++ b/plugins/attach/index.ts
@@ -7,7 +7,7 @@ export const command = {
   description: "Smart attach — local live, sleeping fleet, or remote-live peer (#25 + #1236).",
 };
 
-const USAGE = "usage: maw attach <name> [--dry-run] [-y|--yes] [--node <n>] [--remote-only]";
+const USAGE = "usage: maw attach <name> [--dry-run] [-y|--yes] [--node <n>] [--remote-only] [--no-ssh]";
 
 export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
   const logs: string[] = [];
@@ -33,6 +33,8 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
           "-y": "--yes",
           "--node": String,
           "--remote-only": Boolean,
+          "--no-ssh": Boolean,
+          "--choose": "--no-ssh",
         },
         0,
       );
@@ -48,6 +50,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         yes: flags["--yes"],
         node: flags["--node"],
         remoteOnly: flags["--remote-only"],
+        noSsh: flags["--no-ssh"],
       });
     } else if (ctx.source === "api") {
       const body = ctx.args as Record<string, unknown>;
@@ -59,6 +62,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         yes: true,
         node: body.node as string | undefined,
         remoteOnly: body.remoteOnly as boolean | undefined,
+        noSsh: body.noSsh as boolean | undefined,
       });
     }
 


### PR DESCRIPTION
## Summary

Round-1 brainstorm framing-challenger concluded #1289 is an L2 (attach strategy) problem, not L1 (network transport). This PR ships the additive change without refactoring transports.

- Tier 3 of the attach cascade (peer-reports-a-live-session) now prints a strategy-hint block BEFORE the auto-SSH-attach: it shows the planned SSH command, names two future verbs (`maw clone <name>`, `maw sync <name>`), and pauses 1s so the user can Ctrl-C and pick differently.
- New `--no-ssh` flag (alias `--choose`) prints the hints and exits without attaching — for scripts that want to opt out of auto-SSH.
- `maw clone` / `maw sync` are documented in the hint text as future verbs only; not implemented here (out of scope).

## Compatibility

- Default `maw a <remote-name>` still auto-attaches via SSH. Only added: hint block + 1s pause.
- No package.json bump. ~30 LoC of production change + ~65 LoC of tests.

## Test plan

- [x] `bun test plugins/attach/` — 36 pass / 0 fail (was 34 pass before)
- [x] New test: hint lines print BEFORE the SSH call (proves ordering via sleep callback)
- [x] New test: `--no-ssh` prints hints + exits, no SSH call
- [x] All previously-passing Tier 1/2/3 tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)