### PR TITLE
feat(plugin): add maw fck correction plugin

### DIFF
--- a/plugins/fck/fck.test.ts
+++ b/plugins/fck/fck.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { correct, parseFckArgs, staticCorrection, type Runner } from "./impl";
+import handler from "./index";
+
+const okRunner = (calls: string[][]): Runner => async (argv) => {
+  calls.push(argv);
+  if (argv[0] === "thefuck") return { code: 0, stdout: "git push --set-upstream origin main\n", stderr: "" };
+  if (argv[0] === "sh") return { code: 0, stdout: "done\n", stderr: "" };
+  return { code: 127, stdout: "", stderr: "not found" };
+};
+
+describe("fck parser", () => {
+  test("parses explicit command/output flags", () => {
+    expect(parseFckArgs(["--command", "maw bud x --orgs acme", "--stderr", "Unknown flag --orgs. Did you mean --org?", "--json"])).toMatchObject({
+      command: "maw bud x --orgs acme",
+      stderr: "Unknown flag --orgs. Did you mean --org?",
+      json: true,
+    });
+  });
+});
+
+describe("maw-static provider", () => {
+  test("turns disabled plugin hint into maw plugin enable command", () => {
+    const hit = staticCorrection({
+      command: "maw ls",
+      stderr: "✗ 'shellenv' is installed but disabled.\n  Run: maw plugin enable shellenv",
+    });
+    expect(hit?.candidate).toBe("maw plugin enable shellenv");
+    expect(hit?.source).toBe("maw-static:disabled-plugin");
+  });
+
+  test("rewrites unknown flag from maw suggestion", () => {
+    const hit = staticCorrection({
+      command: "maw bud demo --orgs laris-co",
+      stderr: "Unknown flag --orgs. Did you mean --org?",
+    });
+    expect(hit?.candidate).toBe("maw bud demo --org laris-co");
+  });
+
+  test("rewrites unknown maw command from did-you-mean", () => {
+    const hit = staticCorrection({
+      command: "maw brng mawjs",
+      stderr: "error: unknown command: brng\n  hint: did you mean: bring?",
+    });
+    expect(hit?.candidate).toBe("maw bring mawjs");
+  });
+});
+
+describe("upstream wrapper and execution", () => {
+  test("uses upstream thefuck when static provider misses", async () => {
+    const calls: string[][] = [];
+    const result = await correct({ command: "git push" }, okRunner(calls));
+    expect(result.ok).toBe(true);
+    expect(result.source).toBe("thefuck");
+    expect(result.candidate).toBe("git push --set-upstream origin main");
+    expect(calls[0]).toEqual(["thefuck", "--", "git", "push"]);
+  });
+
+  test("execute requires explicit --yes", async () => {
+    const calls: string[][] = [];
+    const blocked = await correct({ command: "git push", execute: true }, okRunner(calls));
+    expect(blocked.error).toContain("without --yes");
+    const executed = await correct({ command: "git push", execute: true, yes: true }, okRunner(calls));
+    expect(executed.executed?.code).toBe(0);
+    expect(calls.some((c) => c[0] === "sh" && c[1] === "-lc")).toBe(true);
+  });
+});
+
+describe("handler", () => {
+  test("returns JSON corrections", async () => {
+    const res = await handler({ source: "cli", args: ["--command", "maw ls", "--stderr", "✗ 'shellenv' is installed but disabled. Run: maw plugin enable shellenv", "--json"] });
+    expect(res.ok).toBe(true);
+    expect(JSON.parse(res.output!).candidate).toBe("maw plugin enable shellenv");
+  });
+
+  test("lists providers", async () => {
+    const res = await handler({ source: "cli", args: ["--list"] });
+    expect(res.ok).toBe(true);
+    expect(res.output).toContain("maw-static");
+  });
+});

