### PR TITLE
feat(attach): extract Tier 3 SSH into attach-ssh plugin

### DIFF
--- a/plugins/attach-ssh/README.md
+++ b/plugins/attach-ssh/README.md
@@ -1,0 +1,18 @@
+# attach-ssh
+
+Tier 3 (remote-live) SSH + tmux attach strategy for `maw attach`.
+
+When `maw attach <name>` (or `maw a <name>`) resolves to a session running on
+a federation peer, the built-in attach plugin hands control off to any
+installed plugin that declares the `attach:strategy` capability with
+`strategy.tier: 3`. This plugin is the reference implementation — it SSHes
+into the peer and runs `tmux attach -t <session>` so your terminal takes
+over the remote pane. Extracted from the built-in attach (#1262) so the
+SSH + tmux glue can be disabled, replaced, or evolved independently. See
+[../attach](../attach) for the cascade host.
+
+## Install
+
+```
+maw plugin install attach-ssh
+```

--- a/plugins/attach-ssh/index.ts
+++ b/plugins/attach-ssh/index.ts
@@ -1,0 +1,46 @@
+/**
+ * attach-ssh — Tier 3 (remote-live) SSH+tmux attach strategy.
+ *
+ * Extracted from plugins/attach (#1262). When `maw attach <name>` resolves
+ * to a peer-live session, the dispatcher in plugins/attach/impl.ts scans
+ * ~/.maw/plugins/*\/plugin.json for an `attach:strategy` capability matching
+ * `strategy.tier === 3` and hands off the resolved target to `execute()`.
+ *
+ * Keep this small — the friendly console.log lines stay in the host so the
+ * UX is consistent even when no strategy plugin is installed (built-in
+ * fallback path).
+ */
+import { attachRemoteSession, SshAttachError } from "maw-js/sdk";
+
+export interface Tier3Target {
+  tier: 3;
+  sessionName: string;
+  node: string;
+  peerUrl: string;
+  sshAlias: string;
+}
+
+export interface ExecuteOpts {
+  /** Test seam — swap the SSH helper. Defaults to maw-js/sdk's attachRemoteSession. */
+  ssh?: typeof attachRemoteSession;
+}
+
+export default {
+  async execute(target: Tier3Target, opts: ExecuteOpts = {}): Promise<void> {
+    const ssh = opts.ssh ?? attachRemoteSession;
+    try {
+      ssh({
+        node: target.node,
+        sshAlias: target.sshAlias,
+        sessionName: target.sessionName,
+      });
+    } catch (err) {
+      if (err instanceof SshAttachError) {
+        // Surface the helper's friendly one-line message — never process.exit.
+        console.error(err.message);
+        throw new Error(err.message);
+      }
+      throw err;
+    }
+  },
+};

--- a/plugins/attach-ssh/plugin.json
+++ b/plugins/attach-ssh/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "attach-ssh",
+  "version": "0.1.0",
+  "description": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach (#1262).",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "entry": "./index.ts",
+  "capabilities": ["attach:strategy"],
+  "strategy": { "tier": 3 },
+  "schemaVersion": 1,
+  "sdk": "^1.0.0-alpha.1"
+}

--- a/plugins/attach-ssh/registry.meta.json
+++ b/plugins/attach-ssh/registry.meta.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.1.0",
+  "source": "soul-brews-studio/maw-plugin-registry/attach-ssh@v0.1.0-attach-ssh",
+  "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-05-13T03:23:00Z"
+}

--- a/plugins/attach/impl.ts
+++ b/plugins/attach/impl.ts
@@ -156,6 +156,25 @@ export async function cmdAttach(name: string, opts: AttachOpts = {}): Promise<vo
     console.log(`  \x1b[36m→\x1b[0m '${result.sessionName}' is on ${result.node} (peer ${result.peerUrl})`);
     console.log(`  \x1b[90m  ssh ${result.sshAlias} → tmux attach -t '${result.sessionName}'\x1b[0m`);
     console.log(`  \x1b[90m  hint: detach with prefix+d to return to your local shell\x1b[0m`);
