### PR TITLE
fix(dream): forgiving --project lookup + case-insensitive -oracle strip

### DIFF
--- a/plugins/dream/dream.test.ts
+++ b/plugins/dream/dream.test.ts
@@ -108,6 +108,10 @@ describe("extractRepo", () => {
     expect(extractRepo("../ghq/github.com/deachawatss/leaf-oracle/.claude/worktrees/agent-abc123/ψ/memory/file.md")).toBe("leaf");
   });
 
+  it("strips -Oracle suffix case-insensitively", () => {
+    expect(extractRepo("../ghq/github.com/Soul-Brews-Studio/DustBoy-Phd-Oracle/ψ/memory/file.md")).toBe("DustBoy-Phd");
+  });
+
   it("returns unknown when no ψ marker", () => {
     expect(extractRepo("/some/random/path/file.md")).toBe("unknown");
   });

--- a/plugins/dream/impl.ts
+++ b/plugins/dream/impl.ts
@@ -134,8 +134,20 @@ async function cmdDreamProject(projectName: string, flags: DreamFlags): Promise<
 
   console.log("  \x1b[90mscanning...\x1b[0m");
   const repos = await scanRepoStates();
-  const repo = repos.find(r => r.name === projectName)
-    || repos.find(r => r.name.toLowerCase().includes(projectName.toLowerCase()));
+  // Forgiving lookup: try directory name, display name, and either
+  // form stripped of -oracle suffix. Substring match (either direction)
+  // as last resort so partial names still resolve.
+  const needleRaw = projectName.toLowerCase();
+  const needleStripped = needleRaw.replace(/-oracle$/, "");
+  const repo =
+    repos.find(r => r.dirName.toLowerCase() === needleRaw) ||
+    repos.find(r => r.name.toLowerCase() === needleRaw) ||
+    repos.find(r => r.name.toLowerCase() === needleStripped) ||
+    repos.find(r => r.dirName.toLowerCase() === needleStripped) ||
+    repos.find(r => {
+      const n = r.name.toLowerCase();
+      return n.includes(needleStripped) || needleStripped.includes(n);
+    });
 
   if (!repo) {
     const known = repos.map(r => r.name).slice(0, 20).join(", ");
@@ -674,7 +686,7 @@ async function scanRepoStates(): Promise<RepoState[]> {
   for (const repoPath of repoPaths) {
     if (!existsSync(repoPath)) continue;
     const dirName = basename(repoPath);
-    const name = dirName.replace(/-oracle$/, "");
+    const name = dirName.replace(/-oracle$/i, "");
     // Extract owner from ghq path (.../github.com/<owner>/<dirName>)
     const pathParts = repoPath.split("/");
     const owner = pathParts[pathParts.length - 2] || "unknown";
@@ -775,7 +787,7 @@ export function extractRepo(sourceFile: string): string {
           if (parts[j] !== ".claude" && parts[j] !== "worktrees") { repoDir = parts[j]!; break; }
         }
       }
-      return repoDir.replace(/-oracle$/, "");
+      return repoDir.replace(/-oracle$/i, "");
     }
   }
   return "unknown";


### PR DESCRIPTION
## Summary

Two UX bugs in dream's project-name resolver, surfaced by post-merge smoke testing.

## Bug 1: \`--project mawjs-oracle\` returned \"not found\"

The lookup compared the user's argument against the \`-oracle\`-stripped display name only (e.g. \`mawjs\`). Users who typed the actual directory name got rejected.

\`\`\`
$ maw dream --project mawjs-oracle
✗ project \"mawjs-oracle\" not found
  known: ..., mawjs, ...    ← but it's right there
\`\`\`

**Fix**: cascade through forgiving matchers:
1. Exact match on \`dirName\` (e.g. \`mawjs-oracle\`)
2. Exact match on \`name\` (stripped display)
3. Exact match against \`projectName\` stripped of \`-oracle\`
4. Substring either direction (so \`maw\` still finds \`mawjs\`)

## Bug 2: \`-oracle\$\` regex case-sensitive

\`scanRepoStates\` and \`extractRepo\` both stripped \`-oracle\$\` with no \`/i\` flag. So:

- \`mawjs-oracle\` (lowercase) → stripped to \`mawjs\` ✓
- \`DustBoy-Phd-Oracle\` (capital O) → stayed as \`DustBoy-Phd-Oracle\` ✗

Display was inconsistent between repos depending on capitalization.

**Fix**: \`/-oracle\$/i\` in both places.

## Test plan

- [x] \`bun test\` → 31/31 pass (added a case-insensitive extractRepo test)
- [x] \`maw dream --project mawjs-oracle\` now resolves successfully (live-tested with linked plugin)
- [x] \`maw dream --project mawjs\` still works (substring fallback preserved)
- [x] No regression in extractRepo tests for lowercase \`-oracle\` paths

## Files

- \`plugins/dream/impl.ts\`: project lookup rewrite (137-138 → 137-149); two \`/-oracle\$/\` → \`/-oracle\$/i\` strips
- \`plugins/dream/dream.test.ts\`: +1 test case for capital-O stripping

🤖 Generated with [Claude Code](https://claude.com/claude-code)