### PR TITLE
fix(attach-ssh): expose dormant strategy as direct command

### DIFF
--- a/plugins/attach-ssh/README.md
+++ b/plugins/attach-ssh/README.md
@@ -1,18 +1,23 @@
 # attach-ssh
 
-Tier 3 (remote-live) SSH + tmux attach strategy for `maw attach`.
+Explicit SSH + tmux attach command and Tier 3 strategy for `maw attach`.
 
-When `maw attach <name>` (or `maw a <name>`) resolves to a session running on
-a federation peer, the built-in attach plugin hands control off to any
-installed plugin that declares the `attach:strategy` capability with
-`strategy.tier: 3`. This plugin is the reference implementation — it SSHes
-into the peer and runs `tmux attach -t <session>` so your terminal takes
-over the remote pane. Extracted from the built-in attach (#1262) so the
-SSH + tmux glue can be disabled, replaced, or evolved independently. See
-[../attach](../attach) for the cascade host.
+The host-side Tier 3 dispatcher that used to call `attach:strategy` plugins is
+currently dormant, so this plugin also exposes a direct CLI command:
 
-## Install
-
-```
+```sh
 maw plugin install attach-ssh
+maw plugin enable attach-ssh
+maw attach-ssh m5:54-mawjs --dry-run
+maw attach-ssh m5 54-mawjs
+maw attach-ssh m5:54-mawjs --ssh-alias m5.wg
 ```
+
+`--ssh-alias` defaults to the node name. The remote command is:
+
+```sh
+ssh -tt <ssh-alias> "tmux attach-session -t '<session>'"
+```
+
+The default export still carries `default.execute(target)` for future hosts that
+load the plugin as an `attach:strategy` with `strategy.tier: 3`.

--- a/plugins/attach-ssh/attach-ssh.test.ts
+++ b/plugins/attach-ssh/attach-ssh.test.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test";
+import handler, { execute, parseAttachSshCommand, type Tier3Target } from "./index";
+import type { InvokeContext } from "maw-js/plugin/types";
+
+test("parseAttachSshCommand parses node:session syntax", () => {
+  const parsed = parseAttachSshCommand(["m5:54-mawjs"]);
+  expect(parsed).toEqual({
+    dryRun: false,
+    target: { tier: 3, node: "m5", sshAlias: "m5", sessionName: "54-mawjs" },
+  });
+});
+
+test("parseAttachSshCommand parses node session syntax and ssh alias", () => {
+  const parsed = parseAttachSshCommand(["m5", "54-mawjs", "--ssh-alias", "m5.wg", "--dry-run"]);
+  expect(parsed).toEqual({
+    dryRun: true,
+    target: { tier: 3, node: "m5", sshAlias: "m5.wg", sessionName: "54-mawjs" },
+  });
+});
+
+test("parseAttachSshCommand rejects missing session", () => {
+  expect(() => parseAttachSshCommand(["m5"])).toThrow("usage: maw attach-ssh");
+});
+
+test("parseAttachSshCommand rejects unsafe ssh alias", () => {
+  expect(() => parseAttachSshCommand(["m5:54-mawjs", "--ssh-alias", "bad alias"])).toThrow("unsafe ssh alias");
+});
+
+test("execute delegates to SSH helper with strategy target", async () => {
+  const calls: any[] = [];
+  const target: Tier3Target = {
+    tier: 3,
+    node: "m5",
+    peerUrl: "http://m5.example",
+    sshAlias: "m5.wg",
+    sessionName: "54-mawjs",
+  };
+  await execute(target, { ssh: async (request) => calls.push(request) });
+  expect(calls).toEqual([{ node: "m5", sshAlias: "m5.wg", sessionName: "54-mawjs" }]);
+});
+
+test("default export remains strategy-compatible", async () => {
+  expect(typeof handler).toBe("function");
+  expect(typeof handler.execute).toBe("function");
+});
+
+test("handler dry-run is user-callable without SSH side effects", async () => {
+  const ctx: InvokeContext = { source: "cli", args: ["m5:54-mawjs", "--dry-run"] };
+  const result = await handler(ctx);
+  expect(result.ok).toBe(true);
+  expect(result.output).toContain("would ssh m5");
+  expect(result.output).toContain("54-mawjs");
+});
+
+test("handler reports usage for invalid direct command", async () => {
+  const ctx: InvokeContext = { source: "cli", args: ["m5"] };
+  const result = await handler(ctx);
+  expect(result.ok).toBe(false);
+  expect(result.error).toContain("usage: maw attach-ssh");
+});

--- a/plugins/attach-ssh/index.ts
+++ b/plugins/attach-ssh/index.ts
@@ -1,46 +1,167 @@
 /**
- * attach-ssh — Tier 3 (remote-live) SSH+tmux attach strategy.
+ * attach-ssh — explicit SSH+tmux attach command and Tier 3 strategy.
  *
- * Extracted from plugins/attach (#1262). When `maw attach <name>` resolves
- * to a peer-live session, the dispatcher in plugins/attach/impl.ts scans
- * ~/.maw/plugins/*\/plugin.json for an `attach:strategy` capability matching
- * `strategy.tier === 3` and hands off the resolved target to `execute()`.
+ * This plugin used to be only an `attach:strategy`, but the host-side Tier 3
+ * dispatcher is dormant. Keep the strategy shape available for future hosts
+ * while also exposing a direct command:
  *
- * Keep this small — the friendly console.log lines stay in the host so the
- * UX is consistent even when no strategy plugin is installed (built-in
- * fallback path).
+ *   maw attach-ssh <node>:<session> [--ssh-alias <alias>] [--dry-run]
+ *   maw attach-ssh <node> <session> [--ssh-alias <alias>] [--dry-run]
  */
-import { attachRemoteSession, SshAttachError } from "maw-js/sdk";
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { parseFlags } from "maw-js/cli/parse-args";
+
+export const command = {
+  name: "attach-ssh",
+  description: "Attach to a remote tmux session over SSH.",
+};
+
+const USAGE =
+  "usage: maw attach-ssh <node>:<session> [--ssh-alias <alias>] [--dry-run]\n" +
+  "   or: maw attach-ssh <node> <session> [--ssh-alias <alias>] [--dry-run]";
+
+const SAFE_SSH_ALIAS = /^[A-Za-z0-9._@%+=:/-]+$/;
 
 export interface Tier3Target {
   tier: 3;
   sessionName: string;
   node: string;
-  peerUrl: string;
+  peerUrl?: string;
   sshAlias: string;
 }
 
-export interface ExecuteOpts {
-  /** Test seam — swap the SSH helper. Defaults to maw-js/sdk's attachRemoteSession. */
-  ssh?: typeof attachRemoteSession;
+export interface AttachRemoteSessionRequest {
+  node: string;
+  sshAlias: string;
+  sessionName: string;
 }
 
-export default {
-  async execute(target: Tier3Target, opts: ExecuteOpts = {}): Promise<void> {
-    const ssh = opts.ssh ?? attachRemoteSession;
-    try {
-      ssh({
-        node: target.node,
-        sshAlias: target.sshAlias,
-        sessionName: target.sessionName,
-      });
-    } catch (err) {
-      if (err instanceof SshAttachError) {
-        // Surface the helper's friendly one-line message — never process.exit.
-        console.error(err.message);
-        throw new Error(err.message);
-      }
-      throw err;
+export type AttachRemoteSession = (request: AttachRemoteSessionRequest) => void | Promise<void>;
+
+export interface ExecuteOpts {
+  /** Test seam — swap the SSH helper. Defaults to this plugin's SSH+tmux helper. */
+  ssh?: AttachRemoteSession;
+}
+
+export interface ParsedAttachSshCommand {
+  target: Tier3Target;
+  dryRun: boolean;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function assertSafeSshAlias(value: string): void {
+  if (!value || !SAFE_SSH_ALIAS.test(value)) {
+    throw new Error(`unsafe ssh alias: ${value || "(empty)"}`);
+  }
+}
+
+export async function attachRemoteSession(request: AttachRemoteSessionRequest): Promise<void> {
+  const { node, sshAlias, sessionName } = request;
+  if (!node) throw new Error("node required");
+  if (!sessionName) throw new Error("session required");
+  assertSafeSshAlias(sshAlias);
+
+  const remoteCommand = `tmux attach-session -t ${shellQuote(sessionName)}`;
+  const proc = Bun.spawn(["ssh", "-tt", sshAlias, remoteCommand], {
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    throw new Error(`ssh attach failed for ${node}:${sessionName} via ${sshAlias} (exit ${code})`);
+  }
+}
+
+export async function execute(target: Tier3Target, opts: ExecuteOpts = {}): Promise<void> {
+  const ssh = opts.ssh ?? attachRemoteSession;
+  await ssh({
+    node: target.node,
+    sshAlias: target.sshAlias,
+    sessionName: target.sessionName,
+  });
+}
+
+export function parseAttachSshCommand(args: string[]): ParsedAttachSshCommand {
+  const flags = parseFlags(
+    args,
+    {
+      "--dry-run": Boolean,
+      "--ssh-alias": String,
+    },
+    0,
+  );
+
+  const positionals = flags._ as string[];
+  if (positionals.includes("--help") || positionals.includes("-h")) {
+    throw new Error(USAGE);
+  }
+
+  let node = "";
+  let sessionName = "";
+  if (positionals.length === 1 && positionals[0].includes(":")) {
+    const idx = positionals[0].indexOf(":");
+    node = positionals[0].slice(0, idx);
+    sessionName = positionals[0].slice(idx + 1);
+  } else if (positionals.length >= 2) {
+    node = positionals[0];
+    sessionName = positionals.slice(1).join(" ");
+  }
+
+  if (!node || !sessionName) {
+    throw new Error(USAGE);
+  }
+  if (node.startsWith("-") || sessionName.startsWith("-")) {
+    throw new Error(`node/session cannot look like flags\n  ${USAGE}`);
+  }
+
+  const sshAlias = (flags["--ssh-alias"] as string | undefined) || node;
+  assertSafeSshAlias(sshAlias);
+
+  return {
+    dryRun: Boolean(flags["--dry-run"]),
+    target: {
+      tier: 3,
+      node,
+      sshAlias,
+      sessionName,
+    },
+  };
+}
+
+async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  try {
+    if (ctx.source === "api") {
+      const body = (ctx.args ?? {}) as Record<string, unknown>;
+      const node = String(body.node ?? "");
+      const sessionName = String(body.sessionName ?? body.session ?? "");
+      const sshAlias = String(body.sshAlias ?? node);
+      if (!node || !sessionName) return { ok: false, error: "node and sessionName required" };
+      const target: Tier3Target = { tier: 3, node, sessionName, sshAlias };
+      if (body.dryRun) return { ok: true, output: formatDryRun(target) };
+      await execute(target);
+      return { ok: true };
     }
-  },
-};
+
+    const { target, dryRun } = parseAttachSshCommand((ctx.args ?? []) as string[]);
+    if (dryRun) return { ok: true, output: formatDryRun(target) };
+    await execute(target);
+    return { ok: true };
+  } catch (err: any) {
+    return { ok: false, error: err?.message || String(err) };
+  }
+}
+
+function formatDryRun(target: Tier3Target): string {
+  return `would ssh ${target.sshAlias} and attach tmux session ${target.sessionName} (${target.node})`;
+}
+
+// Preserve the old strategy-plugin shape for any host that still loads
+// `default.execute(target)`, while making the default export callable by the
+// modern plugin dispatcher.
+(handler as typeof handler & { execute: typeof execute }).execute = execute;
+
+export default handler as typeof handler & { execute: typeof execute };

--- a/plugins/attach-ssh/plugin.json
+++ b/plugins/attach-ssh/plugin.json
@@ -1,12 +1,24 @@
 {
   "name": "attach-ssh",
   "version": "0.1.0",
-  "description": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach (#1262).",
+  "description": "Explicit SSH+tmux attach command plus Tier 3 attach strategy.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "entry": "./index.ts",
-  "capabilities": ["attach:strategy"],
-  "strategy": { "tier": 3 },
+  "capabilities": [
+    "attach:strategy"
+  ],
+  "strategy": {
+    "tier": 3
+  },
   "schemaVersion": 1,
-  "sdk": "^1.0.0-alpha.1"
+  "sdk": "^1.0.0-alpha.1",
+  "cli": {
+    "command": "attach-ssh",
+    "help": "maw attach-ssh <node>:<session> [--ssh-alias <alias>] [--dry-run] \u2014 attach to a remote tmux session over SSH",
+    "flags": {
+      "--ssh-alias": "string",
+      "--dry-run": "boolean"
+    }
+  }
 }

--- a/plugins/attach-ssh/registry.meta.json
+++ b/plugins/attach-ssh/registry.meta.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
   "source": "soul-brews-studio/maw-plugin-registry/attach-ssh@v0.1.0-attach-ssh",
-  "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach.",
+  "summary": "Explicit SSH+tmux attach command plus Tier 3 attach strategy.",
   "author": "Soul-Brews-Studio",
   "license": "MIT",
   "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",

--- a/registry.json
+++ b/registry.json
@@ -50,7 +50,7 @@
     "attach-ssh": {
       "version": "0.1.0",
       "source": "soul-brews-studio/maw-plugin-registry/attach-ssh@v0.1.0-attach-ssh",
-      "summary": "Tier 3 (remote-live) SSH+tmux attach strategy. Extracted from built-in attach.",
+      "summary": "Explicit SSH+tmux attach command plus Tier 3 attach strategy.",
       "author": "Soul-Brews-Studio",
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",


### PR DESCRIPTION
## Summary
- expose `attach-ssh` as a direct plugin CLI command: `maw attach-ssh <node>:<session>` or `maw attach-ssh <node> <session>`
- preserve the old `default.execute(target)` strategy shape for future host dispatchers
- replace the missing `maw-js/sdk` `attachRemoteSession` import with a plugin-owned SSH+tmux helper
- document install/usage and update registry summaries

Closes #60.

## Verification
- `bun test plugins/attach-ssh/attach-ssh.test.ts plugins/attach/attach.test.ts`
- `bun scripts/validate-registry.ts --step plugin-json --plugins attach-ssh`
- `bun scripts/validate-registry.ts --step license --plugins attach-ssh`
- `bun scripts/validate-registry.ts --step source-format --plugins attach-ssh`
- `bunx ajv validate --spec=draft2020 -c ajv-formats -s schema/registry.json -d registry.json --strict=false`
- `bunx markdownlint-cli2 plugins/attach-ssh/README.md`
- `git diff --check`
- `bun -e 'import handler from "./plugins/attach-ssh/index.ts"; const r = await handler({source:"cli", args:["m5:54-mawjs", "--dry-run"]}); console.log(JSON.stringify(r))'`

## Notes
- This intentionally implements the low-cost explicit command option from #60, not the larger self-contained resolver. Users provide the remote node/session explicitly; `--ssh-alias` defaults to the node.
- Live SSH attach is not exercised in CI to avoid hijacking an interactive terminal.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
