### PR TITLE
feat(kill): cross-node kill via maw kill --peer (#1333)

### DIFF
--- a/plugins/kill/index.ts
+++ b/plugins/kill/index.ts
@@ -25,15 +25,20 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
-      const flags = parseFlags(args, { "--pane": Number }, 0);
+      const flags = parseFlags(args, { "--pane": Number, "--peer": String }, 0);
 
       target = flags._[0];
       if (!target || target === "--help" || target === "-h") {
-        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N]" };
+        return { ok: false, error: "usage: maw kill <target>[:window] [--pane N] [--peer <alias>]" };
       }
       if (target.startsWith("-")) {
         return { ok: false, error: `"${target}" looks like a flag, not a target.\n  usage: maw kill <target>` };
       }
+
+      if (flags["--peer"]) {
+        return await forwardToPeer(flags["--peer"], target, flags);
+      }
+
       opts = { pane: flags["--pane"] };
     } else {
       const body = ctx.args as Record<string, unknown>;
@@ -50,4 +55,50 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     console.log = origLog;
     console.error = origError;
   }
+}
+
+/**
+ * Forward a `maw kill` CLI invocation to a federation peer's /api/kill
+ * endpoint instead of killing a local tmux entity. Mirrors wake's
+ * `forwardToPeer()` — see plugins/wake/index.ts:163.
+ *
+ * Alias lookup goes through `~/.maw/peers.json` (the same store managed by
+ * `maw peers`). Unknown alias surfaces as an `ok: false` plugin error
+ * rather than throwing, so the CLI layer prints a clean message. Network
+ * + non-2xx responses are mapped the same way.
+ *
+ * The forwarded body is `{ target, pane? }` — the same shape the API
+ * branch of this handler accepts on the peer side.
+ */
+async function forwardToPeer(
+  alias: string,
+  target: string,
+  flags: Record<string, any>,
+): Promise<InvokeResult> {
+  const { resolvePeer } = await import("./internal/peer-resolve");
+  const peer = resolvePeer(alias);
+  if (!peer) return { ok: false, error: `unknown peer alias: ${alias} (see: maw peers list)` };
+
+  const body: Record<string, unknown> = { target };
+  if (typeof flags["--pane"] === "number") body.pane = flags["--pane"];
+
+  const { callPeerKill } = await import("./internal/peer-call");
+  let res: { ok: boolean; status?: number; data?: any };
+  try {
+    res = await callPeerKill(peer.url, body);
+  } catch (e: any) {
+    return { ok: false, error: `peer kill failed (${alias} ${peer.url}): ${e?.message || e}` };
+  }
+
+  if (!res?.ok) {
+    if (res?.status === 404) {
+      return { ok: false, error: `peer ${alias} does not support /api/kill (HTTP 404 at ${peer.url})` };
+    }
+    const detail = res?.data?.error || (res?.status ? `HTTP ${res.status}` : "no response");
+    return { ok: false, error: `peer kill failed (${alias} ${peer.url}): ${detail}` };
+  }
+
+  const summary = `\x1b[32m✓\x1b[0m forwarded kill → ${alias} (${peer.url}) — ${target}`;
+  const remoteOut = typeof res.data?.output === "string" ? res.data.output : "";
+  return { ok: true, output: remoteOut ? `${summary}\n${remoteOut}` : summary };
 }

--- a/plugins/kill/internal/peer-call.ts
+++ b/plugins/kill/internal/peer-call.ts
@@ -1,0 +1,28 @@
+/**
+ * Cross-node forwarding of `maw kill --peer <alias>` to a peer's /api/kill.
+ *
+ * Thin wrapper over `curlFetch` so the network call can be stubbed in
+ * tests without dragging in the full maw-js/sdk module graph. The
+ * `from: "auto"` option enables federation signing when peer-identity
+ * keys are configured (see ADR docs/federation/0001-peer-identity.md).
+ *
+ * Mirrors plugins/wake/internal/peer-call.ts. Endpoint is `POST /api/kill`
+ * — declared in this plugin's own plugin.json and served by the maw-js
+ * plugin registry router on the peer node. Body shape matches the API
+ * branch of plugins/kill/index.ts: `{ target: string, pane?: number }`.
+ */
+
+export interface PeerCallResult {
+  ok: boolean;
+  status?: number;
+  data?: any;
+}
+
+export async function callPeerKill(peerUrl: string, body: Record<string, unknown>): Promise<PeerCallResult> {
+  const { curlFetch } = await import("maw-js/sdk");
+  return await curlFetch(`${peerUrl}/api/kill`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    from: "auto",
+  });
+}

