### PR TITLE
feat(shellenv): multi-engine shell functions

### DIFF
--- a/plugins/shellenv/src/snippets/zsh.ts
+++ b/plugins/shellenv/src/snippets/zsh.ts
@@ -32,6 +32,28 @@ maw() {
     command maw "$@"
   fi
 }
+# claude() wrapper — auto-fallback when --continue fails (no prior session).
+# Lets \`maw wake\` send a clean \`claude --dangerously-skip-permissions --continue\`
+# instead of a verbose \`{ X || Y; }\` fallback chain.
+claude() {
+  if [[ "$*" == *"--continue"* ]]; then
+    command claude "$@" || command claude "\${@/--continue/}"
+  else
+    command claude "$@"
+  fi
+}
+# claude46 — Opus 4.6 (1M context). Delegates to claude() for --continue fallback.
+claude46() {
+  ANTHROPIC_MODEL="claude-opus-4-6[1m]" claude "$@"
+}
+# claude47 — Opus 4.7. Delegates to claude() for --continue fallback.
+claude47() {
+  ANTHROPIC_MODEL="claude-opus-4-7" claude "$@"
+}
+# thclaws — CLI REPL mode. --accept-all = auto-approve (like --dangerously-skip-permissions).
+thclaws-cli() {
+  thclaws --cli --accept-all "$@"
+}
 # TODO(shellenv): tab completion for 'maw warp' via compdef + 'command maw completions oracles'
 `;
 }


### PR DESCRIPTION
## Summary
- Add `claude()` wrapper with `--continue` fallback (was in installed copy but missing from registry since PR #1229)
- Add `claude46()` — Opus 4.6 (1M context), delegates to `claude()`
- Add `claude47()` — Opus 4.7, delegates to `claude()`
- Add `thclaws-cli()` — thClaws CLI REPL mode

Syncs registry source with installed copy at `~/.maw/plugins/shellenv/`.

## Test plan
- [ ] `maw shellenv zsh | grep claude` shows all three claude functions
- [ ] `maw shellenv zsh | grep thclaws` shows thclaws-cli
- [ ] `source <(maw shellenv zsh) && claude46 --version` uses Opus 4.6
- [ ] `maw wake <oracle> --engine thclaws` launches thclaws in pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)