### PR TITLE
test: keep registry config mock local

### DIFF
--- a/plugins/costs/costs.test.ts
+++ b/plugins/costs/costs.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+const { mockConfigModule } = await import("../../test/helpers/mock-config");
 mock.module("maw-js/config", () => mockConfigModule(() => ({ host: "localhost", port: 3456 })));
 
 const mockAgentData = {

--- a/plugins/health/health.test.ts
+++ b/plugins/health/health.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import type { InvokeContext } from "maw-js/plugin/types";
 
 // Use the shared mock helper to provide ALL config exports (Bun 1.3 mock leaks globally)
-const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+const { mockConfigModule } = await import("../../test/helpers/mock-config");
 mock.module("maw-js/config", () => mockConfigModule(() => ({ host: "localhost", port: 3456, peers: [] })));
 
 // Mock the health impl directly — do NOT mock child_process (leaks globally in Bun 1.3)

--- a/plugins/hey-test/hey-plugin.test.ts
+++ b/plugins/hey-test/hey-plugin.test.ts
@@ -31,7 +31,7 @@ mock.module("maw-js/plugin/registry", () => ({
   invokePlugin: async (_plugin: LoadedPlugin, _ctx: unknown) => fakeInvokeResult,
 }));
 
-const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+const { mockConfigModule } = await import("../../test/helpers/mock-config");
 mock.module("maw-js/config", () => mockConfigModule(() => ({ node: "local-node", port: 3456 })));
 
 mock.module("maw-js/core/transport/ssh", () => ({

--- a/plugins/ping/ping.test.ts
+++ b/plugins/ping/ping.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, mock } from "bun:test";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const { mockConfigModule } = await import("maw-js/test/helpers/mock-config");
+const { mockConfigModule } = await import("../../test/helpers/mock-config");
 
 mock.module("maw-js/config", () => mockConfigModule(() => ({
   namedPeers: [{ name: "white", url: "http://white.local:3456" }],

--- a/test/helpers/mock-config.ts
+++ b/test/helpers/mock-config.ts
@@ -1,0 +1,98 @@
+/**
+ * Shared registry test config mock.
+ *
+ * The registry test suite must not import maw-js/test/helpers/*: maw-js does not
+ * export test helpers through package exports, so Bun package resolution rejects
+ * that subpath. Keep the minimal complete `maw-js/config` mock local to this
+ * repository instead.
+ */
+
+type ConfigLike = Record<string, any>;
+
+type IntervalKey =
+  | "capture"
+  | "sessions"
+  | "status"
+  | "teams"
+  | "preview"
+  | "peerFetch"
+  | "crashCheck";
+type TimeoutKey =
+  | "http"
+  | "health"
+  | "ping"
+  | "pty"
+  | "workspace"
+  | "shellInit"
+  | "wakeRetry"
+  | "wakeVerify";
+type LimitKey =
+  | "feedMax"
+  | "feedDefault"
+  | "feedHistory"
+  | "logsMax"
+  | "logsDefault"
+  | "logsTruncate"
+  | "messageTruncate"
+  | "ptyCols"
+  | "ptyRows"
+  | "maxConcurrentAgents";
+
+const INTERVALS: Record<IntervalKey, number> = {
+  capture: 50,
+  sessions: 5000,
+  status: 3000,
+  teams: 3000,
+  preview: 2000,
+  peerFetch: 10000,
+  crashCheck: 30000,
+};
+
+const TIMEOUTS: Record<TimeoutKey, number> = {
+  http: 5000,
+  health: 3000,
+  ping: 5000,
+  pty: 5000,
+  workspace: 5000,
+  shellInit: 3000,
+  wakeRetry: 500,
+  wakeVerify: 3000,
+};
+
+const LIMITS: Record<LimitKey, number> = {
+  feedMax: 500,
+  feedDefault: 50,
+  feedHistory: 50,
+  logsMax: 500,
+  logsDefault: 50,
+  logsTruncate: 500,
+  messageTruncate: 100,
+  ptyCols: 500,
+  ptyRows: 200,
+  maxConcurrentAgents: 0,
+};
+
+export const TEST_D = {
+  intervals: INTERVALS,
+  timeouts: TIMEOUTS,
+  limits: LIMITS,
+  hmacWindowSeconds: 300,
+} as const;
+
+export function mockConfigModule(loadConfig: () => Partial<ConfigLike>) {
+  return {
+    loadConfig,
+    resetConfig: () => {},
+    saveConfig: () => {},
+    validateConfigShape: (c: unknown) => c,
+    configForDisplay: () => ({}),
+    buildCommand: (_name: string) => "echo test",
+    buildCommandInDir: (_name: string, cwd: string) => `cd '${cwd}' && echo test`,
+    getEnvVars: () => ({}),
+    D: TEST_D,
+    cfgInterval: (k: IntervalKey) => INTERVALS[k],
+    cfgTimeout: (k: TimeoutKey) => TIMEOUTS[k],
+    cfgLimit: (k: LimitKey) => LIMITS[k],
+    cfg: (k: string) => loadConfig()[k],
+  };
+}


### PR DESCRIPTION
## Summary
- add a local registry `test/helpers/mock-config.ts`
- stop importing private `maw-js/test/helpers/mock-config` from four registry test files
- removes the package-export module resolution errors from the #47 full-suite run

Part of #47.

## Verification
- `bun test plugins/costs/costs.test.ts plugins/ping/ping.test.ts plugins/hey-test/hey-plugin.test.ts plugins/health/health.test.ts`
- `bun test 2>&1 | tee /tmp/mpr-bun-test-after-mock-helper.log | tail -80`
- `git diff --check`

## Full-suite delta
Before this change, local full-suite smoke showed:
- `601 pass`
- `18 skip`
- `41 fail`
- `6 errors`

After this change:
- `616 pass`
- `18 skip`
- `36 fail`
- `1 error`

Remaining #47 clusters are still real and should be handled in follow-up PRs; this PR only removes the broken private-helper import cluster.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
