### PR TITLE
feat(oracle-workon): alpha plugin — port skill to maw CLI

### DIFF
--- a/plugins/oracle-workon/index.ts
+++ b/plugins/oracle-workon/index.ts
@@ -1,0 +1,172 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { execSync } from "child_process";
+import { basename } from "path";
+
+export const command = {
+  name: "oracle-workon",
+  description: "Spawn a worktree team for oracle work — composes maw wake --task --split + maw swarm.",
+};
+
+const HELP = `\x1b[36mmaw oracle-workon\x1b[0m — Spawn a worktree team for oracle work
+
+USAGE
+  maw oracle-workon --task <slug> [--with codex,thclaws]
+                    [--engine claude47] [--tiled] [--prompt '<text>']
+                    [--dry-run] [<oracle>]
+
+FLAGS
+  --task <slug>       worktree branch slug (required)
+  --with <list>       comma-separated extra engines (e.g. codex,thclaws)
+  --engine <name>     leader engine (default: claude47)
+  --tiled             tiled swarm layout instead of split
+  --prompt <text>     initial prompt for the leader
+  --dry-run           print commands without executing
+  --help, -h          show this help
+
+POSITIONAL
+  <oracle>            optional oracle override; auto-detected from cwd
+                      (basename stripped of trailing '-oracle')
+
+EXAMPLES
+  maw oracle-workon --task ship-fix
+  maw oracle-workon --task ship-fix --with codex,thclaws
+  maw oracle-workon --task long-investigation --engine claude46 --with codex
+  maw oracle-workon arra --task ship-cache --with codex --tiled
+  maw oracle-workon --task ship-fix --dry-run
+
+CLEANUP
+  maw done <oracle>-<slug>            full cleanup
+  maw done <oracle>-<slug> --force    skip rrr/git
+`;
+
+function getFlag(args: string[], name: string): string | undefined {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx === args.length - 1) return undefined;
+  return args[idx + 1];
+}
+
+function hasFlag(args: string[], ...names: string[]): boolean {
+  return names.some((n) => args.includes(n));
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (ctx.writer) ctx.writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  try {
+    const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+
+    if (hasFlag(args, "--help", "-h") || args.length === 0) {
+      console.log(HELP);
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (!process.env.TMUX) {
+      console.error("⚠ maw oracle-workon requires tmux (splits need a pane to split FROM).");
+      console.error("  Try: tmux attach -t 01-mawjs   or   tmux new -s play");
+      return { ok: false, error: "not in tmux", output: logs.join("\n") || undefined };
+    }
+
+    const slug = getFlag(args, "--task");
+    if (!slug) {
+      console.error("⚠ --task <slug> is required. Try: maw oracle-workon --task ship-fix");
+      return { ok: false, error: "missing --task", output: logs.join("\n") || undefined };
+    }
+
+    const withList = getFlag(args, "--with") ?? "";
+    const agents = withList ? withList.split(",").map((s) => s.trim()).filter(Boolean) : [];
+    const engine = getFlag(args, "--engine") ?? "claude47";
+    const prompt = getFlag(args, "--prompt");
+    const tiled = hasFlag(args, "--tiled");
+    const dryRun = hasFlag(args, "--dry-run");
+
+    const positional = args.filter((a, i) => {
+      if (a.startsWith("-")) return false;
+      const prev = args[i - 1];
+      if (prev === "--task" || prev === "--with" || prev === "--engine" || prev === "--prompt") return false;
+      return true;
+    });
+
+    let oracle = positional[0];
+    if (!oracle) {
+      const cwdBase = basename(process.cwd());
+      const stripped = cwdBase.replace(/-oracle$/, "");
+      if (stripped === cwdBase) {
+        console.error(`⚠ cwd '${cwdBase}' is not an oracle repo. Pass <oracle> as positional.`);
+        return { ok: false, error: "oracle not detected", output: logs.join("\n") || undefined };
+      }
+      oracle = stripped;
+      console.log(`  auto-detected oracle: ${oracle} (from cwd: ${cwdBase})`);
+    }
+
+    console.log(`  oracle:  ${oracle}`);
+    console.log(`  slug:    ${slug}`);
+    console.log(`  engine:  ${engine}`);
+    console.log(`  agents:  ${agents.length ? agents.join(" ") : "none"}`);
+
+    let leaderCmd = `maw wake ${oracle} --task ${slug} --split --no-attach --engine ${engine}`;
+    if (prompt) leaderCmd += ` --prompt '${prompt.replace(/'/g, "'\\''")}'`;
+
+    const swarmCmd = agents.length
+      ? `maw swarm ${agents.join(" ")}${tiled ? " --tiled" : ""}`
+      : "";
+
+    if (dryRun) {
+      console.log("");
+      console.log(`▶ ${leaderCmd}`);
+      if (swarmCmd) console.log(`▶ (in new pane) ${swarmCmd}`);
+      console.log("");
+      console.log("[dry-run] no changes made.");
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    console.log("");
+    console.log(`▶ ${leaderCmd}`);
+    execSync(leaderCmd, { stdio: "inherit" });
+
+    await new Promise((r) => setTimeout(r, 2000));
+
+    let newPane = "";
+    if (agents.length) {
+      const panes = execSync("tmux list-panes -a -F '#{pane_id} #{pane_title}'", { encoding: "utf8" });
+      const match = panes
+        .split("\n")
+        .find((line: string) => line.toLowerCase().includes(slug.toLowerCase()));
+      if (match) newPane = match.split(" ")[0];
+
+      if (!newPane) {
+        console.error(`⚠ Could not find new pane via title. Check: maw panes --all | grep ${slug}`);
+        console.log("(leader is up; swarm skipped)");
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      console.log(`▶ (in ${newPane}) ${swarmCmd}`);
+      await new Promise((r) => setTimeout(r, 3000));
+      execSync(`maw run ${newPane} '${swarmCmd.replace(/'/g, "'\\''")}'`, { stdio: "inherit" });
+    }
+
+    console.log("");
+    console.log("✓ oracle-workon complete:");
+    console.log(`  oracle:    ${oracle}`);
+    console.log(`  slug:      ${slug}`);
+    console.log(`  leader:    ${newPane || "(check: maw panes)"}`);
+    if (agents.length) console.log(`  agents:    ${agents.join(" ")}`);
+    console.log("");
+    console.log(`  cleanup:   maw done ${oracle}-${slug}`);
+
+    return { ok: true, output: logs.join("\n") || undefined };
+  } catch (e: any) {
+    return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/oracle-workon/plugin.json
+++ b/plugins/oracle-workon/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
+  "name": "oracle-workon",
+  "version": "0.1.0-alpha",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Alpha: Spawn a worktree team for oracle work — composes maw wake --task --split + maw swarm.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "oracle-workon",
+    "aliases": [],
+    "help": "maw oracle-workon --task <slug> [--with codex,thclaws] [--engine claude46] [--tiled] [--dry-run] — spawn a worktree team"
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/plugins/oracle-workon/registry.meta.json
+++ b/plugins/oracle-workon/registry.meta.json
@@ -1,8 +1,11 @@
 {
   "version": "0.1.0-alpha",
+  "source": "soul-brews-studio/maw-plugin-registry/oracle-workon@v0.1.0-alpha-oracle-workon",
+  "sha256": null,
   "summary": "Alpha: Spawn a worktree team for oracle work — composes maw wake + maw swarm",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
-  "addedAt": "2026-05-14T12:00:00Z"
+  "addedAt": "2026-05-14T12:00:00Z",
+  "tier": "extra"
 }

--- a/plugins/oracle-workon/registry.meta.json
+++ b/plugins/oracle-workon/registry.meta.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1.0-alpha",
+  "summary": "Alpha: Spawn a worktree team for oracle work — composes maw wake + maw swarm",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-05-14T12:00:00Z"
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-13T08:09:59Z",
+  "updated": "2026-05-14T05:38:18Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -382,6 +382,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-05-13T13:45:00Z",
+      "tier": "extra"
+    },
+    "oracle-workon": {
+      "version": "0.1.0-alpha",
+      "source": "soul-brews-studio/maw-plugin-registry/oracle-workon@v0.1.0-alpha-oracle-workon",
+      "sha256": null,
+      "summary": "Alpha: Spawn a worktree team for oracle work \u2014 composes maw wake + maw swarm",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-05-14T12:00:00Z",
       "tier": "extra"
     },
     "overview": {


### PR DESCRIPTION
## Summary
- Adds `maw oracle-workon` CLI command as alpha plugin
- Composes existing primitives — `maw wake --task --split` + `maw swarm` + `maw run`
- Zero new business logic, pure delegation
- Auto-detects oracle from cwd (strips `-oracle` suffix)

## Alpha status
Version `0.1.0-alpha`. API may change. Validates "skills first, plugins second" — ported from a Claude Code skill that proved the composition works.

## Implementation
- `plugins/oracle-workon/index.ts` (172 lines, single file — no src/ subdir, like `cleanup`)
- Bun runtime imports (no `node:` prefix)
- Subprocesses out to `maw wake`, `maw swarm`, `maw run` via execSync

## Notes for human review
- **Alias dropped**: spec called for `workon` alias, but `plugins/workon/` already owns that command (different impl). Implementer dropped the alias to avoid runtime registry collision. Worth confirming whether the existing `workon` plugin should be deprecated or these two should coexist.
- **sha256 is null**: no build script computes plugin tarball hashes; matches the convention used by `oracle-skills`, `dream`, `token`, `attach-ssh`.

## Test plan
- [ ] CI green (TypeScript compile)
- [ ] Manual: \`maw oracle-workon --task test --dry-run\` shows expected output
- [ ] Manual: \`maw oracle-workon --task test\` from inside tmux creates worktree + split + leader

## Source skill
\`.claude/skills/oracle-workon/SKILL.md\` in mawjs-oracle vault.
Spec: \`ψ/memory/traces/2026-05-14/1200_oracle-workon-skill-spec.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)