--- a/plugins/kill/internal/peer-resolve.ts
+++ b/plugins/kill/internal/peer-resolve.ts
@@ -1,0 +1,38 @@
+/**
+ * Read-only peer alias resolution for `maw kill --peer <alias>`.
+ *
+ * Mirrors plugins/wake/internal/peer-resolve.ts in shape — reads the same
+ * `~/.maw/peers.json` store managed by `maw peers add/list/rm`. Path
+ * resolution is a function (not a const) so tests can override via
+ * `PEERS_FILE`.
+ *
+ * Kept minimal on purpose — the full `peers/store.ts` adds atomic writes,
+ * locking, and corruption recovery. None of that is needed for a read-only
+ * URL lookup at dispatch time.
+ */
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export interface ResolvedPeer {
+  url: string;
+  node: string | null;
+}
+
+function peersPath(): string {
+  return process.env.PEERS_FILE || join(homedir(), ".maw", "peers.json");
+}
+
+export function resolvePeer(alias: string): ResolvedPeer | null {
+  const path = peersPath();
+  if (!existsSync(path)) return null;
+  let parsed: any;
+  try {
+    parsed = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return null;
+  }
+  const peer = parsed?.peers?.[alias];
+  if (!peer || typeof peer.url !== "string") return null;
+  return { url: peer.url, node: typeof peer.node === "string" ? peer.node : null };
+}

