### PR TITLE
Fix osmosis fuzzy repo resolution

### DIFF
--- a/plugins/osmosis/lib/execute.test.ts
+++ b/plugins/osmosis/lib/execute.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { resolveRepository } from "./execute";
+import type { Config } from "./types";
+
+function cfg(repo: string): Config {
+  return {
+    host: "white.local",
+    direction: "push",
+    repo,
+    owner: "laris-co",
+    apply: false,
+    json: false,
+    verbose: false,
+    safe: false,
+    force: false,
+    yes: false,
+    noWorktrees: false,
+    sessions: false,
+    diff: true,
+  };
+}
+
+describe("resolveRepository", () => {
+  test("rewrites osmosis repo targets from fleet oracle mappings", async () => {
+    const config = cfg("homekeeper");
+    const err = await resolveRepository(config, [], "/opt/Code", {
+      resolveFleetRepo: async () => ({ owner: "laris-co", repo: "homelab", source: "fleet:20-homekeeper" }),
+      stat: (async () => { throw new Error("strict path should not be checked after fleet hit"); }) as any,
+      ghqResolveRepo: async () => { throw new Error("ghq should not be checked after fleet hit"); },
+    });
+
+    expect(err).toBeNull();
+    expect(config.owner).toBe("laris-co");
+    expect(config.repo).toBe("homelab");
+    expect(config.derivedFrom).toBe("laris-co/homelab (via fleet:20-homekeeper)");
+  });
+
+  test("respects explicit --owner by bypassing fuzzy resolution", async () => {
+    const config = cfg("homekeeper");
+    const err = await resolveRepository(config, ["--owner", "laris-co"], "/opt/Code", {
+      resolveFleetRepo: async () => { throw new Error("fleet should be bypassed"); },
+      stat: (async () => { throw new Error("stat should be bypassed"); }) as any,
+      ghqResolveRepo: async () => { throw new Error("ghq should be bypassed"); },
+    });
+
+    expect(err).toBeNull();
+    expect(config.repo).toBe("homekeeper");
+  });
+
+  test("falls back to ghq fuzzy repo matches when no fleet mapping or strict path exists", async () => {
+    const config = cfg("homekeeper");
+    const err = await resolveRepository(config, [], "/opt/Code", {
+      resolveFleetRepo: async () => null,
+      stat: (async () => { throw new Error("missing strict path"); }) as any,
+      ghqResolveRepo: async () => ({ owner: "laris-co", repo: "homekeeper-oracle", source: "ghq" }),
+    });
+
+    expect(err).toBeNull();
+    expect(config.repo).toBe("homekeeper-oracle");
+    expect(config.derivedFrom).toBe("laris-co/homekeeper-oracle (via ghq)");
+  });
+});

--- a/plugins/osmosis/lib/execute.ts
+++ b/plugins/osmosis/lib/execute.ts
@@ -2,7 +2,7 @@ import { stat } from "node:fs/promises";
 import { type Config, UsageError } from "./types";
 import { parseArgs, help } from "./config";
 import { ghBase } from "./paths";
-import { ghqRoot, ghqRemoteRoot, ghqResolveOwner, remoteHomedir } from "./ghq";
+import { ghqRoot, ghqRemoteRoot, ghqResolveRepo, resolveFleetRepo, remoteHomedir } from "./ghq";
 import { enumerateTargets } from "./targets";
 import { type PlanRow, buildPlan, renderPlan } from "./plan";
 import { runPreviews, renderPreviews } from "./preview";
