### PR TITLE
feat(osmosis): target per-user fleet trees

### DIFF
--- a/plugins/osmosis/lib/config.test.ts
+++ b/plugins/osmosis/lib/config.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { parseArgs, parseHostTarget } from "./config";
+import { UsageError } from "./types";
+
+describe("osmosis host target parsing", () => {
+  test("keeps plain hosts as the ssh target without a remote user", () => {
+    expect(parseHostTarget("white.local")).toEqual({ host: "white.local", remoteUser: undefined });
+  });
+
+  test("accepts ssh-style user@host and exposes the user for remote ghq root selection", () => {
+    expect(parseHostTarget("alpha@white.local")).toEqual({ host: "alpha@white.local", remoteUser: "alpha" });
+  });
+
+  test("--user is alternate spelling for user@host", () => {
+    expect(parseHostTarget("white.local", "alpha")).toEqual({ host: "alpha@white.local", remoteUser: "alpha" });
+  });
+
+  test("rejects conflicting --user and user@host values", () => {
+    expect(() => parseHostTarget("alpha@white.local", "beta")).toThrow(UsageError);
+  });
+
+  test("rejects shell-shaped ssh targets instead of passing arbitrary ssh strings", () => {
+    expect(() => parseHostTarget("alpha@white.local -oProxyCommand=oops")).toThrow(UsageError);
+    expect(() => parseHostTarget("alpha@white.local:/opt/alpha/Code")).toThrow(UsageError);
+  });
+
+  test("parseArgs stores the normalized ssh target and remote user", () => {
+    const cfg = parseArgs(["--push", "alpha@white", "--repo", "odin-oracle"], "/tmp/no-derive");
+    expect(cfg.host).toBe("alpha@white");
+    expect(cfg.remoteUser).toBe("alpha");
+    expect(cfg.repo).toBe("odin-oracle");
+  });
+});

--- a/plugins/osmosis/lib/config.ts
+++ b/plugins/osmosis/lib/config.ts
@@ -1,6 +1,7 @@
 import { type Config, type Direction, UsageError } from "./types";
 
 const VALID_NAME = /^[A-Za-z0-9._-]+$/;
+const VALID_HOST_TARGET = /^(?:([A-Za-z0-9._-]+)@)?([A-Za-z0-9._-]+)$/;
 
 export function deriveFromPwd(cwd: string): { owner?: string; repo?: string; worktreeSuffix?: string } {
   const m = cwd.match(/\/opt\/Code\/github\.com\/([^/]+)\/([^/]+)/);
@@ -24,6 +25,23 @@ export function validate(name: string, value: string): void {
   }
 }
 
