### PR TITLE
fix(team): support worktree cwd and enter

### DIFF
--- a/plugins/team/index.ts
+++ b/plugins/team/index.ts
@@ -7,6 +7,7 @@ import {
   cmdTeamSend, cmdTeamResume, cmdTeamLives,
 } from "./impl";
 import { parseFlags } from "maw-js/cli/parse-args";
+import { hostExec } from "maw-js/sdk";
 
 export const command = {
   name: "team",
@@ -26,6 +27,22 @@ export const command = {
 function resolveTeamFromContext(): string {
   const envTeam = process.env.MAW_TEAM;
   if (envTeam) return envTeam;
+
+  if (process.env.TMUX) {
+    try {
+      const sessionName = Bun.spawnSync({
+        cmd: ["tmux", "display-message", "-p", "#{session_name}"],
+        stdout: "pipe",
+        stderr: "pipe",
+      }).stdout.toString().trim();
+      const teamName = sessionName.replace(/^\d+-/, "");
+      const teamsDir = join(homedir(), ".claude/teams");
+      if (teamName && existsSync(join(teamsDir, teamName, "config.json"))) {
+        return teamName;
+      }
+    } catch { /* not in tmux or tmux failed */ }
+  }
+
   const teamsDir = join(homedir(), ".claude/teams");
   try {
     const live = readdirSync(teamsDir).filter(d =>
@@ -62,20 +79,33 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
       cmdTeamCreate(args[1], { description });
     } else if (sub === "spawn") {
       if (!args[1] || !args[2]) {
-        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--prompt <text>] [--exec]");
+        logs.push("usage: maw team spawn <team> <role> [--model <model>] [--cwd <path>] [--worktree <path>] [--prompt <text>] [--exec]");
         return { ok: false, error: "team and role required", output: logs.join("\n") };
       }
       const modelIdx = args.indexOf("--model");
       const model = modelIdx !== -1 ? args[modelIdx + 1] : undefined;
+      const cwdIdx = args.indexOf("--cwd");
+      const worktreeIdx = args.indexOf("--worktree");
+      const cwd = cwdIdx !== -1 ? args[cwdIdx + 1] : (worktreeIdx !== -1 ? args[worktreeIdx + 1] : undefined);
       const promptIdx = args.indexOf("--prompt");
       const exec = args.includes("--exec");
-      // --prompt is greedy to end-of-argv; strip --exec if it appears in the tail
+      // --prompt is greedy to end-of-argv; strip known flags if they appear in the tail.
       let prompt: string | undefined;
       if (promptIdx !== -1) {
-        const tail = args.slice(promptIdx + 1).filter(a => a !== "--exec");
+        const rawTail = args.slice(promptIdx + 1);
+        const tail: string[] = [];
+        for (let i = 0; i < rawTail.length; i++) {
+          const a = rawTail[i];
+          if (a === "--exec") continue;
+          if (a === "--model" || a === "--cwd" || a === "--worktree") {
+            i++;
+            continue;
+          }
+          tail.push(a);
+        }
         prompt = tail.join(" ") || undefined;
       }
-      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec });
+      await cmdTeamSpawn(args[1], args[2], { model, prompt, exec, cwd });
     } else if (sub === "send" || sub === "msg") {
       if (!args[1] || !args[2] || !args[3]) {
         logs.push("usage: maw team send <team> <agent> <message>");
@@ -218,9 +248,37 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
         || resolveTeamFromContext();
       cmdOracleMembers(team);
 
+    } else if (sub === "enter" || sub === "send-enter") {
+      // maw team enter <agent|all> — submit pending input in agent pane(s)
+      const agent = args[1];
+      if (!agent) {
+        logs.push("usage: maw team enter <agent|all>");
+        return { ok: false, error: "agent required", output: logs.join("\n") };
+      }
+      const teamName = resolveTeamFromContext();
+      const { loadTeam } = await import("./team-helpers");
+      const team = loadTeam(teamName);
+      if (!team) {
+        logs.push(`\x1b[33m⚠\x1b[0m team '${teamName}' not found`);
+        return { ok: false, error: "team not found", output: logs.join("\n") };
+      }
+      const members = team.members.filter(m =>
+        m.tmuxPaneId && m.agentType !== "team-lead" &&
+        (agent === "all" || m.name === agent || m.agentId === agent || m.agentId === `${agent}@${teamName}`)
+      );
+      if (!members.length) {
+        logs.push(`\x1b[33m⚠\x1b[0m agent '${agent}' not found or no pane ID`);
+        logs.push(`Available: ${team.members.filter(m => m.tmuxPaneId).map(m => m.name).join(", ") || "none"}`);
+        return { ok: false, error: "agent not found", output: logs.join("\n") };
+      }
+      for (const m of members) {
+        await hostExec(`tmux send-keys -t '${m.tmuxPaneId}' Enter`);
+        console.log(`\x1b[36m↵\x1b[0m enter sent to ${m.agentId || m.name}`);
+      }
+
     } else {
       logs.push(`unknown team subcommand: ${sub}`);
-      logs.push("usage: maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members>");
+      logs.push("usage: maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>");
       return { ok: false, error: `unknown subcommand: ${sub}`, output: logs.join("\n") };
     }
 

--- a/plugins/team/plugin.json
+++ b/plugins/team/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "team",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "description": "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
@@ -10,7 +10,7 @@
     "aliases": [
       "t"
     ],
-    "help": "maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members>"
+    "help": "maw team <create|spawn|send|shutdown|resume|lives|list|status|add|tasks|done|assign|delete|invite|oracle-invite|oracle-remove|members|enter>"
   },
   "weight": 50,
   "license": "MIT",

--- a/plugins/team/registry.meta.json
+++ b/plugins/team/registry.meta.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.1.0",
-  "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.0-team",
-  "sha256": "7e09168f18aac770a550d2046a582849323551732de8364bee01930e04988bbd",
-  "summary": "Agent reincarnation engine \u2014 create, spawn, send, shutdown, resume, lives.",
+  "version": "0.1.1",
+  "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.1-team",
+  "sha256": null,
+  "summary": "Agent team engine with worktree cwd spawn, inbox send, status, tasks, and pane submit.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/plugins/team/team-lifecycle.ts
+++ b/plugins/team/team-lifecycle.ts
@@ -165,7 +165,7 @@ export function cmdTeamCreate(name: string, opts: { description?: string } = {})
 export async function cmdTeamSpawn(
   teamName: string,
   role: string,
-  opts: { model?: string; prompt?: string; exec?: boolean } = {},
+  opts: { model?: string; prompt?: string; exec?: boolean; cwd?: string } = {},
 ) {
   const PSI = resolvePsi();
   const teamDir = join(PSI, "memory", "mailbox", "teams", teamName);
@@ -202,6 +202,8 @@ export async function cmdTeamSpawn(
 
   // Build spawn prompt
   const model = opts.model || "sonnet";
+  const shellQuote = (s: string) => `'${s.replace(/'/g, "'\\''")}'`;
+  const cwdPrefix = opts.cwd ? `cd ${shellQuote(opts.cwd)} && ` : "";
   const parts: string[] = [];
   parts.push(`You are '${role}' on team '${teamName}'.`);
   if (opts.prompt) parts.push(opts.prompt);
@@ -249,23 +251,23 @@ export async function cmdTeamSpawn(
     if (!process.env.TMUX) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec requires an active tmux session ($TMUX not set).`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
       return;
     }
     try {
       const { hostExec } = await import("maw-js/sdk");
-      const claudeCmd = `claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
+      const claudeCmd = `${cwdPrefix}claude --model ${model} --prompt-file '${promptPath.replace(/'/g, "'\\''")}'`;
       await hostExec(`tmux split-window -h -l 50% '${claudeCmd.replace(/'/g, "'\\''")}'`);
       console.log();
       console.log(`  \x1b[32m✓ --exec\x1b[0m spawned ${role} in a new tmux pane (right, 50%)`);
     } catch (e: any) {
       console.log();
       console.log(`  \x1b[33m⚠\x1b[0m --exec split failed: ${e?.message || e}`);
-      console.log(`  \x1b[36mRun manually:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+      console.log(`  \x1b[36mRun manually:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
     }
     return;
   }
 
   console.log();
-  console.log(`  \x1b[36mRun:\x1b[0m claude --model ${model} --prompt-file "${promptPath}"`);
+  console.log(`  \x1b[36mRun:\x1b[0m ${cwdPrefix}claude --model ${model} --prompt-file "${promptPath}"`);
 }

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-14T05:38:18Z",
+  "updated": "2026-05-14T15:30:21Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -723,10 +723,10 @@
       "tier": "extra"
     },
     "team": {
-      "version": "0.1.0",
-      "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.0-team",
-      "sha256": "7e09168f18aac770a550d2046a582849323551732de8364bee01930e04988bbd",
-      "summary": "Agent reincarnation engine \u2014 create, spawn, send, shutdown, resume, lives.",
+      "version": "0.1.1",
+      "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.1-team",
+      "sha256": null,
+      "summary": "Agent team engine with worktree cwd spawn, inbox send, status, tasks, and pane submit.",
       "author": "Soul-Brews-Studio",
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",


### PR DESCRIPTION
## Summary
- update the community `team` plugin with `maw team spawn --cwd <path>` and `--worktree <path>`
- add `maw team enter <agent|all>` / `send-enter` so operators can submit staged TUI input through maw instead of raw tmux
- bump the registry listing to `0.1.1` and regenerate `registry.json`

This moves the live Somwind team-pane fix into the community registry plugin path instead of keeping it only in maw-js core.

## Verification
- `python3 scripts/build-registry.py`
- `bun -e 'import("./plugins/team/index.ts").then(()=>console.log("registry team import ok"))'`\n- `bun scripts/validate-registry.ts --step license --plugins team`\n- `bun scripts/validate-registry.ts --step source-format --plugins team`\n\n## Known caveat\n- `bun scripts/validate-registry.ts --step plugin-json --plugins team` reports the existing non-blocking warning because `plugins/team/plugin.json` already has a `cli` field while the current schema disallows it.\n