### PR TITLE
feat(wake): add --peer flag for remote dispatch via federation

### DIFF
--- a/plugins/wake/index.ts
+++ b/plugins/wake/index.ts
@@ -32,7 +32,7 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       if (!args[0]) {
         return {
           ok: false,
-          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
+          error: "usage: maw wake <oracle|org/repo|URL> [task] [--task \"<prompt>\"] [--wt <name>] [--fresh] [--attach] [--issue N] [--pr N] [--repo org/name] [--list] [--all-local] [--peer <alias>]\n       maw wake all [--kill]\n       (--new is a deprecated alias for --wt, removed in alpha.114)",
         };
       }
 
@@ -55,7 +55,12 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         "--list": Boolean, "--ls": "--list",
         "--split": Boolean,
         "--all-local": Boolean,
+        "--peer": String,
       }, 1);
+
+      if (flags["--peer"]) {
+        return await forwardToPeer(flags["--peer"], args[0], flags);
+      }
 
       const wakeOpts: {
         task?: string; wt?: string; prompt?: string;
@@ -111,12 +116,21 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     const oracle = body.oracle as string | undefined;
     if (!oracle) return { ok: false, error: "missing oracle name" };
 
-    const wakeOpts: { task?: string; prompt?: string; fresh?: boolean; attach?: boolean } = {};
+    const wakeOpts: {
+      task?: string; prompt?: string; wt?: string;
+      fresh?: boolean; attach?: boolean;
+    } = {};
     if (body.task) wakeOpts.task = body.task as string;
+    if (body.wt) wakeOpts.wt = body.wt as string;
+    if (body.prompt) wakeOpts.prompt = body.prompt as string;
     if (body.issue) {
       const issueNum = body.issue as number;
       wakeOpts.prompt = await fetchGitHubPrompt("issue", issueNum, body.repo as string | undefined);
       if (!wakeOpts.task) wakeOpts.task = `issue-${issueNum}`;
+    } else if (body.pr) {
+      const prNum = body.pr as number;
+      wakeOpts.prompt = await fetchGitHubPrompt("pr", prNum, body.repo as string | undefined);
+      if (!wakeOpts.task) wakeOpts.task = `pr-${prNum}`;
     }
     if (body.fresh) wakeOpts.fresh = true;
     if (body.attach) wakeOpts.attach = true;
@@ -129,4 +143,59 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     console.log = origLog;
     console.error = origError;
   }
+}
+
+/**
+ * Forward a `maw wake` CLI invocation to a federation peer's /api/wake
+ * endpoint instead of spawning a local tmux session. Enables cross-node
+ * agent dispatch (e.g. brain → headless GPU node) without bespoke wrappers.
+ *
+ * Alias lookup goes through `~/.maw/peers.json` (the same store managed by
+ * `maw peers`). Unknown alias surfaces as an `ok: false` plugin error
+ * rather than throwing, so the CLI layer prints a clean message. Network
+ * + non-2xx responses are mapped the same way.
+ *
+ * The forwarded body is a subset of CLI flags translated into the API
+ * handler's vocabulary (above): `oracle`, optional worktree `task`/`wt`,
+ * `prompt`, `issue`/`pr`/`repo`, `fresh`. Attach is intentionally not
+ * forwarded — there is no local tmux to attach to on the remote node.
+ */
+async function forwardToPeer(
+  alias: string,
+  oracle: string,
+  flags: Record<string, any>,
+): Promise<InvokeResult> {
+  const { resolvePeer } = await import("./internal/peer-resolve");
+  const peer = resolvePeer(alias);
+  if (!peer) return { ok: false, error: `unknown peer alias: ${alias} (see: maw peers list)` };
+
+  const positionals: string[] = Array.isArray(flags._) ? flags._ : [];
+  const body: Record<string, unknown> = { oracle };
+  if (positionals.length > 0) body.task = positionals[0];
+  if (flags["--wt"]) body.wt = flags["--wt"];
+  if (flags["--task"]) body.prompt = flags["--task"];
+  if (flags["--issue"]) body.issue = flags["--issue"];
+  if (flags["--pr"]) body.pr = flags["--pr"];
+  if (flags["--repo"]) body.repo = flags["--repo"];
+  if (flags["--fresh"]) body.fresh = true;
+
+  const { callPeerWake } = await import("./internal/peer-call");
+  let res: { ok: boolean; status?: number; data?: any };
+  try {
+    res = await callPeerWake(peer.url, body);
+  } catch (e: any) {
+    return { ok: false, error: `peer wake failed (${alias} ${peer.url}): ${e?.message || e}` };
+  }
+
+  if (!res?.ok) {
+    if (res?.status === 404) {
+      return { ok: false, error: `peer ${alias} does not support /api/wake (HTTP 404 at ${peer.url})` };
+    }
+    const detail = res?.data?.error || (res?.status ? `HTTP ${res.status}` : "no response");
+    return { ok: false, error: `peer wake failed (${alias} ${peer.url}): ${detail}` };
+  }
+
+  const summary = `\x1b[32m⚡\x1b[0m forwarded wake → ${alias} (${peer.url}) — ${oracle}`;
+  const remoteOut = typeof res.data?.output === "string" ? res.data.output : "";
+  return { ok: true, output: remoteOut ? `${summary}\n${remoteOut}` : summary };
 }

