### PR TITLE
feat(done): maw done --all — batch cleanup of non-lead windows

### DIFF
--- a/plugins/done/done.test.ts
+++ b/plugins/done/done.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
-mock.module(join(root, "commands/plugins/done/impl"), () => ({
+mock.module(join(import.meta.dir, "./impl"), () => ({
   cmdDone: async (name: string, opts: { force?: boolean; dryRun?: boolean }) => {
     console.log(`done ${name} force=${!!opts.force} dryRun=${!!opts.dryRun}`);
+  },
+  cmdDoneAll: async (opts: { force?: boolean; dryRun?: boolean }) => {
+    console.log(`done-all force=${!!opts.force} dryRun=${!!opts.dryRun}`);
   },
 }));
 
@@ -34,6 +35,27 @@ describe("done plugin", () => {
     expect(result.output).toContain("dryRun=true");
   });
 
+  it("CLI — --all flag calls cmdDoneAll", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--all"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("done-all");
+  });
+
+  it("CLI — --all --force passes through", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--all", "--force"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("force=true");
+  });
+
+  it("CLI — --all --dry-run passes through", async () => {
+    const ctx: InvokeContext = { source: "cli", args: ["--all", "--dry-run"] };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("dryRun=true");
+  });
+
   it("CLI — missing name returns error", async () => {
     const ctx: InvokeContext = { source: "cli", args: [] };
     const result = await handler(ctx);
@@ -46,6 +68,13 @@ describe("done plugin", () => {
     const result = await handler(ctx);
     expect(result.ok).toBe(true);
     expect(result.output).toContain("done neo-freelance");
+  });
+
+  it("API — all flag calls cmdDoneAll", async () => {
+    const ctx: InvokeContext = { source: "api", args: { all: true } };
+    const result = await handler(ctx);
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("done-all");
   });
 
   it("API — missing name returns error", async () => {

--- a/plugins/done/impl.ts
+++ b/plugins/done/impl.ts
@@ -3,7 +3,7 @@ import { listSessions } from "maw-js/sdk";
 import { getGhqRoot } from "maw-js/config/ghq-root";
 import { FLEET_DIR } from "maw-js/sdk";
 import { takeSnapshot } from "maw-js/sdk";
-import { tmux } from "maw-js/sdk";
+import { tmux, hostExec, scanWorktrees, cleanupWorktree } from "maw-js/sdk";
 import { normalizeTarget } from "maw-js/core/matcher/normalize-target";
 import { signalParentInbox, autoSave } from "./done-autosave";
 import { removeWorktreeViaConfig, removeWorktreeByGhqScan, removeFromFleetConfig } from "./done-worktree";
@@ -79,5 +79,81 @@ export async function cmdDone(windowName_: string, opts: DoneOpts = {}) {
   // Snapshot after done
   takeSnapshot("done").catch(() => {});
 
+  console.log();
+}
+
+/**
+ * maw done --all [--force] [--dry-run]
+ *
+ * Clean up ALL non-lead windows in the current tmux session:
+ * 1. Detect current session
+ * 2. Skip the lead window (index 0)
+ * 3. Run cmdDone for each remaining window (reverse order — highest index first)
+ * 4. Sweep orphan worktrees
+ */
+export async function cmdDoneAll(opts: DoneOpts = {}) {
+  // Resolve current session name
+  let sessionName: string;
+  try {
+    sessionName = (await hostExec("tmux display-message -p '#{session_name}'")).trim();
+  } catch {
+    console.log("  \x1b[31m✗\x1b[0m not inside a tmux session");
+    return;
+  }
+  if (!sessionName) {
+    console.log("  \x1b[31m✗\x1b[0m could not determine current session");
+    return;
+  }
+
+  const sessions = await listSessions();
+  const current = sessions.find(s => s.name === sessionName);
+  if (!current || current.windows.length === 0) {
+    console.log(`  \x1b[90m○\x1b[0m session '${sessionName}' has no windows`);
+    return;
+  }
+
+  // Lead window = index 0; everything else gets cleaned up
+  const leadWindow = current.windows.reduce((a, b) => a.index < b.index ? a : b);
+  const targets = current.windows
+    .filter(w => w.index !== leadWindow.index)
+    .sort((a, b) => b.index - a.index); // reverse order — kill highest first
+
+  if (targets.length === 0) {
+    console.log(`  \x1b[90m○\x1b[0m no non-lead windows in session '${sessionName}'`);
+  } else {
+    console.log(`  \x1b[36m⬡\x1b[0m cleaning ${targets.length} window(s) in '${sessionName}' (keeping lead: ${leadWindow.name})\n`);
+    for (const w of targets) {
+      console.log(`─── done: ${w.name} ───`);
+      try {
+        await cmdDone(w.name, opts);
+      } catch (e: any) {
+        console.error(`  \x1b[33m⚠\x1b[0m failed: ${e.message || e}`);
+      }
+    }
+  }
+
+  // Sweep orphan worktrees
+  if (opts.dryRun) {
+    console.log(`  \x1b[36m⬡\x1b[0m [dry-run] would sweep orphan worktrees`);
+  } else {
+    console.log(`─── sweeping orphan worktrees ───`);
+    try {
+      const worktrees = await scanWorktrees();
+      const orphans = worktrees.filter(w => w.status === "orphan");
+      if (orphans.length === 0) {
+        console.log(`  \x1b[90m○\x1b[0m no orphan worktrees`);
+      } else {
+        for (const o of orphans) {
+          console.log(`  \x1b[36m⏳\x1b[0m cleaning orphan: ${o.name}`);
+          const log = await cleanupWorktree(o.path);
+          for (const line of log) console.log(`  ${line}`);
+        }
+      }
+    } catch (e: any) {
+      console.error(`  \x1b[33m⚠\x1b[0m orphan sweep failed: ${e.message || e}`);
+    }
+  }
+
+  takeSnapshot("done-all").catch(() => {});
   console.log();
 }

--- a/plugins/done/index.ts
+++ b/plugins/done/index.ts
@@ -1,5 +1,5 @@
 import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
-import { cmdDone } from "./impl";
+import { cmdDone, cmdDoneAll } from "./impl";
 
 export const command = {
   name: ["done", "finish"],
@@ -19,31 +19,43 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
     else logs.push(a.map(String).join(" "));
   };
   try {
-    let name: string;
     let force: boolean | undefined;
     let dryRun: boolean | undefined;
+    let all: boolean | undefined;
 
     if (ctx.source === "cli") {
       const args = ctx.args as string[];
-      // Find first non-flag arg
-      const positional = args.filter(a => !a.startsWith("--"));
-      if (!positional[0]) {
-        return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run]" };
-      }
-      name = positional[0];
       force = args.includes("--force");
       dryRun = args.includes("--dry-run");
+      all = args.includes("--all");
+
+      if (all) {
+        await cmdDoneAll({ force, dryRun });
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      const positional = args.filter(a => !a.startsWith("--"));
+      if (!positional[0]) {
+        return { ok: false, error: "usage: maw done <window-name> [--force] [--dry-run]\n       maw done --all [--force] [--dry-run]" };
+      }
+      await cmdDone(positional[0], { force, dryRun });
     } else {
       const args = ctx.args as Record<string, unknown>;
-      if (!args.name) {
-        return { ok: false, error: "name is required" };
-      }
-      name = args.name as string;
       force = args.force as boolean | undefined;
       dryRun = args.dryRun as boolean | undefined;
+      all = args.all as boolean | undefined;
+
+      if (all) {
+        await cmdDoneAll({ force, dryRun });
+        return { ok: true, output: logs.join("\n") || undefined };
+      }
+
+      if (!args.name) {
+        return { ok: false, error: "name is required (or pass all: true)" };
+      }
+      await cmdDone(args.name as string, { force, dryRun });
     }
 
-    await cmdDone(name, { force, dryRun });
     return { ok: true, output: logs.join("\n") || undefined };
   } catch (e: any) {
     return { ok: false, error: logs.join("\n") || e.message, output: logs.join("\n") || undefined };

--- a/plugins/done/plugin.json
+++ b/plugins/done/plugin.json
@@ -10,7 +10,7 @@
     "aliases": [
       "finish"
     ],
-    "help": "maw done <window-name> [--force] [--dry-run] — clean up a finished worktree"
+    "help": "maw done <window-name> [--force] [--dry-run] | maw done --all [--force] [--dry-run]"
   },
   "api": {
     "path": "/api/done",


### PR DESCRIPTION
## Summary
- Adds `--all` flag to `maw done` that iterates all non-lead windows in the current tmux session
- Runs the full done lifecycle on each (rrr → commit → push → reunion → kill → worktree remove)
- Sweeps orphan worktrees after all windows cleaned
- Supports `--force` and `--dry-run` pass-through
- CLI and API paths both supported

Closes Soul-Brews-Studio/maw-js#1380 (partial — tile resume/idempotent spawn is separate)

## Test plan
- [x] `bun test plugins/done/done.test.ts` — 10/10 pass
- [x] CLI `--all`, `--all --force`, `--all --dry-run` tested
- [x] API `all: true` tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)