--- a/plugins/fck/impl.ts
+++ b/plugins/fck/impl.ts
@@ -1,0 +1,244 @@
+export type RunResult = { code: number; stdout: string; stderr: string };
+export type Runner = (argv: string[], opts?: { stdin?: string }) => Promise<RunResult>;
+
+export type FckOptions = {
+  command?: string;
+  stdout?: string;
+  stderr?: string;
+  json?: boolean;
+  execute?: boolean;
+  yes?: boolean;
+  ai?: boolean;
+  list?: boolean;
+  installShell?: boolean;
+};
+
+export type Correction = {
+  ok: boolean;
+  candidate?: string;
+  source?: string;
+  confidence?: number;
+  risk?: "low" | "medium" | "high";
+  rationale?: string;
+  requiresConfirmation?: boolean;
+  error?: string;
+  installHint?: string;
+  executed?: RunResult;
+};
+
+const MAX_TEXT = 8_000;
+
+export function parseFckArgs(args: string[]): FckOptions {
+  const opts: FckOptions = {};
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    const readValue = (name: string): string => {
+      const inline = arg.startsWith(`${name}=`) ? arg.slice(name.length + 1) : undefined;
+      if (inline !== undefined) return inline;
+      const value = args[++i];
+      if (!value || value.startsWith("--")) throw new Error(`${name} requires a value`);
+      return value;
+    };
+    if (arg === "--command" || arg.startsWith("--command=")) opts.command = readValue("--command");
+    else if (arg === "--stderr" || arg.startsWith("--stderr=")) opts.stderr = readValue("--stderr");
+    else if (arg === "--stdout" || arg.startsWith("--stdout=")) opts.stdout = readValue("--stdout");
+    else if (arg === "--json") opts.json = true;
+    else if (arg === "--execute" || arg === "-x") opts.execute = true;
+    else if (arg === "--yes" || arg === "-y") opts.yes = true;
+    else if (arg === "--ai" || arg === "--spark") opts.ai = true;
+    else if (arg === "--list") opts.list = true;
+    else if (arg === "--install-shell") opts.installShell = true;
+    else if (!arg.startsWith("-") && !opts.command) opts.command = args.slice(i).join(" ");
+    else throw new Error(`unknown fck argument: ${arg}`);
+  }
+  opts.command ??= process.env.MAW_FCK_COMMAND;
+  opts.stderr ??= process.env.MAW_FCK_STDERR ?? process.env.MAW_FCK_OUTPUT;
+  opts.stdout ??= process.env.MAW_FCK_STDOUT;
+  return opts;
+}
+
+function bounded(value?: string): string {
+  return (value ?? "").slice(-MAX_TEXT);
+}
+
+function replaceFirstCommandToken(command: string, replacement: string): string {
+  const parts = command.trim().split(/\s+/);
+  if (parts[0] !== "maw" || parts.length < 2) return command;
+  parts[1] = replacement;
+  return parts.join(" ");
+}
+
+function replaceFlag(command: string, badFlag: string, goodFlag: string): string {
+  return command.replace(new RegExp(`(^|\\s)${escapeRegExp(badFlag)}(?=$|\\s|=)`, "g"), `$1${goodFlag}`);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function staticCorrection(opts: FckOptions): Correction | null {
+  const command = opts.command?.trim();
+  const output = `${bounded(opts.stdout)}\n${bounded(opts.stderr)}`;
+  if (!command) return null;
+
+  const disabled = output.match(/['`]([a-z][a-z0-9-]*)['`] is installed but disabled[\s\S]*?maw plugin enable ([a-z][a-z0-9-]*)/i);
+  if (disabled) {
+    const plugin = disabled[2] ?? disabled[1]!;
+    return {
+      ok: true,
+      candidate: `maw plugin enable ${plugin}`,
+      source: "maw-static:disabled-plugin",
+      confidence: 0.98,
+      risk: "low",
+      rationale: `Maw reported plugin '${plugin}' is installed but disabled.`,
+      requiresConfirmation: false,
+    };
+  }
+
+  const flag = output.match(/Unknown flag\s+(`?--[A-Za-z0-9-]+`?).*?(?:Did you mean|did you mean)\s+(`?--[A-Za-z0-9-]+`?)/is);
+  if (flag) {
+    const bad = flag[1]!.replace(/`/g, "");
+    const good = flag[2]!.replace(/`/g, "");
+    return {
+      ok: true,
+      candidate: replaceFlag(command, bad, good),
+      source: "maw-static:flag-suggestion",
+      confidence: 0.94,
+      risk: "low",
+      rationale: `Replace unknown flag ${bad} with suggested flag ${good}.`,
+      requiresConfirmation: true,
+    };
+  }
+
+  const unknown = output.match(/unknown command:\s*([a-z][a-z0-9-]*)[\s\S]*?did you mean:\s*([a-z][a-z0-9-]*)/i);
+  if (unknown && command.startsWith("maw ")) {
+    return {
+      ok: true,
+      candidate: replaceFirstCommandToken(command, unknown[2]!),
+      source: "maw-static:command-suggestion",
+      confidence: 0.82,
+      risk: "low",
+      rationale: `Maw suggested '${unknown[2]}' for unknown command '${unknown[1]}'.`,
+      requiresConfirmation: true,
+    };
+  }
+
+  if (/command not found:\s*maw|maw:\s*command not found/i.test(output)) {
+    return {
+      ok: true,
+      candidate: "bun link maw-js",
+      source: "maw-static:maw-not-found",
+      confidence: 0.72,
+      risk: "low",
+      rationale: "The maw binary was not found; if this repo is linked locally, bun link restores the command.",
+      requiresConfirmation: true,
+    };
+  }
+
+  return null;
+}
+
+export async function defaultRunner(argv: string[], opts: { stdin?: string } = {}): Promise<RunResult> {
+  const proc = Bun.spawn(argv, { stdout: "pipe", stderr: "pipe", stdin: opts.stdin ? "pipe" : "ignore" });
+  if (opts.stdin && proc.stdin) {
+    proc.stdin.write(opts.stdin);
+    proc.stdin.end();
+  }
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { code, stdout: stdout.slice(-MAX_TEXT), stderr: stderr.slice(-MAX_TEXT) };
+}
+
+export async function upstreamCorrection(opts: FckOptions, run: Runner = defaultRunner): Promise<Correction | null> {
+  const command = opts.command?.trim();
+  if (!command) return null;
+  const args = ["thefuck"];
+  if (opts.yes) args.push("--yes");
+  args.push("--", ...command.split(/\s+/));
+  const result = await run(args);
+  if (result.code === 127 || /not found|No such file/i.test(result.stderr)) {
+    return {
+      ok: false,
+      source: "thefuck",
+      error: "thefuck binary not found",
+      installHint: "Install upstream first, e.g. pipx install thefuck or brew install thefuck. Then rerun maw fck.",
+    };
+  }
+  const text = `${result.stdout}\n${result.stderr}`.trim();
+  if (result.code !== 0 && !text) return null;
+  const candidate = text.split("\n").map((s) => s.trim()).filter(Boolean).find((line) => !/^No fucks given/i.test(line));
+  if (!candidate) return null;
+  return {
+    ok: true,
+    candidate,
+    source: "thefuck",
+    confidence: 0.7,
+    risk: "medium",
+    rationale: "Upstream thefuck produced a correction.",
+    requiresConfirmation: true,
+  };
+}
+
+export async function executeCandidate(candidate: string, run: Runner): Promise<RunResult> {
+  return run(["sh", "-lc", candidate]);
+}
+
+export async function correct(opts: FckOptions, run: Runner = defaultRunner): Promise<Correction> {
+  const staticHit = staticCorrection(opts);
+  let correction = staticHit ?? await upstreamCorrection(opts, run);
+  if (!correction) {
+    correction = {
+      ok: false,
+      error: opts.command ? "no correction found" : "no failed command provided",
+      installHint: opts.command ? "Try installing upstream thefuck for broader rules: pipx install thefuck" : "Pass --command '<failed command>' or set MAW_FCK_COMMAND from shell integration.",
+    };
+  }
+
+  if (opts.ai && !correction.ok) {
+    correction.installHint = `${correction.installHint ?? ""}\nSpark fallback is intentionally not implemented in v0.1.0; it will remain opt-in with JSON/risk guards.`.trim();
+  }
+
+  if (opts.execute && correction.ok && correction.candidate) {
+    if (!opts.yes) {
+      correction.requiresConfirmation = true;
+      correction.error = "refusing to execute without --yes";
+      return correction;
+    }
+    correction.executed = await executeCandidate(correction.candidate, run);
+  }
+  return correction;
+}
+
+export function listProviders(): string {
+  return [
+    "fck providers:",
+    "  maw-static        disabled plugin, unknown command, flag typo, maw not found",
+    "  thefuck          upstream binary wrapper when installed",
+    "  codex-spark      planned opt-in fallback; not active in v0.1.0",
+  ].join("\n");
+}
+
+export function shellSnippet(): string {
+  return [
+    "# maw fck shell helper (manual v0.1.0)",
+    "# Capture a failed command explicitly:",
+    "#   MAW_FCK_COMMAND='maw bud foo --orgs acme' MAW_FCK_STDERR='Unknown flag --orgs. Did you mean --org?' maw fck",
+    "alias fck='maw fck'",
+    "alias fuck='maw fck'",
+    "alias please='maw fck'",
+  ].join("\n");
+}
+
+export function formatCorrection(c: Correction): string {
+  if (c.ok && c.candidate) {
+    const lines = [`${c.candidate}`, `  source: ${c.source ?? "unknown"}`];
+    if (c.rationale) lines.push(`  why: ${c.rationale}`);
+    if (c.executed) lines.push(`  executed: exit ${c.executed.code}`);
+    if (c.error) lines.push(`  note: ${c.error}`);
+    return lines.join("\n");
+  }
+  return [`no correction: ${c.error ?? "unknown"}`, c.installHint ? `hint: ${c.installHint}` : ""].filter(Boolean).join("\n");
+}

--- a/plugins/fck/index.ts
+++ b/plugins/fck/index.ts
@@ -1,0 +1,32 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { correct, formatCorrection, listProviders, parseFckArgs, shellSnippet } from "./impl";
+
+export const command = {
+  name: ["fck", "fuck", "please", "damnit"],
+  description: "thefuck-style typo and command correction for maw CLI and shell commands.",
+};
+
+function usage(): string {
+  return [
+    "usage: maw fck [--command <cmd>] [--stderr <text>] [--stdout <text>] [--json] [--execute --yes]",
+    "       maw fck --list",
+    "       maw fck --install-shell",
+    "",
+    "v0.1.0 chain: maw-static rules → upstream thefuck (if installed). Spark fallback is planned but off.",
+  ].join("\n");
+}
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const args = ctx.source === "cli" ? (ctx.args as string[]) : [];
+  try {
+    if (args.includes("--help") || args.includes("-h")) return { ok: true, output: usage() };
+    const opts = parseFckArgs(args);
+    if (opts.list) return { ok: true, output: listProviders() };
+    if (opts.installShell) return { ok: true, output: shellSnippet() };
+    const result = await correct(opts);
+    const output = opts.json ? JSON.stringify(result, null, 2) : formatCorrection(result);
+    return { ok: result.ok && !result.error, output, error: result.ok ? result.error : result.error };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err), output: usage() };
+  }
+}

--- a/plugins/fck/plugin.json
+++ b/plugins/fck/plugin.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
+  "name": "fck",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "tier": "standard",
+  "description": "thefuck-style typo and command correction for maw CLI and shell commands.",
+  "author": "Soul-Brews-Studio",
+  "capabilities": [
+    "shell:correct",
+    "proc:execute",
+    "sdk:plugin"
+  ],
+  "cli": {
+    "command": "fck",
+    "aliases": ["fuck", "please", "damnit"],
+    "help": "maw fck [--command <cmd>] [--stderr <text>] [--stdout <text>] [--json] [--execute --yes] [--ai] [--list]",
+    "flags": {
+      "--command": "string",
+      "--stderr": "string",
+      "--stdout": "string",
+      "--json": "boolean",
+      "--execute": "boolean",
+      "--yes": "boolean",
+      "--ai": "boolean",
+      "--spark": "boolean",
+      "--list": "boolean",
+      "--install-shell": "boolean"
+    }
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/plugins/fck/registry.meta.json
+++ b/plugins/fck/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.0",
+  "source": "soul-brews-studio/maw-plugin-registry/fck@v0.1.0-fck",
+  "sha256": null,
+  "summary": "thefuck-style typo and command correction for maw CLI and shell commands.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-05-17T00:25:00Z",
+  "tier": "standard"
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-16T17:11:29Z",
+  "updated": "2026-05-16T17:23:40Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -229,6 +229,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-05-13T08:00:00Z",
       "tier": "extra"
+    },
+    "fck": {
+      "version": "0.1.0",
+      "source": "soul-brews-studio/maw-plugin-registry/fck@v0.1.0-fck",
+      "sha256": null,
+      "summary": "thefuck-style typo and command correction for maw CLI and shell commands.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-05-17T00:25:00Z",
+      "tier": "standard"
     },
     "federation": {
       "version": "1.0.0",


### PR DESCRIPTION
## Summary
- add the `fck` registry plugin as an opt-in maw command corrector
- include deterministic maw-specific correction rules plus optional upstream `thefuck` binary delegation
- keep Codex/Spark correction as an explicit future hook, disabled by default so no AI/network path runs accidentally

## Verification
- `bun test plugins/fck/fck.test.ts`
- `bun test plugins/fck/fck.test.ts plugins/fleet-ui/fleet-ui.test.ts`
- `bun scripts/validate-registry.ts --step plugin-json --plugins fck`
- `bun scripts/validate-registry.ts --step license --plugins fck`
- `bun scripts/validate-registry.ts --step source-format --plugins fck`
- `bunx ajv validate --spec=draft2020 -c ajv-formats -s schema/registry.json -d registry.json --strict=false`
- `git diff --check`

Closes #74

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