+export function parseHostTarget(raw: string, userFlag = ""): { host: string; remoteUser?: string } {
+  const m = raw.match(VALID_HOST_TARGET);
+  if (!m) {
+    throw new UsageError(`invalid host: ${JSON.stringify(raw)} — must match ${VALID_HOST_TARGET}`);
+  }
+  const userFromHost = m[1] || "";
+  const hostOnly = m[2];
+  if (userFlag && userFromHost && userFlag !== userFromHost) {
+    throw new UsageError(`invalid host: --user ${JSON.stringify(userFlag)} conflicts with ${JSON.stringify(raw)}`);
+  }
+  if (userFlag) validate("user", userFlag);
+  if (userFromHost) validate("user", userFromHost);
+  validate("host", hostOnly);
+  const remoteUser = userFlag || userFromHost || undefined;
+  return { host: remoteUser ? `${remoteUser}@${hostOnly}` : hostOnly, remoteUser };
+}
+
 export function parseArgs(argv: string[], cwd: string = process.cwd()): Config {
   const get = (name: string, fallback: string) => {
     const i = argv.indexOf(name);
@@ -45,9 +63,11 @@ export function parseArgs(argv: string[], cwd: string = process.cwd()): Config {
   if (!host) {
     throw new UsageError("must specify --push <host> or --pull <host>");
   }
+  const hostTarget = parseHostTarget(host, get("--user", ""));
 
   const cfg: Config = {
-    host,
+    host: hostTarget.host,
+    remoteUser: hostTarget.remoteUser,
     direction,
     repo: get("--repo", derived.repo ?? ""),
     owner: get("--owner", derived.owner ?? "laris-co"),
@@ -63,7 +83,6 @@ export function parseArgs(argv: string[], cwd: string = process.cwd()): Config {
     derivedFrom,
   };
 
-  validate("host", cfg.host);
   validate("owner", cfg.owner);
   if (cfg.repo) validate("repo", cfg.repo);
   return cfg;
@@ -75,8 +94,9 @@ export function help(): string {
     "",
     "  rsync between m5 and a trusted fleet host. Worktrees synced by default.",
     "",
-    "  --push <host>     m5 → host",
-    "  --pull <host>     host → m5",
+    "  --push [user@]host  m5 → host (user targets /opt/<user>/Code)",
+    "  --pull [user@]host  host → m5 (user targets /opt/<user>/Code)",
+    "  --user USER       alternate spelling for USER@host",
     "  --repo NAME       repo name (default: derived from pwd)",
     "  --owner OWNER     github owner (default: pwd; ghq resolves; fallback laris-co)",
     "  --no-worktrees    repo only, skip <repo>.wt-* siblings",

--- a/plugins/osmosis/lib/execute.ts
+++ b/plugins/osmosis/lib/execute.ts
@@ -45,8 +45,10 @@ export async function execute(args: string[], options: { exitOnMissing?: boolean
     return;
   }
 
-  let remoteRoot = localRoot;
-  try { remoteRoot = await ghqRemoteRoot(cfg.host); } catch { /* surfaced via targetState */ }
+  let remoteRoot = cfg.remoteUser ? `/opt/${cfg.remoteUser}/Code` : localRoot;
+  if (!cfg.remoteUser) {
+    try { remoteRoot = await ghqRemoteRoot(cfg.host); } catch { /* surfaced via targetState */ }
+  }
   const remoteHome = await remoteHomedir(cfg.host);
 
   const { targets, warnings } = await enumerateTargets(cfg, localRoot, remoteRoot, remoteHome);

--- a/plugins/osmosis/lib/targets.test.ts
+++ b/plugins/osmosis/lib/targets.test.ts
@@ -1,0 +1,50 @@
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { realpathSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { enumerateTargets } from "./targets";
+import type { Config } from "./types";
+
+const temps: string[] = [];
+
+function cfg(overrides: Partial<Config> = {}): Config {
+  return {
+    host: "alpha@white",
+    remoteUser: "alpha",
+    direction: "push",
+    repo: "odin-oracle",
+    owner: "laris-co",
+    apply: false,
+    json: false,
+    verbose: false,
+    safe: false,
+    force: false,
+    yes: false,
+    noWorktrees: true,
+    sessions: false,
+    diff: false,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(temps.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("osmosis target paths", () => {
+  test("per-user ssh targets sync repos into /opt/<user>/Code ghq trees", async () => {
+    const root = realpathSync(await mkdtemp(join(tmpdir(), "osmosis-targets-")));
+    temps.push(root);
+    await mkdir(join(root, "github.com/laris-co/odin-oracle"), { recursive: true });
+
+    const { targets } = await enumerateTargets(cfg(), root, "/opt/alpha/Code", "/home/alpha");
+
+    expect(targets).toHaveLength(1);
+    expect(targets[0]).toMatchObject({
+      localPath: `${root}/github.com/laris-co/odin-oracle`,
+      remotePath: "/opt/alpha/Code/github.com/laris-co/odin-oracle",
+      realLocal: `${root}/github.com/laris-co/odin-oracle`,
+    });
+  });
+});

--- a/plugins/osmosis/lib/types.ts
+++ b/plugins/osmosis/lib/types.ts
@@ -2,6 +2,7 @@ export type Direction = "push" | "pull";
 
 export type Config = {
   host: string;
+  remoteUser?: string;
   direction: Direction;
   repo: string;
   owner: string;

--- a/plugins/osmosis/plugin.json
+++ b/plugins/osmosis/plugin.json
@@ -12,10 +12,11 @@
   "cli": {
     "command": "osmosis",
     "aliases": ["sync"],
-    "help": "maw osmosis|sync (--push <host> | --pull <host>) [--repo X] [--owner Y] [--no-worktrees] [--sessions | --all] [--apply [--yes]] [--safe [--force]] [--json] [--verbose]",
+    "help": "maw osmosis|sync (--push [user@]host | --pull [user@]host) [--user USER] [--repo X] [--owner Y] [--no-worktrees] [--sessions | --all] [--apply [--yes]] [--safe [--force]] [--json] [--verbose]",
     "flags": {
       "--push": "string",
       "--pull": "string",
+      "--user": "string",
       "--repo": "string",
       "--owner": "string",
       "--no-worktrees": "boolean",


### PR DESCRIPTION
## Summary
- accept validated `[user@]host` osmosis targets plus `--user USER`
- preserve `cfg.host` as the SSH/rsync transport string while using `remoteUser` to select `/opt/<user>/Code`
- reject arbitrary SSH option strings and scp-style `host:path` targets

Fixes Soul-Brews-Studio/maw-js#1791.

## Validation
- `rtk bun test plugins/osmosis`
- `rtk bun scripts/validate-registry.ts --step plugin-json --plugins osmosis` (non-blocking existing ajv executable warning)
- `rtk bun scripts/validate-registry.ts --step license --plugins osmosis`
- `rtk bun scripts/validate-registry.ts --step source-format --plugins osmosis`

Written by [m5:mawjs-codex] — an Oracle AI running GPT-5.5 in Nat's m5 session, using GitHub auth @nazt. AI speaking as itself, not pretending to be human.