--- a/plugins/kill/kill.test.ts
+++ b/plugins/kill/kill.test.ts
@@ -1,0 +1,308 @@
+/**
+ * kill — peer extension tests (#1333).
+ *
+ * Covers the cross-node kill added on top of the existing local `maw kill`:
+ *   • no --peer → existing local cmdKill (backward compat preserved)
+ *   • --peer <alias> resolved against ~/.maw/peers.json (PEERS_FILE override)
+ *   • curlFetch is called with POST `${peerUrl}/api/kill` + from:"auto"
+ *   • --pane forwarded into the JSON body when --peer set
+ *   • 4xx / 5xx / throw surface a clean { ok:false, error } (no stack trace)
+ *
+ * Mocking strategy:
+ *   • bun:test `mock.module` stubs `maw-js/sdk` (curlFetch) and `./impl`
+ *     (cmdKill) so tests don't touch tmux, the real fleet, or the network.
+ *   • `PEERS_FILE` env var (honored by peer-resolve.ts) points at a temp
+ *     peers.json so each test gets an isolated alias registry.
+ *
+ * Mirrors plugins/ls/ls.test.ts in shape — same fixtures, same mock pattern.
+ */
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { writeFileSync, existsSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type { InvokeContext } from "maw-js/plugin/types";
+
+// ---------------------------------------------------------------------------
+// Module mocks — registered BEFORE handler import so the dynamic imports
+// inside index.ts / peer-call.ts resolve to these stubs.
+// ---------------------------------------------------------------------------
+interface MockFetchResult {
+  ok: boolean;
+  status?: number;
+  data?: any;
+}
+const curlFetchMock = mock(
+  async (_url: string, _opts: any): Promise<MockFetchResult> => ({
+    ok: true,
+    status: 200,
+    data: { ok: true },
+  }),
+);
+const cmdKillMock = mock(async (_target: string, _opts?: { pane?: number }) => {
+  // Mimic real cmdKill side effect: emit a confirmation line so the handler's
+  // logs array captures something — exercises the console.log -> ctx.writer
+  // plumbing.
+  console.log("local kill (mock)");
+});
+
+mock.module("maw-js/sdk", () => ({ curlFetch: curlFetchMock }));
+mock.module("./impl", () => ({ cmdKill: cmdKillMock }));
+
+// Now safe to import the plugin — its top-level `import { cmdKill } from "./impl"`
+// and the dynamic `import("maw-js/sdk")` inside peer-call.ts will both pick up
+// the mocks above.
+import handler, { command } from "./index";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+let peersDir: string;
+let peersFile: string;
+
+function writePeers(peers: Record<string, { url?: string; node?: string }>) {
+  writeFileSync(peersFile, JSON.stringify({ peers }, null, 2));
+}
+
+beforeEach(() => {
+  peersDir = mkdtempSync(join(tmpdir(), "mpr-kill-test-"));
+  peersFile = join(peersDir, "peers.json");
+  process.env.PEERS_FILE = peersFile;
+  curlFetchMock.mockClear();
+  cmdKillMock.mockClear();
+});
+
+afterEach(() => {
+  if (existsSync(peersDir)) rmSync(peersDir, { recursive: true, force: true });
+  delete process.env.PEERS_FILE;
+});
+
+// ---------------------------------------------------------------------------
+// 1. Smoke
+// ---------------------------------------------------------------------------
+describe("kill plugin — smoke", () => {
+  it("exports command metadata", () => {
+    expect(command.name).toBe("kill");
+    expect(command.description).toBeTruthy();
+  });
+
+  it("--help / no target → usage block mentioning --peer", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--help"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("maw kill");
+    expect(res.error ?? "").toContain("--peer");
+    expect(curlFetchMock).not.toHaveBeenCalled();
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("bare flag-looking target → 'looks like a flag' guard", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--bogus"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("looks like a flag");
+    expect(curlFetchMock).not.toHaveBeenCalled();
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Local path (existing behavior preserved — backward compat)
+// ---------------------------------------------------------------------------
+describe("kill plugin — local path (existing behavior)", () => {
+  it("CLI bare target → cmdKill(target, {pane:undefined}), no peer dispatch", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(true);
+    expect(cmdKillMock).toHaveBeenCalledTimes(1);
+    expect(cmdKillMock.mock.calls[0][0]).toBe("mawjs");
+    expect(cmdKillMock.mock.calls[0][1]).toEqual({ pane: undefined });
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("CLI target:window → cmdKill receives the full composite target", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs:1"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(true);
+    expect(cmdKillMock).toHaveBeenCalledTimes(1);
+    expect(cmdKillMock.mock.calls[0][0]).toBe("mawjs:1");
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("CLI --pane N → forwarded to cmdKill({pane:N})", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--pane", "2"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(true);
+    expect(cmdKillMock).toHaveBeenCalledTimes(1);
+    expect(cmdKillMock.mock.calls[0][0]).toBe("mawjs");
+    expect(cmdKillMock.mock.calls[0][1]).toEqual({ pane: 2 });
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("API source (non-CLI) → cmdKill called from body, never dispatches peer", async () => {
+    const ctx: InvokeContext = { source: "api", args: { target: "mawjs", pane: 3 } as any };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(true);
+    expect(cmdKillMock).toHaveBeenCalledTimes(1);
+    expect(cmdKillMock.mock.calls[0][0]).toBe("mawjs");
+    expect(cmdKillMock.mock.calls[0][1]).toEqual({ pane: 3 });
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("API source missing target → ok:false 'target is required'", async () => {
+    const ctx: InvokeContext = { source: "api", args: {} as any };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("target is required");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. --peer dispatch (cross-node)
+// ---------------------------------------------------------------------------
+describe("kill plugin — --peer dispatch", () => {
+  it("unknown peer alias → { ok:false } with 'unknown peer alias', NEVER falls through to local kill", async () => {
+    writePeers({}); // empty registry on disk
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "ghost-peer"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("unknown peer alias");
+    expect(res.error ?? "").toContain("ghost-peer");
+    // critical: must NOT silently fall through to local kill
+    expect(cmdKillMock).not.toHaveBeenCalled();
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("unknown peer (no peers.json at all) → also clean error, no local fall-through", async () => {
+    // PEERS_FILE points at a path that doesn't exist (no writePeers call)
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "whoever"] };
+    const res = await handler(ctx);
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("unknown peer alias");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+    expect(curlFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("known peer → curlFetch hits POST `${url}/api/kill` with from:'auto' + JSON body", async () => {
+    writePeers({ "white-wg": { url: "http://10.0.0.5:47777", node: "m5" } });
+    curlFetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true, output: "killed session mawjs on m5" },
+    }));
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "white-wg"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(true);
+    expect(curlFetchMock).toHaveBeenCalledTimes(1);
+    const [url, opts] = curlFetchMock.mock.calls[0];
+    expect(url).toBe("http://10.0.0.5:47777/api/kill");
+    expect(opts.method).toBe("POST");
+    expect(opts.from).toBe("auto"); // federation signing, not hand-rolled HMAC
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ target: "mawjs" });
+    expect(res.output ?? "").toContain("white-wg");
+    expect(res.output ?? "").toContain("mawjs");
+    // local must NOT have run
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("known peer + --pane → pane forwarded in JSON body", async () => {
+    writePeers({ "white-wg": { url: "http://10.0.0.5:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true },
+    }));
+
+    const ctx: InvokeContext = {
+      source: "cli",
+      args: ["mawjs:0", "--pane", "1", "--peer", "white-wg"],
+    };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(true);
+    expect(curlFetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(curlFetchMock.mock.calls[0][1].body);
+    expect(body).toEqual({ target: "mawjs:0", pane: 1 });
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("peer 5xx → graceful { ok:false }, error includes alias + url + detail", async () => {
+    writePeers({ "white-wg": { url: "http://10.0.0.5:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => ({
+      ok: false,
+      status: 503,
+      data: { error: "service unavailable" },
+    }));
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "white-wg"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("white-wg");
+    expect(res.error ?? "").toContain("service unavailable");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("peer 404 → 'does not support /api/kill' guidance", async () => {
+    writePeers({ "old-node": { url: "http://10.0.0.6:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => ({ ok: false, status: 404 }));
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "old-node"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("/api/kill");
+    expect(res.error ?? "").toContain("404");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("peer non-2xx with no body.error → falls back to 'HTTP <status>' detail", async () => {
+    writePeers({ "weird": { url: "http://10.0.0.8:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => ({ ok: false, status: 418 }));
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "weird"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("weird");
+    expect(res.error ?? "").toContain("HTTP 418");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("curlFetch throws (DNS/network) → caught + surfaced cleanly with alias", async () => {
+    writePeers({ "dns-fail": { url: "http://nope.invalid:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => {
+      throw new Error("ENOTFOUND");
+    });
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "dns-fail"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(false);
+    expect(res.error ?? "").toContain("ENOTFOUND");
+    expect(res.error ?? "").toContain("dns-fail");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+
+  it("peer success with no remote output → still ok:true with local summary", async () => {
+    writePeers({ "white-wg": { url: "http://10.0.0.5:47777" } });
+    curlFetchMock.mockImplementationOnce(async () => ({
+      ok: true,
+      status: 200,
+      data: { ok: true }, // no `output` field
+    }));
+
+    const ctx: InvokeContext = { source: "cli", args: ["mawjs", "--peer", "white-wg"] };
+    const res = await handler(ctx);
+
+    expect(res.ok).toBe(true);
+    expect(res.output ?? "").toContain("forwarded kill");
+    expect(res.output ?? "").toContain("white-wg");
+    expect(res.output ?? "").toContain("mawjs");
+    expect(cmdKillMock).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/kill/plugin.json
+++ b/plugins/kill/plugin.json
@@ -1,14 +1,15 @@
 {
   "name": "kill",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "description": "Kill a tmux session, window, or pane (trusts the user — no --force).",
   "cli": {
     "command": "kill",
-    "help": "maw kill <target>[:window] [--pane N]",
+    "help": "maw kill <target>[:window] [--pane N] [--peer <alias>]",
     "flags": {
-      "--pane": "number"
+      "--pane": "number",
+      "--peer": "string"
     }
   },
   "api": {


### PR DESCRIPTION
## Summary

Adds `--peer <alias>` to `maw kill`, mirroring the pattern shipped for `maw wake` in mpr #65 and `maw ls` in the recent ls --peer PR.

- `maw kill <target> --peer <alias>` → forwards to peer's `POST /api/kill` via `curlFetch` from `maw-js/sdk` with `from: "auto"` (federation signing when peer-identity keys configured).
- `maw kill <target>:<pane> --peer <alias>` → forwards (whole target string + parsed `pane`).
- `maw kill <target>` (no `--peer`) → existing **local** kill behavior unchanged.
- Unknown peer alias → `ok:false` with clear error referencing `maw peers list`.

Closes Soul-Brews-Studio/maw-js#1333

Issue: https://github.com/Soul-Brews-Studio/maw-js/issues/1333

## Endpoint

- **POST `/api/kill`** with body `{ target: string, pane?: number }` — confirmed against this plugin's API branch and `plugins/wake` pattern.
- Reuses `curlFetch` from `maw-js/sdk` with `from: "auto"` — no hand-rolled signing.

## Pattern

Direct mirror of wake's `--peer` (mpr #65):

- `plugins/kill/internal/peer-resolve.ts` — alias → peer URL lookup (copy of wake's shape).
- `plugins/kill/internal/peer-call.ts` — thin `curlFetch` wrapper hitting `POST /api/kill`.
- `plugins/kill/index.ts` — parses `--peer` flag, dispatches to `callPeerKill` when present.

## Backward compatibility

Bare `maw kill X` and `maw kill X:N` paths are byte-for-byte unchanged. The `--peer` flag is opt-in; absence routes to the existing local handler.

## Tests

`bun test plugins/kill/kill.test.ts` — **17 tests, 0 failures, 77 expect() calls**.

Coverage includes:

- No `--peer` → local kill called (backward compat).
- `--peer <unknown>` → `ok:false`, error mentions `maw peers list`.
- `--peer <known>` + valid target → `curlFetch` invoked with correct URL + `from:"auto"`.
- Peer 5xx response → graceful `ok:false`, error includes alias.
- `curlFetch` throws (network) → `ok:false`, error surfaced.
- `--pane` flag forwarded in body when `--peer` set; still works locally.

## Plugin version

`plugin.json` bumped 1.0.0 → 1.1.0 (semver — mpr does not use CalVer).

## Files

- `plugins/kill/index.ts` (modified)
- `plugins/kill/plugin.json` (1.0.0 → 1.1.0, `--peer` flag declared)
- `plugins/kill/internal/peer-resolve.ts` (new)
- `plugins/kill/internal/peer-call.ts` (new)
- `plugins/kill/kill.test.ts` (new)

## Test plan

- [x] `bun test plugins/kill/kill.test.ts` green (17/17)
- [ ] CI green on PR
- [ ] Human review before merge — **do not auto-merge**

🤖 Generated with [Claude Code](https://claude.com/claude-code)