### PR TITLE
test: mock plugin handler import keys

### DIFF
--- a/plugins/about/about.test.ts
+++ b/plugins/about/about.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
-mock.module(join(root, "commands/plugins/oracle/impl"), () => ({
+mock.module(join(import.meta.dir, "internal/impl-about"), () => ({
   cmdOracleAbout: async (oracle: string) => {
     console.log(`Oracle — ${oracle}`);
     console.log(`  Repo:      /home/neo/ghq/github.com/Soul-Brews-Studio/${oracle}-oracle`);

--- a/plugins/stop/stop.test.ts
+++ b/plugins/stop/stop.test.ts
@@ -1,10 +1,7 @@
 import { describe, it, expect, mock } from "bun:test";
-import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
-mock.module(join(root, "commands/shared/fleet"), () => ({
+mock.module("maw-js/commands/shared/fleet", () => ({
   cmdSleep: async () => {
     console.log("fleet stopped");
   },

--- a/plugins/take/take.test.ts
+++ b/plugins/take/take.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, mock } from "bun:test";
 import { join } from "path";
 import type { InvokeContext } from "maw-js/plugin/types";
 
-const root = join(import.meta.dir, "../../..");
-
-mock.module(join(root, "commands/plugins/take/impl"), () => ({
+mock.module(join(import.meta.dir, "impl"), () => ({
   cmdTake: async (source: string, target?: string) => {
     console.log(`take ${source}${target ? ` → ${target}` : " (new session)"}`);
   },

--- a/plugins/wake/wake.test.ts
+++ b/plugins/wake/wake.test.ts
@@ -8,10 +8,8 @@ let lastWakeAllCall: { opts: any } | null = null;
 // Bun's module cache key is the normalized path WITHOUT the .ts extension.
 // Use join() from the src root — same convention as stop.test.ts and other plugin
 // tests — so the mock key matches what bun uses for the dynamic imports in the handler.
-const src = join(import.meta.dir, "../../..");
-
 // Mock config to prevent getEnvVars resolution failure in CI (Bun 1.3 mock.module bug)
-mock.module(join(src, "config"), () => ({
+mock.module("maw-js/config", () => ({
   loadConfig: () => ({ node: "test", agents: {}, env: {} }),
   buildCommand: () => "echo test",
   getEnvVars: () => ({}),
@@ -21,7 +19,7 @@ mock.module(join(src, "config"), () => ({
   validateConfig: (c: any) => c,
 }));
 
-mock.module(join(src, "commands/shared/wake"), () => ({
+mock.module("maw-js/commands/shared/wake", () => ({
   cmdWake: async (oracle: string, opts: any) => {
     lastWakeCall = { oracle, opts };
     console.log(`woke ${oracle}`);
@@ -35,7 +33,7 @@ mock.module(join(src, "commands/shared/wake"), () => ({
   resolveFleetSession: () => null,
 }));
 
-mock.module(join(src, "commands/shared/fleet"), () => ({
+mock.module("maw-js/commands/shared/fleet", () => ({
   cmdWakeAll: async (opts: any) => {
     lastWakeAllCall = { opts };
     console.log("wake all");
@@ -44,12 +42,12 @@ mock.module(join(src, "commands/shared/fleet"), () => ({
   cmdWakeAll_: null,
 }));
 
-mock.module(join(src, "commands/shared/wake-target"), () => ({
+mock.module("maw-js/commands/shared/wake-target", () => ({
   parseWakeTarget: () => null,
   ensureCloned: async () => {},
 }));
 
-mock.module(join(src, "commands/shared/wake-resolve"), () => ({
+mock.module("maw-js/commands/shared/wake-resolve", () => ({
   fetchGitHubPrompt: async (type: string, num: number) => `${type} #${num} prompt`,
 }));
 


### PR DESCRIPTION
## Summary
- update stop/about/wake/take tests to mock the exact module IDs their handlers import
- prevents live maw-js commands from running during registry tests
- reduces the remaining #47 full-suite failures from 36 to 21

Part of #47.

## Verification
- `bun test plugins/stop/stop.test.ts plugins/about/about.test.ts plugins/wake/wake.test.ts plugins/take/take.test.ts`
- `bun test 2>&1 | tee /tmp/mpr-bun-test-after-mock-keys.log | tail -80`
- `git diff --check`

## Full-suite delta
After PR #80, local full-suite smoke showed:
- `616 pass`
- `18 skip`
- `36 fail`
- `1 error`

After this change:
- `631 pass`
- `18 skip`
- `21 fail`
- `2 errors`

Remaining #47 clusters are peers store/probe-all and bud/from-repo pollution. This PR only fixes stale mock module IDs.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