@@ -37,7 +37,7 @@ export async function execute(args: string[], options: { exitOnMissing?: boolean
   }
 
   const localRoot = await ghqRoot();
-  const ownerErr = await resolveOwner(cfg, args, localRoot);
+  const ownerErr = await resolveRepository(cfg, args, localRoot);
   if (ownerErr) {
     console.error(`✖ ${ownerErr}`);
     if (options.exitOnMissing) process.exitCode = 1;
@@ -121,15 +121,46 @@ export async function execute(args: string[], options: { exitOnMissing?: boolean
   await runApply(plan, cfg, options);
 }
 
-async function resolveOwner(cfg: Config, args: string[], localRoot: string): Promise<string | null> {
+export type ResolveRepositoryDeps = {
+  stat?: typeof stat;
+  resolveFleetRepo?: typeof resolveFleetRepo;
+  ghqResolveRepo?: typeof ghqResolveRepo;
+};
+
+export async function resolveRepository(
+  cfg: Config,
+  args: string[],
+  localRoot: string,
+  deps: ResolveRepositoryDeps = {},
+): Promise<string | null> {
   if (args.includes("--owner")) return null;
-  const tryPath = `${ghBase(localRoot)}/${cfg.owner}/${cfg.repo}`;
-  try { await stat(tryPath); return null; } catch { /* not found locally */ }
+
+  const resolveFromFleet = deps.resolveFleetRepo ?? resolveFleetRepo;
+  const resolveFromGhq = deps.ghqResolveRepo ?? ghqResolveRepo;
+  const statPath = deps.stat ?? stat;
+
   try {
-    const resolved = await ghqResolveOwner(cfg.repo);
-    if (resolved && resolved !== cfg.owner) {
-      cfg.owner = resolved;
-      cfg.derivedFrom = `${resolved}/${cfg.repo} (via ghq)`;
+    const fleet = await resolveFromFleet(cfg.repo);
+    if (fleet && (fleet.owner !== cfg.owner || fleet.repo !== cfg.repo)) {
+      cfg.owner = fleet.owner;
+      cfg.repo = fleet.repo;
+      cfg.derivedFrom = `${fleet.owner}/${fleet.repo} (via ${fleet.source})`;
+      return null;
+    }
+  } catch (e) {
+    if (e instanceof UsageError) return e.message;
+    throw e;
+  }
+
+  const tryPath = `${ghBase(localRoot)}/${cfg.owner}/${cfg.repo}`;
+  try { await statPath(tryPath); return null; } catch { /* not found locally */ }
+
+  try {
+    const resolved = await resolveFromGhq(cfg.repo);
+    if (resolved && (resolved.owner !== cfg.owner || resolved.repo !== cfg.repo)) {
+      cfg.owner = resolved.owner;
+      cfg.repo = resolved.repo;
+      cfg.derivedFrom = `${resolved.owner}/${resolved.repo} (via ghq)`;
     }
     return null;
   } catch (e) {

--- a/plugins/osmosis/lib/ghq.test.ts
+++ b/plugins/osmosis/lib/ghq.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { resolveFleetRepoFromSessions, resolveGhqRepoFromPaths } from "./ghq";
+import { UsageError } from "./types";
+
+describe("osmosis repository resolution", () => {
+  test("maps oracle aliases through fleet windows before strict repo lookup", () => {
+    const resolved = resolveFleetRepoFromSessions("homekeeper", [
+      {
+        name: "20-homekeeper",
+        windows: [
+          { name: "homekeeper-oracle", repo: "laris-co/homelab" },
+        ],
+      },
+    ]);
+
+    expect(resolved).toEqual({
+      owner: "laris-co",
+      repo: "homelab",
+      source: "fleet:20-homekeeper",
+    });
+  });
+
+  test("treats numbered fleet session names as oracle aliases", () => {
+    const resolved = resolveFleetRepoFromSessions("homekeeper", [
+      {
+        name: "20-homekeeper",
+        windows: [
+          { name: "other-window", repo: "laris-co/homelab" },
+        ],
+      },
+    ]);
+
+    expect(resolved?.repo).toBe("homelab");
+  });
+
+  test("fails loudly when fleet has competing repo mappings for one alias", () => {
+    expect(() => resolveFleetRepoFromSessions("homekeeper", [
+      { name: "20-homekeeper", windows: [{ name: "homekeeper-oracle", repo: "laris-co/homelab" }] },
+      { name: "21-homekeeper", windows: [{ name: "homekeeper-oracle", repo: "Soul-Brews-Studio/homekeeper-oracle" }] },
+    ])).toThrow(UsageError);
+  });
+
+  test("prefers exact ghq repo matches before fuzzy oracle repo matches", () => {
+    const resolved = resolveGhqRepoFromPaths("homekeeper", [
+      "/opt/Code/github.com/laris-co/homekeeper-oracle",
+      "/opt/Code/github.com/laris-co/homekeeper",
+    ]);
+
+    expect(resolved?.repo).toBe("homekeeper");
+  });
+
+  test("fuzzy-matches ghq oracle repos when no exact repo exists", () => {
+    const resolved = resolveGhqRepoFromPaths("homekeeper", [
+      "/opt/Code/github.com/laris-co/homekeeper-oracle",
+    ]);
+
+    expect(resolved).toMatchObject({ owner: "laris-co", repo: "homekeeper-oracle" });
+  });
+});

--- a/plugins/osmosis/lib/ghq.ts
+++ b/plugins/osmosis/lib/ghq.ts
@@ -1,6 +1,133 @@
 import { spawn } from "node:child_process";
+import { readdir, readFile } from "node:fs/promises";
 import { homedir } from "node:os";
+import { join } from "node:path";
 import { type ExecResult, type TargetState, UsageError } from "./types";
+
+
+export type RepoSpec = {
+  owner: string;
+  repo: string;
+  path?: string;
+  source: string;
+};
+
+type FleetWindow = { name?: unknown; repo?: unknown };
+type FleetSession = { name?: unknown; windows?: unknown };
+
+function splitRepoSlug(slug: string): { owner: string; repo: string } | null {
+  const cleaned = slug.trim().replace(/^github\.com\//, "").replace(/^https?:\/\/github\.com\//, "").replace(/\.git$/, "");
+  const parts = cleaned.split("/").filter(Boolean);
+  if (parts.length !== 2) return null;
+  const [owner, repo] = parts;
+  if (!owner || !repo) return null;
+  return { owner, repo };
+}
+
+function repoFromGhqPath(path: string): RepoSpec | null {
+  const m = path.match(/\/github\.com\/([^/]+)\/([^/]+)\/?$/);
+  if (!m) return null;
+  return { owner: m[1], repo: m[2], path, source: "ghq" };
+}
+
+function normalizeName(name: string): string {
+  return name.trim().toLowerCase();
+}
+
+function stripOracleSuffix(name: string): string {
+  return name.replace(/-oracle$/i, "");
+}
+
+function fleetSessionAliases(name: string): string[] {
+  const normalized = normalizeName(name);
+  const withoutOrdinal = normalized.replace(/^\d+[-_]/, "");
+  return [...new Set([normalized, withoutOrdinal, stripOracleSuffix(normalized), stripOracleSuffix(withoutOrdinal)])];
+}
+
+function fleetWindowMatches(query: string, sessionName: string | undefined, windowName: string | undefined, repoSlug: string): boolean {
+  const q = normalizeName(query);
+  const repo = splitRepoSlug(repoSlug);
+  const aliases = new Set<string>([q, `${q}-oracle`, stripOracleSuffix(q)]);
+  if (windowName) {
+    const win = normalizeName(windowName);
+    if (aliases.has(win) || aliases.has(stripOracleSuffix(win))) return true;
+  }
+  if (sessionName && fleetSessionAliases(sessionName).some((a) => aliases.has(a))) return true;
+  if (repo) {
+    const repoName = normalizeName(repo.repo);
+    if (aliases.has(repoName) || aliases.has(stripOracleSuffix(repoName))) return true;
+  }
+  return false;
+}
+
+function uniqueRepoSpecs(specs: RepoSpec[]): RepoSpec[] {
+  const seen = new Map<string, RepoSpec>();
+  for (const spec of specs) {
+    const key = `${spec.owner}/${spec.repo}`;
+    if (!seen.has(key)) seen.set(key, spec);
+  }
+  return [...seen.values()];
+}
+
+function pickSingleRepo(query: string, matches: RepoSpec[], source: string): RepoSpec | null {
+  const unique = uniqueRepoSpecs(matches);
+  if (unique.length === 0) return null;
+  if (unique.length === 1) return unique[0];
+  throw new UsageError(
+    `ambiguous repo "${query}" — ${source} found ${unique.length} matches:\n  ${unique.map((m) => `${m.owner}/${m.repo}${m.path ? ` (${m.path})` : ""}`).join("\n  ")}\nspecify --owner and --repo`,
+  );
+}
+
+export function fleetDir(): string {
+  if (process.env.MAW_HOME) return join(process.env.MAW_HOME, "config", "fleet");
+  return join(process.env.MAW_CONFIG_DIR || join(homedir(), ".config", "maw"), "fleet");
+}
+
+export function resolveFleetRepoFromSessions(query: string, sessions: FleetSession[]): RepoSpec | null {
+  const matches: RepoSpec[] = [];
+  for (const session of sessions) {
+    const sessionName = typeof session.name === "string" ? session.name : undefined;
+    const windows = Array.isArray(session.windows) ? session.windows as FleetWindow[] : [];
+    for (const window of windows) {
+      const repoSlug = typeof window.repo === "string" ? window.repo : "";
+      if (!repoSlug || !fleetWindowMatches(query, sessionName, typeof window.name === "string" ? window.name : undefined, repoSlug)) continue;
+      const split = splitRepoSlug(repoSlug);
+      if (!split) continue;
+      matches.push({ owner: split.owner, repo: split.repo, source: sessionName ? `fleet:${sessionName}` : "fleet" });
+    }
+  }
+  return pickSingleRepo(query, matches, "fleet");
+}
+
+export async function resolveFleetRepo(query: string, dir: string = fleetDir()): Promise<RepoSpec | null> {
+  let files: string[];
+  try {
+    files = await readdir(dir);
+  } catch {
+    return null;
+  }
+  const sessions: FleetSession[] = [];
+  for (const file of files.filter((f) => f.endsWith(".json") && !f.endsWith(".disabled")).sort()) {
+    try {
+      sessions.push(JSON.parse(await readFile(join(dir, file), "utf8")) as FleetSession);
+    } catch {
+      // Ignore malformed/stale fleet files; osmosis can still fall back to local paths/ghq.
+    }
+  }
+  return resolveFleetRepoFromSessions(query, sessions);
+}
+
+export function resolveGhqRepoFromPaths(query: string, paths: string[]): RepoSpec | null {
+  const repos = paths.map(repoFromGhqPath).filter((repo): repo is RepoSpec => !!repo);
+  const q = normalizeName(query);
+  const exact = repos.filter((r) => normalizeName(r.repo) === q);
+  if (exact.length > 0) return pickSingleRepo(query, exact, "ghq");
+  const fuzzy = repos.filter((r) => {
+    const repo = normalizeName(r.repo);
+    return stripOracleSuffix(repo) === q || repo.includes(q);
+  });
+  return pickSingleRepo(query, fuzzy, "ghq");
+}
 
 const M5_ROOT_FALLBACK = "/opt/Code";
 
@@ -30,6 +157,13 @@ export async function ghqRemoteRoot(host: string): Promise<string> {
   ]);
   if (code !== 0) throw new UsageError(`ghq root on ${host} failed`);
   return stdout.trim();
+}
+
+export async function ghqResolveRepo(repo: string): Promise<RepoSpec | null> {
+  const { code, stdout } = await exec("ghq", ["list", "-p", repo]);
+  if (code !== 0) return null;
+  const matches = stdout.trim().split("\n").filter(Boolean);
+  return resolveGhqRepoFromPaths(repo, matches);
 }
 
 export async function ghqResolveOwner(repo: string): Promise<string | null> {

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-17T11:08:47Z",
+  "updated": "2026-05-18T04:57:28Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -416,6 +416,17 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-05-14T12:00:00Z",
       "tier": "extra"
+    },
+    "osmosis": {
+      "version": "0.1.0",
+      "source": "soul-brews-studio/maw-plugin-registry/osmosis@main",
+      "sha256": null,
+      "summary": "Cross-host repo sync with a safety membrane \u2014 case-collisions, secret-sniff, AppleDouble filter. Dry-run by default.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-05-17T18:10:00Z",
+      "tier": "standard"
     },
     "overview": {
       "version": "0.1.0",


### PR DESCRIPTION
## Summary
- Resolve osmosis `--repo` aliases through fleet window metadata before strict local lookup.
- Add ghq fuzzy repo fallback for oracle-style names like `homekeeper` → `homekeeper-oracle` when no fleet pin exists.
- Keep explicit `--owner` as the opt-out/escape hatch.

Fixes Soul-Brews-Studio/maw-js#1778.

## Validation
- `bun test plugins/osmosis`
- `bun --check plugins/osmosis/lib/ghq.ts`
- `bun --check plugins/osmosis/lib/execute.ts`
- `bun plugins/osmosis/index.ts --push white.local --repo homekeeper --diff --no-worktrees` now resolves `laris-co/homelab` via `fleet:20-homekeeper` and completes dry-run preview.

## Known unrelated suite state
- `bun test` across the whole registry is still red in this temporary worktree because multiple unrelated plugins cannot import `maw-js/*` subpath exports from the worktree dependency layout, and existing peers tests time out. The osmosis-targeted suite is green.

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