--- a/plugins/wake/internal/peer-call.ts
+++ b/plugins/wake/internal/peer-call.ts
@@ -1,0 +1,23 @@
+/**
+ * Cross-node forwarding of `maw wake --peer <alias>` to a peer's /api/wake.
+ *
+ * Thin wrapper over `curlFetch` so the network call can be stubbed in
+ * tests without dragging in the full maw-js/sdk module graph. The
+ * `from: "auto"` option enables federation signing when peer-identity
+ * keys are configured (see ADR docs/federation/0001-peer-identity.md).
+ */
+
+export interface PeerCallResult {
+  ok: boolean;
+  status?: number;
+  data?: any;
+}
+
+export async function callPeerWake(peerUrl: string, body: Record<string, unknown>): Promise<PeerCallResult> {
+  const { curlFetch } = await import("maw-js/sdk");
+  return await curlFetch(`${peerUrl}/api/wake`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    from: "auto",
+  });
+}

--- a/plugins/wake/internal/peer-resolve.ts
+++ b/plugins/wake/internal/peer-resolve.ts
@@ -1,0 +1,40 @@
+/**
+ * Read-only peer alias resolution for `maw wake --peer <alias>`.
+ *
+ * Looks up the URL for a peer alias in `~/.maw/peers.json` (the federation
+ * peers store managed by the `maw peers` plugin). Returns null when the
+ * alias is unknown, the store file is missing, or the file is unreadable —
+ * the caller surfaces an error with the alias name so the operator can
+ * `maw peers add` and retry. Path resolution is a function (not a const)
+ * so tests can override via `PEERS_FILE`.
+ *
+ * Kept minimal on purpose — the full `peers/store.ts` adds atomic writes,
+ * locking, and corruption recovery. None of that is needed for a read-only
+ * URL lookup at dispatch time.
+ */
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export interface ResolvedPeer {
+  url: string;
+  node: string | null;
+}
+
+function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function resolvePeer(alias: string): ResolvedPeer | null {
+  const path = peersPath();
+  if (!existsSync(path)) return null;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+  const peer = parsed?.peers?.[alias];
+  if (!peer || typeof peer.url !== "string") return null;
+  return { url: peer.url, node: typeof peer.node === "string" ? peer.node : null };
+}