+
+    // Strategy plugin dispatcher (#1262). If a plugin in ~/.maw/plugins/
+    // declares the `attach:strategy` capability for tier 3, hand the SSH
+    // execution off to it. `opts.ssh` is only set by tests — in that path
+    // we keep the built-in so the test seam still intercepts the call.
+    if (!opts.ssh) {
+      const stratPath = findStrategyPluginForTier(3);
+      if (stratPath) {
+        try {
+          const mod: any = await import(stratPath);
+          await (mod.default ?? mod).execute(result, opts);
+          return;
+        } catch (err: any) {
+          console.error(`[attach] strategy plugin failed: ${err?.message ?? err}; falling back to built-in`);
+          // fall through to the built-in path below
+        }
+      }
+    }
+
     const ssh = opts.ssh ?? attachRemoteSession;
     try {
       ssh({
@@ -181,6 +200,42 @@ function printRemoteAlternates(alts: RemoteAlternate[], name: string): void {
     console.log(`  \x1b[90m    • ${a.sessionName} on ${a.node}\x1b[0m`);
   }
   console.log(`  \x1b[90m  pin remote: maw attach ${alts[0].node}:${name}\x1b[0m`);
+}
+
+/**
+ * Walk ~/.maw/plugins/ looking for a plugin whose manifest declares the
+ * `attach:strategy` capability AND targets the given tier. Returns the
+ * absolute import path to the entry file, or null if none found / dir
+ * missing. Honors `MAW_PLUGINS_DIR` for tests (matches maw-js's
+ * installRoot()). Best-effort: any per-entry error is silently skipped so
+ * a single broken manifest can't block the cascade.
+ */
+function findStrategyPluginForTier(tier: number): string | null {
+  const fs = require("fs");
+  const path = require("path");
+  const os = require("os");
+  const root: string = process.env.MAW_PLUGINS_DIR || path.join(os.homedir(), ".maw", "plugins");
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(root);
+  } catch {
+    return null;
+  }
+  for (const name of entries) {
+    const manifestPath = path.join(root, name, "plugin.json");
+    let manifest: any;
+    try {
+      manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    } catch {
+      continue;
+    }
+    const caps = manifest.capabilities;
+    if (!Array.isArray(caps) || !caps.includes("attach:strategy")) continue;
+    if (manifest.strategy?.tier !== tier) continue;
+    const entryRel: string = typeof manifest.entry === "string" ? manifest.entry : "./index.ts";
+    return path.join(root, name, entryRel);
+  }
+  return null;
 }
 
 /**

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-13T03:30:00Z",
+  "updated": "2026-05-13T03:35:06Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -50,12 +50,11 @@
     "attach-ssh": {
       "version": "0.1.0",
       "source": "soul-brews-studio/maw-plugin-registry/attach-ssh@v0.1.0-attach-ssh",
-      "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach (#1262).",
+      "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach.",
       "author": "Soul-Brews-Studio",
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
-      "addedAt": "2026-05-13T00:00:00Z",
-      "tier": "extra"
+      "addedAt": "2026-05-13T03:23:00Z"
     },
     "avengers": {
       "version": "0.1.0",

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-13T01:19:58Z",
+  "updated": "2026-05-13T03:30:00Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -45,6 +45,16 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:39:10Z",
+      "tier": "extra"
+    },
+    "attach-ssh": {
+      "version": "0.1.0",
+      "source": "soul-brews-studio/maw-plugin-registry/attach-ssh@v0.1.0-attach-ssh",
+      "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach (#1262).",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-05-13T00:00:00Z",
       "tier": "extra"
     },
     "avengers": {

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -40,6 +40,24 @@
       "type": "string",
       "description": "Semver range of the maw-js plugin SDK the plugin targets."
     },
+    "entry": {
+      "type": "string",
+      "description": "Relative path to the plugin's entry module (e.g. ./index.ts)."
+    },
+    "capabilities": {
+      "type": "array",
+      "items": { "type": "string" },
+      "uniqueItems": true,
+      "description": "Free-form capability strings the plugin advertises (e.g. \"attach:strategy\")."
+    },
+    "strategy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tier": { "type": "integer", "minimum": 1 }
+      },
+      "description": "Strategy-plugin metadata. `tier` selects which cascade tier this plugin implements."
+    },
     "api": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
## Summary

Extracts today's Tier 3 (remote-live) SSH+tmux dispatch from the built-in `attach` plugin into a new `attach-ssh` plugin. Users can now disable/replace SSH attach without forking the host.

- New `attach-ssh` plugin (~76 LOC: plugin.json + index.ts + README)
- Dispatcher hook in `attach/impl.ts:160` — walks `~/.maw/plugins/` for `capabilities: ["attach:strategy"]` + `strategy.tier === 3`, dynamic-imports, calls `execute(result, opts)`
- On any error or absence: falls through to today's built-in SSH path (unchanged at L156-175)
- Test seam preserved: dispatcher gated on `!opts.ssh` so existing tests still hit the built-in

## Deliberately skipped (simple-first)

The design discussion (vault: `mawjs-oracle/ψ/learn/attach-plugin-design/2026-05-13/`) covered a full plugin-system spec with cache, SDK floor enforcement, `maw plugins reindex`, atomic writes, 11 integration tests, etc. — ~640 LOC across PR-1 (maw-js) + PR-2 (registry). That's parked. This PR is the minimum-viable cut: ~160 LOC, registry-only, no maw-js changes needed.

If/when a real second strategy (#1289 attach-clone, attach-sync) lands, the audited additions are the natural follow-up.

## Files

| File | LOC |
|---|---|
| `plugins/attach-ssh/plugin.json` | 12 (new) |
| `plugins/attach-ssh/index.ts` | 46 (new) |
| `plugins/attach-ssh/README.md` | 18 (new) |
| `plugins/attach/impl.ts` | +55 (dispatcher + helper) |
| `schema/plugin.json` | +18 (entry/capabilities/strategy properties — also fixes pre-existing schema gap) |
| `registry.json` | +11 (attach-ssh entry, tier:"extra") |

## Known wart

`maw plugin install attach-ssh` prints `unknown capability namespace "attach" in "attach:strategy" (known: net, fs, peer, sdk, proc, ffi, tmux, shell)`. Install proceeds anyway. Fix is a 3-LOC addition to maw-js's validator (add `attach` to the known-namespace list). Filed as follow-up.

## Test plan

- [x] `bunx ajv validate` passes on `attach-ssh/plugin.json` and `registry.json`
- [x] `bun run scripts/validate-registry.ts --step plugin-json --plugins attach-ssh` ✓
- [x] `bun run scripts/validate-registry.ts --step source-format --plugins attach-ssh` ✓
- [x] `tsc --noEmit` on changed files: zero errors
- [x] End-to-end smoke (manual): `findStrategyPluginForTier(3)` resolves attach-ssh, dynamic import succeeds, `execute` is a function
- [x] `maw a phd --dry-run` unchanged (dry-run short-circuits before dispatcher — correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)