### PR TITLE
feat(oracle-skills): wrap arra-oracle-skills CLI as maw plugin

### DIFF
--- a/plugins/oracle-skills/README.md
+++ b/plugins/oracle-skills/README.md
@@ -1,0 +1,39 @@
+# maw oracle-skills
+
+Wraps the [`arra-oracle-skills`](https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli) CLI as a maw plugin. Installs Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.
+
+This plugin is a thin dispatcher: every `maw oracle-skills <verb> [args]` call is forwarded to `arra-oracle-skills <verb> [args]` with stdio inherited. The upstream CLI owns help text, verb routing, and output.
+
+## Install
+
+```bash
+bun add -g arra-oracle-skills
+maw plugin install oracle-skills
+```
+
+For local dev against an unpublished checkout:
+
+```bash
+cd /path/to/arra-oracle-skills-cli && bun link && bun link arra-oracle-skills
+```
+
+## Usage
+
+```bash
+maw oracle-skills --help
+maw oracle-skills agents          # list supported AI agents
+maw oracle-skills install         # install skills to agents
+maw oracle-skills list            # show installed skills
+maw oracle-skills awaken          # Oracle awakening ritual
+maw oracle-skills xray memory     # deep scan
+```
+
+All verbs from `arra-oracle-skills` pass through transparently: `agents`, `install`, `init`, `uninstall`, `select`, `list`, `profiles`, `about`, `awaken`, `inspect`, `xray`, `shortcut`, `contacts`.
+
+## Failure mode
+
+If `arra-oracle-skills` is not on `$PATH`, the wrapper fails with an install hint. No auto-install — consistent with `maw token` (which assumes `pass` / `direnv` are present).
+
+## License
+
+MIT

--- a/plugins/oracle-skills/index.ts
+++ b/plugins/oracle-skills/index.ts
@@ -1,0 +1,49 @@
+/**
+ * maw oracle-skills — pure wrapper around the arra-oracle-skills CLI.
+ *
+ * Mirrors the maw-token / pass / direnv precedent: spawn the external
+ * binary directly with inherited stdio, propagate its exit code, surface
+ * an install hint if it isn't on $PATH.
+ *
+ * All argv (verbs, flags, --help) flows through transparently. The
+ * upstream CLI owns help text, verb routing, and output formatting.
+ */
+
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+
+export const command = {
+  name: "oracle-skills",
+  description:
+    "Wraps the arra-oracle-skills CLI — install Oracle skills to AI coding agents.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args: string[] = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+  let proc: ReturnType<typeof Bun.spawnSync>;
+  try {
+    proc = Bun.spawnSync(["arra-oracle-skills", ...args], {
+      stdout: "inherit",
+      stderr: "inherit",
+      stdin: "inherit",
+    });
+  } catch (e: any) {
+    return {
+      ok: false,
+      error:
+        `arra-oracle-skills not found on $PATH. ` +
+        `Install with: bun add -g arra-oracle-skills`,
+      output: "",
+    };
+  }
+
+  if (proc.exitCode === 0) {
+    return { ok: true, output: "" };
+  }
+
+  return {
+    ok: false,
+    error: `arra-oracle-skills exited with code ${proc.exitCode}`,
+    output: "",
+  };
+}

--- a/plugins/oracle-skills/plugin.json
+++ b/plugins/oracle-skills/plugin.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
+  "name": "oracle-skills",
+  "version": "0.1.0",
+  "description": "Wraps the arra-oracle-skills CLI — install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "sdk": "^1.0.0",
+  "schemaVersion": 1,
+  "entry": "./index.ts"
+}

--- a/plugins/oracle-skills/registry.meta.json
+++ b/plugins/oracle-skills/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.0",
+  "source": "soul-brews-studio/maw-plugin-registry/oracle-skills@v0.1.0-oracle-skills",
+  "sha256": null,
+  "summary": "Wraps the arra-oracle-skills CLI — install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-05-13T13:45:00Z",
+  "tier": "extra"
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-13T03:35:06Z",
+  "updated": "2026-05-13T07:13:50Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -360,6 +360,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:07Z",
+      "tier": "extra"
+    },
+    "oracle-skills": {
+      "version": "0.1.0",
+      "source": "soul-brews-studio/maw-plugin-registry/oracle-skills@v0.1.0-oracle-skills",
+      "sha256": null,
+      "summary": "Wraps the arra-oracle-skills CLI \u2014 install Oracle skills to Claude Code, OpenCode, Cursor, and 11+ AI coding agents.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-05-13T13:45:00Z",
       "tier": "extra"
     },
     "overview": {


### PR DESCRIPTION
## Summary

Adds `oracle-skills` as a pure wrapper plugin around the [`arra-oracle-skills`](https://github.com/Soul-Brews-Studio/arra-oracle-skills-cli) CLI. Mirrors the `maw token` precedent — single dispatcher (~25 LOC) forwards all argv to the external binary via \`Bun.spawnSync\` with inherited stdio.

## Why this shape

- **Pure wrapper, not per-verb files** — arra-oracle-skills has 13 verbs that all do distinct work; per-verb files in the plugin would be 13 identical 3-line shells (ceremony without value). Token has per-verb files because each verb hosts real logic (parsing pass output, etc.); this one doesn't need them.
- **Not a full port** — arra-oracle-skills-cli is a real, published, independently-versioned project. Vendoring 500+ LOC + 80 skill markdowns would drift within weeks.
- **No bunx wrapping** — adds cold-start latency every invocation; the token/ui/init precedent spawns binaries directly and surfaces OS-level errors.

## Files

- \`plugins/oracle-skills/plugin.json\` — name, version 0.1.0, entry, sdk
- \`plugins/oracle-skills/registry.meta.json\` — tier \"extra\"
- \`plugins/oracle-skills/index.ts\` — dispatcher (~25 LOC)
- \`plugins/oracle-skills/README.md\` — install + usage
- \`registry.json\` — regenerated via \`scripts/build-registry.py\` (now 75 plugins)

## Failure UX

Missing binary surfaces as: \`arra-oracle-skills not found on \$PATH. Install with: bun add -g arra-oracle-skills\` — consistent with maw-token (which fails the same way when \`pass\` / \`direnv\` aren't installed).

## Test plan

- [x] \`scripts/build-registry.py\` regenerated successfully (75 plugins)
- [x] \`scripts/validate-registry.ts --step plugin-json --plugins oracle-skills\` — only the existing ajv warning (non-blocking)
- [x] \`scripts/validate-registry.ts --step license --plugins oracle-skills\` — MIT OK
- [x] \`scripts/validate-registry.ts --step source-format --plugins oracle-skills\` — clean
- [x] \`maw plugin install --link\` succeeds
- [x] \`maw oracle-skills about\` outputs identical to \`arra-oracle-skills about\`
- [x] \`maw oracle-skills agents\` — \`diff\` against direct CLI: identical
- [x] Interactive verb (no args) — preserves stdin/stdout/stderr correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)