--- a/plugins/wake/plugin.json
+++ b/plugins/wake/plugin.json
@@ -6,7 +6,7 @@
   "description": "Spawn or attach to an oracle session",
   "cli": {
     "command": "wake",
-    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--wt <name>] [--fresh] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list]  (--new is deprecated alias for --wt, removed in alpha.114)",
+    "help": "maw wake <oracle|org/repo|URL> [task] [--task '<prompt>'] [--wt <name>] [--fresh] [--no-attach] [--issue N] [--pr N] [--repo org/name] [--list] [--peer <alias>]  (--new is deprecated alias for --wt, removed in alpha.114)",
     "flags": {
       "--wt": "string",
       "--new": "string",
@@ -17,7 +17,8 @@
       "--task": "string",
       "--fresh": "boolean",
       "--no-attach": "boolean",
-      "--list": "boolean"
+      "--list": "boolean",
+      "--peer": "string"
     }
   },
   "api": {

--- a/plugins/wake/wake.test.ts
+++ b/plugins/wake/wake.test.ts
@@ -53,12 +53,37 @@ mock.module(join(src, "commands/shared/wake-resolve"), () => ({
   fetchGitHubPrompt: async (type: string, num: number) => `${type} #${num} prompt`,
 }));
 
+let lastResolveAlias: string | null = null;
+let resolvePeerImpl: (alias: string) => { url: string; node: string | null } | null = () => null;
+mock.module(join(import.meta.dir, "internal/peer-resolve"), () => ({
+  resolvePeer: (alias: string) => {
+    lastResolveAlias = alias;
+    return resolvePeerImpl(alias);
+  },
+}));
+
+let lastPeerCall: { url: string; body: any } | null = null;
+let peerCallImpl: () => any = () => ({ ok: true, status: 200, data: { ok: true, output: "remote-output" } });
+let peerCallThrows: Error | null = null;
+mock.module(join(import.meta.dir, "internal/peer-call"), () => ({
+  callPeerWake: async (url: string, body: any) => {
+    lastPeerCall = { url, body };
+    if (peerCallThrows) throw peerCallThrows;
+    return peerCallImpl();
+  },
+}));
+
 describe("wake plugin", () => {
   let handler: (ctx: InvokeContext) => Promise<any>;
 
   beforeEach(async () => {
     lastWakeCall = null;
     lastWakeAllCall = null;
+    lastResolveAlias = null;
+    lastPeerCall = null;
+    peerCallThrows = null;
+    resolvePeerImpl = () => null;
+    peerCallImpl = () => ({ ok: true, status: 200, data: { ok: true, output: "remote-output" } });
     const mod = await import("./index");
     handler = mod.default;
   });
@@ -154,5 +179,70 @@ describe("wake plugin", () => {
     const result = await handler({ source: "cli", args: ["neo"] });
     expect(result.ok).toBe(true);
     expect(lastWakeCall?.opts.attach).toBeUndefined();
+  });
+
+  it("CLI --peer <alias>: forwards body to peer /api/wake, skips local cmdWake", async () => {
+    resolvePeerImpl = (alias) => alias === "headless" ? { url: "http://10.0.0.5:7777", node: "gpu" } : null;
+    const result = await handler({
+      source: "cli",
+      args: ["neo", "fix-bug", "--peer", "headless", "--task", "go fix it", "--wt", "wt-1", "--fresh"],
+    });
+    expect(result.ok).toBe(true);
+    expect(lastResolveAlias).toBe("headless");
+    expect(lastWakeCall).toBeNull(); // local wake must NOT run
+    expect(lastPeerCall?.url).toBe("http://10.0.0.5:7777");
+    expect(lastPeerCall?.body).toEqual({
+      oracle: "neo",
+      task: "fix-bug",
+      wt: "wt-1",
+      prompt: "go fix it",
+      fresh: true,
+    });
+  });
+
+  it("CLI --peer <unknown>: returns clear error, no fetch attempted", async () => {
+    resolvePeerImpl = () => null;
+    const result = await handler({ source: "cli", args: ["neo", "--peer", "nope"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("unknown peer alias: nope");
+    expect(lastPeerCall).toBeNull();
+    expect(lastWakeCall).toBeNull();
+  });
+
+  it("CLI --peer with peer returning HTTP 404: surfaces 'does not support' error", async () => {
+    resolvePeerImpl = () => ({ url: "http://10.0.0.5:7777", node: "gpu" });
+    peerCallImpl = () => ({ ok: false, status: 404, data: {} });
+    const result = await handler({ source: "cli", args: ["neo", "--peer", "headless"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("does not support /api/wake");
+    expect(lastWakeCall).toBeNull();
+  });
+
+  it("CLI --peer with peer returning HTTP 500: surfaces underlying detail", async () => {
+    resolvePeerImpl = () => ({ url: "http://10.0.0.5:7777", node: "gpu" });
+    peerCallImpl = () => ({ ok: false, status: 500, data: { error: "spawn failed" } });
+    const result = await handler({ source: "cli", args: ["neo", "--peer", "headless"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("peer wake failed");
+    expect(result.error).toContain("spawn failed");
+  });
+
+  it("CLI --peer with network failure: surfaces error", async () => {
+    resolvePeerImpl = () => ({ url: "http://10.0.0.5:7777", node: "gpu" });
+    peerCallThrows = new Error("connection refused");
+    const result = await handler({ source: "cli", args: ["neo", "--peer", "headless"] });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("peer wake failed");
+    expect(result.error).toContain("connection refused");
+  });
+
+  it("API: { oracle, prompt, wt } → cmdWake receives prompt + wt", async () => {
+    const result = await handler({
+      source: "api",
+      args: { oracle: "neo", prompt: "do thing", wt: "wt-99" },
+    });
+    expect(result.ok).toBe(true);
+    expect(lastWakeCall?.opts.prompt).toBe("do thing");
+    expect(lastWakeCall?.opts.wt).toBe("wt-99");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `--peer <alias>` flag to `maw wake`. When set, the wake call is forwarded to the named peer's `/api/wake` endpoint instead of spawning a local tmux session.
- Alias resolution reuses the existing `~/.maw/peers.json` store managed by `maw peers` — no new config surface.
- `/api/wake` body schema extended with `wt`, `prompt`, and `pr` so a forwarded CLI invocation (`--wt`, `--task`, `--pr`) behaves the same on the receiving node as it would locally.

## Motivation
Today `maw wake` is local-only. Federation peers can list/info each other but cannot wake remote sessions, so cross-node orchestrator agents (e.g. `brain` routing work to a headless GPU node or a storage-only node) need bespoke wrappers around the wake CLI. This adds first-class cross-node dispatch over the existing federation transport — `from: \"auto\"` lets the underlying `curlFetch` sign the call when peer-identity keys exist (#804 Step 4).

## Behavior
- `maw wake neo` — unchanged, local tmux spawn.
- `maw wake neo --peer headless` — forwards `{oracle: \"neo\"}` to `<headless.url>/api/wake`.
- `maw wake neo task-name --wt wt-1 --task \"do thing\" --fresh --peer headless` — body is `{oracle, task, wt, prompt, fresh}`.
- Unknown alias → `ok: false` with clear error and a `maw peers list` hint; no fetch attempted.
- Peer returns 404 at `/api/wake` → \"peer does not support /api/wake\" error (so operator can update the remote node).
- Peer returns non-2xx or throws → surfaces underlying detail in the error message.
- `--attach` is intentionally not forwarded — no local tmux on the remote side to attach to.

## Test plan
- [x] New unit tests cover: happy-path body forwarding, unknown alias, HTTP 404, HTTP 5xx with peer-supplied detail, network failure (5 tests, all passing).
- [x] API handler change covered by a new test asserting `{oracle, prompt, wt}` reaches `cmdWake`.
- [x] Existing wake tests still parse and run (the pre-existing 'Scan now?' interactive-prompt hang is issue #42 and is unaffected by this change).
- [x] `bun build` of `plugins/wake/index.ts` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)