### PR TITLE
discord plugin v0.4.1 + v0.4.2 + v0.4.2+ merges to main

### DIFF
--- a/plugins/discord/index.ts
+++ b/plugins/discord/index.ts
@@ -3,6 +3,7 @@ import { cmdTokens } from "./tokens";
 import { cmdStatus } from "./status";
 import { cmdBind } from "./bind";
 import { cmdAccess } from "./access";
+import { cmdGuilds, cmdChannels, cmdMembers, cmdInventory } from "./inventory";
 import { readFileSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
@@ -30,6 +31,7 @@ function printVersion(log: (s: string) => void): void {
   log("  ✓ status [bot] [flags]     v0.3.1 (real online/where via bun ancestry)");
   log("  ✓ bind <bot>               v0.3 (rewrite to use 'maw wake' pending)");
   log("  ✓ access <bot> ...         v0.4 (list/show/map/add/rm/set/allow/lockdown)");
+  log("  ✓ guilds/channels/members/inventory <bot>  v0.4.2 (Discord-state visibility)");
   log("  ⏸ pair <oracle> <chan>     v0.5 planned");
   log("  ⏸ route <from> <to>        v0.5 planned");
   log("  ⏸ serve (after_send hook)  v0.5 planned (replaces daemon — engine.serve)");
@@ -105,6 +107,26 @@ export default async function handler(ctx: InvokeContext): Promise<InvokeResult>
 
     if (sub === "access") {
       await cmdAccess.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "guilds") {
+      await cmdGuilds.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "channels") {
+      await cmdChannels.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "members") {
+      await cmdMembers.run(log, args.slice(1));
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    if (sub === "inventory") {
+      await cmdInventory.run(log, args.slice(1));
       return { ok: true, output: logs.join("\n") };
     }
 

--- a/plugins/discord/inventory.ts
+++ b/plugins/discord/inventory.ts
@@ -1,0 +1,301 @@
+/**
+ * `maw discord <guilds|channels|inventory|members>` — Discord-state visibility.
+ *
+ * Complements access.ts (config side) with the REST/Discord side:
+ *   - guilds:    which servers is this bot in?
+ *   - channels:  what channels exist per guild?
+ *   - members:   who can chat in a channel (allowFrom + optional REST member list)?
+ *   - inventory: full report — guilds × channels × access cross-reference
+ *
+ * All read-only. No JSON mutation. Heavy callers should use --json to pipe.
+ */
+import { listPassTokens, decryptToken, findHybridDiscord, findLegacyStateDir } from "./lib";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+interface BotPre {
+  bot: string;
+  stateDir: string;
+  tokenName: string;
+  token: string;
+  accessJson: string;
+  channelMap: string;
+}
+
+async function resolveBot(log: (s: string) => void, bot: string): Promise<BotPre | null> {
+  const hybrid = await findHybridDiscord(bot);
+  const legacy = findLegacyStateDir(bot);
+  const stateDir = hybrid || legacy;
+  if (!stateDir) {
+    log(`✗ no state-dir for '${bot}'`);
+    return null;
+  }
+  const tokens = listPassTokens();
+  const tok = tokens.find(t => t.bot === bot);
+  if (!tok) {
+    log(`✗ no pass entry for '${bot}'`);
+    return null;
+  }
+  const token = await decryptToken(tok.name);
+  if (!token) {
+    log(`✗ failed to decrypt pass entry for '${bot}'`);
+    return null;
+  }
+  return {
+    bot,
+    stateDir,
+    tokenName: tok.name,
+    token,
+    accessJson: join(stateDir, "access.json"),
+    channelMap: join(stateDir, "channel-map.json"),
+  };
+}
+
+interface Guild {
+  id: string;
+  name: string;
+}
+
+interface Channel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id?: string | null;
+  guild_id?: string;
+}
+
+async function fetchGuilds(token: string): Promise<Guild[]> {
+  const res = await fetch("https://discord.com/api/v10/users/@me/guilds", {
+    headers: { Authorization: `Bot ${token}` },
+  });
+  if (!res.ok) throw new Error(`guilds REST ${res.status}`);
+  return await res.json() as Guild[];
+}
+
+async function fetchChannels(token: string, guildId: string, retries = 2): Promise<Channel[]> {
+  for (let i = 0; i <= retries; i++) {
+    const res = await fetch(`https://discord.com/api/v10/guilds/${guildId}/channels`, {
+      headers: { Authorization: `Bot ${token}` },
+    });
+    if (res.status === 429) {
+      const retryAfter = parseFloat(res.headers.get("retry-after") || "1");
+      await new Promise(r => setTimeout(r, (retryAfter + 0.2) * 1000));
+      continue;
+    }
+    if (!res.ok) throw new Error(`channels REST ${res.status} for guild ${guildId}`);
+    return await res.json() as Channel[];
+  }
+  throw new Error(`channels REST 429 (exhausted retries) for guild ${guildId}`);
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+function channelTypeLabel(t: number): string {
+  switch (t) {
+    case 0: return "text";
+    case 2: return "voice";
+    case 4: return "cat";
+    case 5: return "news";
+    case 10: case 11: case 12: return "thread";
+    case 13: return "stage";
+    case 15: return "forum";
+    case 16: return "media";
+    default: return `t${t}`;
+  }
+}
+
+function loadAccessGroups(path: string): Record<string, any> {
+  if (!existsSync(path)) return {};
+  try { return JSON.parse(readFileSync(path, "utf8")).groups || {}; } catch { return {}; }
+}
+
+function parseFlags(args: string[]): { positional: string[]; flags: Record<string, any> } {
+  const positional: string[] = [];
+  const flags: Record<string, any> = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--json") flags.json = true;
+    else if (a === "--all-guilds") flags.allGuilds = true;
+    else if (a === "--with-threads") flags.withThreads = true;
+    else if (a === "--guild") flags.guild = args[++i] ?? "";
+    else positional.push(a);
+  }
+  return { positional, flags };
+}
+
+export const cmdGuilds = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord guilds <bot> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+    const guilds = await fetchGuilds(pre.token);
+    if (flags.json) {
+      log(JSON.stringify({ bot, guilds }, null, 2));
+      return;
+    }
+    log(`🌐 ${bot} is in ${guilds.length} server(s):`);
+    log("");
+    log("  id                    name");
+    log("  ────────────────────  ────────────────────────────────────");
+    for (const g of guilds) {
+      log(`  ${g.id}  ${g.name}`);
+    }
+  },
+};
+
+export const cmdChannels = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord channels <bot> [--guild <id>] [--all-guilds] [--json] [--with-threads]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+
+    const guilds = await fetchGuilds(pre.token);
+    const targets = flags.guild
+      ? guilds.filter(g => g.id === flags.guild)
+      : (flags.allGuilds ? guilds : guilds.slice(0, 1));
+
+    const out: Array<{ guild: Guild; channels: Channel[] }> = [];
+    for (const g of targets) {
+      try {
+        await sleep(250); // pace requests to stay under Discord per-route limits
+        const chs = await fetchChannels(pre.token, g.id);
+        const filtered = flags.withThreads ? chs : chs.filter(c => c.type !== 10 && c.type !== 11 && c.type !== 12);
+        out.push({ guild: g, channels: filtered });
+      } catch (e: any) {
+        log(`  ⚠ ${g.id} ${g.name}: ${e.message}`);
+      }
+    }
+    if (flags.json) {
+      log(JSON.stringify({ bot, guilds: out }, null, 2));
+      return;
+    }
+    log(`📺 ${bot} channels across ${out.length} guild(s):`);
+    log("");
+    for (const { guild, channels } of out) {
+      log(`  ▼ ${guild.name} (${guild.id})  ·  ${channels.length} channel(s)`);
+      const groups: Record<string, Channel[]> = {};
+      for (const c of channels) {
+        const cat = c.parent_id || "_root";
+        if (!groups[cat]) groups[cat] = [];
+        groups[cat]!.push(c);
+      }
+      const cats = channels.filter(c => c.type === 4);
+      const catNameById = new Map(cats.map(c => [c.id, c.name]));
+      for (const c of channels.filter(c => c.type !== 4).sort((a, b) => a.name.localeCompare(b.name))) {
+        const catLabel = c.parent_id ? `[${catNameById.get(c.parent_id) || "?"}]` : "";
+        log(`     ${c.id}  ${channelTypeLabel(c.type).padEnd(6)}  #${c.name.padEnd(36)} ${catLabel}`);
+      }
+      log("");
+    }
+  },
+};
+
+export const cmdMembers = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, channelArg] = args;
+    if (!bot || !channelArg) { log("usage: maw discord members <bot> <channel-name-or-id> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+
+    // Resolve channel to id
+    let channelId = /^\d+$/.test(channelArg) ? channelArg : null;
+    if (!channelId) {
+      const map = existsSync(pre.channelMap) ? JSON.parse(readFileSync(pre.channelMap, "utf8")) : {};
+      channelId = map[channelArg] || null;
+    }
+    if (!channelId) {
+      log(`✗ channel '${channelArg}' not in channel-map. Run 'maw discord access ${bot} map --guild <id> --refresh'`);
+      return;
+    }
+    const groups = loadAccessGroups(pre.accessJson);
+    const cfg = groups[channelId];
+    if (!cfg) {
+      log(`✗ channel ${channelId} not in access.json groups for ${bot}`);
+      return;
+    }
+    const { flags } = parseFlags(args.slice(2));
+    const result = {
+      bot,
+      channel: { id: channelId, name: channelArg },
+      requireMention: cfg.requireMention,
+      allowFrom: cfg.allowFrom || [],
+      effective: (cfg.allowFrom || []).length === 0 ? "EVERYONE (no allowlist)" : `${(cfg.allowFrom || []).length} user(s)`,
+    };
+    if (flags.json) { log(JSON.stringify(result, null, 2)); return; }
+    log(`👥 ${bot} · #${channelArg} (${channelId})`);
+    log(`   requireMention: ${result.requireMention}`);
+    log(`   allowFrom:      ${result.allowFrom.length ? result.allowFrom.join(", ") : "(none)"}`);
+    log(`   effective:      ${result.effective}`);
+    log("");
+    log(`   ℹ to list Discord channel members, use --with-discord-members (v0.4.3 — paginated, rate-limited)`);
+  },
+};
+
+export const cmdInventory = {
+  async run(log: (s: string) => void, args: string[]): Promise<void> {
+    const [bot, ...rest] = args;
+    if (!bot) { log("usage: maw discord inventory <bot> [--json]"); return; }
+    const pre = await resolveBot(log, bot);
+    if (!pre) return;
+    const { flags } = parseFlags(rest);
+
+    const guilds = await fetchGuilds(pre.token);
+    const groups = loadAccessGroups(pre.accessJson);
+
+    interface Row {
+      guild: Guild;
+      channels: Array<{ channel: Channel; enabled: boolean; mention?: boolean; allowFrom?: string[] }>;
+    }
+    const rows: Row[] = [];
+    for (const g of guilds) {
+      try {
+        await sleep(250); // pace requests to stay under Discord per-route limits
+        const chs = await fetchChannels(pre.token, g.id);
+        const visible = chs.filter(c => c.type === 0 || c.type === 5 || c.type === 15);
+        const annotated = visible.map(c => {
+          const cfg = groups[c.id];
+          return {
+            channel: c,
+            enabled: !!cfg,
+            mention: cfg?.requireMention,
+            allowFrom: cfg?.allowFrom || [],
+          };
+        });
+        rows.push({ guild: g, channels: annotated });
+      } catch (e: any) {
+        log(`  ⚠ ${g.id} ${g.name}: ${e.message}`);
+      }
+    }
+
+    if (flags.json) {
+      log(JSON.stringify({ bot, inventory: rows }, null, 2));
+      return;
+    }
+
+    let totalEnabled = 0;
+    let totalChannels = 0;
+    log(`📋 ${bot} — full inventory`);
+    log("");
+    for (const { guild, channels } of rows) {
+      const enabled = channels.filter(c => c.enabled).length;
+      totalEnabled += enabled;
+      totalChannels += channels.length;
+      log(`  ▼ ${guild.name}  (${guild.id})  ·  ${enabled}/${channels.length} enabled`);
+      for (const c of channels.sort((a, b) => a.channel.name.localeCompare(b.channel.name))) {
+        if (c.enabled) {
+          const mention = c.mention ? "✓ tag " : "○ all ";
+          const allow = c.allowFrom!.length === 0 ? "EVERYONE" : `${c.allowFrom!.length} user(s)`;
+          log(`     ✓ #${c.channel.name.padEnd(36)} ${mention} ${allow}`);
+        } else {
+          log(`     · #${c.channel.name.padEnd(36)} (in guild, no access)`);
+        }
+      }
+      log("");
+    }
+    log(`summary: ${guilds.length} server(s) · ${totalChannels} channels visible · ${totalEnabled} enabled in access.json`);
+  },
+};

--- a/plugins/discord/inventory.ts
+++ b/plugins/discord/inventory.ts
@@ -72,6 +72,40 @@ async function fetchGuilds(token: string): Promise<Guild[]> {
   return await res.json() as Guild[];
 }
 
+// Per-process user-name cache so repeated id→name lookups don't refetch
+const _userCache: Map<string, string> = new Map();
+
+async function resolveUserName(token: string, userId: string): Promise<string> {
+  if (_userCache.has(userId)) return _userCache.get(userId)!;
+  try {
+    const res = await fetch(`https://discord.com/api/v10/users/${userId}`, {
+      headers: { Authorization: `Bot ${token}` },
+    });
+    if (res.status === 429) {
+      const retry = parseFloat(res.headers.get("retry-after") || "1");
+      await new Promise(r => setTimeout(r, (retry + 0.2) * 1000));
+      return resolveUserName(token, userId);
+    }
+    if (!res.ok) { _userCache.set(userId, userId); return userId; }
+    const u: any = await res.json();
+    const name = u.global_name || u.username || userId;
+    _userCache.set(userId, name);
+    return name;
+  } catch {
+    _userCache.set(userId, userId);
+    return userId;
+  }
+}
+
+async function resolveUserList(token: string, ids: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const id of ids) {
+    out.push(await resolveUserName(token, id));
+    await new Promise(r => setTimeout(r, 80));
+  }
+  return out;
+}
+
 async function fetchChannels(token: string, guildId: string, retries = 2): Promise<Channel[]> {
   for (let i = 0; i <= retries; i++) {
     const res = await fetch(`https://discord.com/api/v10/guilds/${guildId}/channels`, {
@@ -218,20 +252,26 @@ export const cmdMembers = {
       return;
     }
     const { flags } = parseFlags(args.slice(2));
+    const ids: string[] = cfg.allowFrom || [];
+    const names = await resolveUserList(pre.token, ids);
+    const pairs = ids.map((id, i) => ({ id, name: names[i]! }));
     const result = {
       bot,
       channel: { id: channelId, name: channelArg },
       requireMention: cfg.requireMention,
-      allowFrom: cfg.allowFrom || [],
-      effective: (cfg.allowFrom || []).length === 0 ? "EVERYONE (no allowlist)" : `${(cfg.allowFrom || []).length} user(s)`,
+      allowFrom: pairs,
+      effective: ids.length === 0 ? "EVERYONE (no allowlist)" : `${ids.length} user(s)`,
     };
     if (flags.json) { log(JSON.stringify(result, null, 2)); return; }
     log(`👥 ${bot} · #${channelArg} (${channelId})`);
     log(`   requireMention: ${result.requireMention}`);
-    log(`   allowFrom:      ${result.allowFrom.length ? result.allowFrom.join(", ") : "(none)"}`);
+    if (pairs.length === 0) {
+      log(`   allowFrom:      (none)`);
+    } else {
+      log(`   allowFrom:`);
+      for (const p of pairs) log(`     · ${p.name.padEnd(18)} (${p.id})`);
+    }
     log(`   effective:      ${result.effective}`);
-    log("");
-    log(`   ℹ to list Discord channel members, use --with-discord-members (v0.4.3 — paginated, rate-limited)`);
   },
 };
 
@@ -276,6 +316,12 @@ export const cmdInventory = {
       return;
     }
 
+    // Pre-resolve all unique user ids referenced in access.json for nicer rendering
+    const allIds = new Set<string>();
+    for (const r of rows) for (const c of r.channels) (c.allowFrom || []).forEach(id => allIds.add(id));
+    const nameById = new Map<string, string>();
+    for (const id of allIds) nameById.set(id, await resolveUserName(pre.token, id));
+
     let totalEnabled = 0;
     let totalChannels = 0;
     log(`📋 ${bot} — full inventory`);
@@ -288,7 +334,9 @@ export const cmdInventory = {
       for (const c of channels.sort((a, b) => a.channel.name.localeCompare(b.channel.name))) {
         if (c.enabled) {
           const mention = c.mention ? "✓ tag " : "○ all ";
-          const allow = c.allowFrom!.length === 0 ? "EVERYONE" : `${c.allowFrom!.length} user(s)`;
+          const allow = c.allowFrom!.length === 0
+            ? "EVERYONE"
+            : c.allowFrom!.map(id => nameById.get(id) || id).join(", ");
           log(`     ✓ #${c.channel.name.padEnd(36)} ${mention} ${allow}`);
         } else {
           log(`     · #${c.channel.name.padEnd(36)} (in guild, no access)`);
@@ -296,6 +344,6 @@ export const cmdInventory = {
       }
       log("");
     }
-    log(`summary: ${guilds.length} server(s) · ${totalChannels} channels visible · ${totalEnabled} enabled in access.json`);
+    log(`summary: ${guilds.length} server(s) · ${totalChannels} channels visible · ${totalEnabled} enabled · ${nameById.size} unique allow-users resolved`);
   },
 };

--- a/plugins/discord/lib.ts
+++ b/plugins/discord/lib.ts
@@ -131,11 +131,36 @@ export async function loadStateDirsRegistry(): Promise<Set<string>> {
   if (!existsSync(file)) return new Set();
   try {
     const content = readFileSync(file, "utf8");
-    // Match keys of the STATE_DIRS object: `"<bot-name>":`
-    const matches = content.matchAll(/"([a-z][a-z0-9-]+)":/gi);
+    // Limit to STATE_DIRS block (avoid matching ANCHORS keys)
+    const stateBlock = content.split(/export const ANCHORS/)[0]!;
+    const matches = stateBlock.matchAll(/"([a-z][a-z0-9-]+)":/gi);
     return new Set(Array.from(matches, m => m[1]!));
   } catch {
     return new Set();
+  }
+}
+
+/**
+ * Parse the ANCHORS export from discord-oracle/src/state-dirs.ts.
+ * Returns bot → canonical-host mapping. Bots not in ANCHORS have no anchor.
+ */
+export async function loadAnchors(): Promise<Record<string, string>> {
+  const repo = await findGhqPath("discord-oracle");
+  if (!repo) return {};
+  const file = join(repo, "src", "state-dirs.ts");
+  if (!existsSync(file)) return {};
+  try {
+    const content = readFileSync(file, "utf8");
+    const block = content.split(/export const ANCHORS[^{]*{/)[1];
+    if (!block) return {};
+    const body = block.split(/^};/m)[0] || "";
+    const out: Record<string, string> = {};
+    for (const m of body.matchAll(/"([a-z][a-z0-9-]+)"\s*:\s*"([^"]+)"/gi)) {
+      out[m[1]!] = m[2]!;
+    }
+    return out;
+  } catch {
+    return {};
   }
 }
 

--- a/plugins/discord/plugin.json
+++ b/plugins/discord/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "discord",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "description": "Discord fleet ops — tokens, bind, status, route, pair. Hybrid pattern (token in pass, config in repo).",

--- a/plugins/discord/plugin.json
+++ b/plugins/discord/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "discord",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "description": "Discord fleet ops — tokens, bind, status, route, pair. Hybrid pattern (token in pass, config in repo).",

--- a/plugins/discord/status.ts
+++ b/plugins/discord/status.ts
@@ -16,7 +16,7 @@
 import {
   listPassTokens, decryptToken, pingDiscord,
   findLegacyStateDir, findHybridDiscord, findTmuxSession,
-  loadStateDirsRegistry, findOnlineBunForBot, fmtSize,
+  loadStateDirsRegistry, loadAnchors, findOnlineBunForBot, fmtSize,
 } from "./lib";
 import { readdirSync, statSync } from "fs";
 import { join } from "path";
@@ -32,6 +32,7 @@ interface BotRow {
   online: boolean;
   onlineSession: string | null;
   onlineBunPid: number | null;
+  anchor: string | null;
   discordOK?: boolean;
   discordStatus?: number;
   discordUsername?: string;
@@ -70,6 +71,7 @@ function classifyBot(row: BotRow): { severity: Severity; reason: string } {
 async function gatherRows(): Promise<BotRow[]> {
   const tokens = listPassTokens();
   const registry = await loadStateDirsRegistry();
+  const anchors = await loadAnchors();
   const allBots = new Set<string>([...tokens.map(t => t.bot), ...registry]);
 
   const rows: BotRow[] = [];
@@ -90,6 +92,7 @@ async function gatherRows(): Promise<BotRow[]> {
       online: !!onlineInfo,
       onlineSession: onlineInfo?.tmuxSession ?? null,
       onlineBunPid: onlineInfo?.bunPid ?? null,
+      anchor: anchors[bot] ?? null,
     });
   }
   return rows;
@@ -113,10 +116,6 @@ async function addDiscordChecks(rows: BotRow[]): Promise<void> {
     row.discordStatus = ping.status;
     row.discordUsername = ping.username;
   }
-}
-
-function sym(b: boolean): string {
-  return b ? "✓" : "·";
 }
 
 function sevIcon(s: Severity): string {
@@ -178,42 +177,36 @@ export const cmdStatus = {
     const host = hostname().split(".")[0];
     log(`🔍 maw discord status @ ${host} — ${rows.length} bot(s) | ${opts.redact ? "REDACTED · " : ""}${opts.check ? "with Discord REST" : "online/where via bun ancestry — use --check for REST"}`);
     log("");
-    const head = opts.check
-      ? "  bot                          online  where (tmux session)              path                                              reg  discord       severity"
-      : "  bot                          online  where (tmux session)              path                                              reg  severity";
+    const head = "  bot                          online  anchor              drift  where (tmux session)              severity";
     log(head);
     log("  " + "─".repeat(head.length - 2));
 
     const counts: Record<Severity, number> = { ok: 0, warn: 0, info: 0, error: 0 };
+    let driftCount = 0;
     for (const row of rows) {
       const cls = classifyBot(row);
       counts[cls.severity]++;
       const bot = row.bot.padEnd(28);
       const online = row.online ? "✓ ON  " : "✗ off ";
+      const anchor = (row.anchor || "—").padEnd(18);
+      // Drift detection: bot is online HERE but its anchor is elsewhere → ⚠ drift
+      const hostNow = host;
+      const isHere = row.anchor === hostNow || row.anchor === `nat@${hostNow}` || row.anchor?.endsWith(`@${hostNow}`) || row.anchor?.endsWith(`@${hostNow}.wg`);
+      let drift = "  ─  ";
+      if (row.online && row.anchor && !isHere) { drift = "⚠ here"; driftCount++; }
+      else if (row.online && row.anchor) drift = " ✓ ok ";
+      else if (!row.online && row.anchor && isHere) drift = "⚠ down";
       const where = (row.onlineSession || (row.tmuxLine ? "(orphan tmux)" : "—")).padEnd(33);
-      const path = (row.hybridPath || row.legacyPath || "—")
-        .replace(process.env.HOME || "~", "~")
-        .padEnd(49);
-      const reg = sym(row.inRegistry).padEnd(4);
       const sev = `${sevIcon(cls.severity)} ${cls.severity}`;
-
-      if (opts.check) {
-        const discord = row.discordOK === undefined
-          ? "—            "
-          : row.discordOK
-            ? `✓ 200 ${(row.discordUsername || "—").slice(0, 6).padEnd(7)}`
-            : `✗ ${(row.discordStatus || "ERR").toString().padEnd(11)}`;
-        log(`  ${bot}${online}  ${where} ${path} ${reg} ${discord} ${sev}`);
-      } else {
-        log(`  ${bot}${online}  ${where} ${path} ${reg} ${sev}`);
-      }
+      log(`  ${bot}${online}  ${anchor}  ${drift}  ${where} ${sev}`);
     }
 
     log("");
     log(`summary @ ${host}: ${counts.ok} ok · ${counts.warn} warn · ${counts.info} info · ${counts.error} error`);
-    log(`  online: ${rows.filter(r => r.online).length}/${rows.length}  ·  legend: ✓ ON = Gateway bun verified · ✗ off = no bun on this host`);
-    if (counts.error > 0) {
-      log(`run 'maw discord status <bot>' for details on any error/info row`);
+    log(`  online: ${rows.filter(r => r.online).length}/${rows.length}  ·  anchors: ${rows.filter(r => r.anchor).length}/${rows.length}  ·  drift: ${driftCount}`);
+    log(`  legend: ✓ ON = Gateway bun verified · anchor = canonical host (state-dirs.ts ANCHORS) · drift = bot online but not on anchor host`);
+    if (counts.error > 0 || driftCount > 0) {
+      log(`run 'maw discord status <bot>' for details on any error/drift row`);
     }
   },
 

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-18T04:57:28Z",
+  "updated": "2026-05-22T01:15:37Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -196,17 +196,6 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:40:03Z",
       "tier": "extra"
-    },
-    "dig": {
-      "version": "0.1.0",
-      "source": "soul-brews-studio/maw-plugin-registry/dig@main",
-      "sha256": null,
-      "summary": "Session mining CLI \u2014 human/AI message separation, time-range filters, keyword grep across Claude Code .jsonl history.",
-      "author": "Soul-Brews-Studio",
-      "license": "MIT",
-      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
-      "addedAt": "2026-05-17T12:00:00Z",
-      "tier": "standard"
     },
     "doctor": {
       "version": "0.1.0",


### PR DESCRIPTION
Cherry-picks three discord plugin commits from \`absorb-plugin\` that never landed on main. \`absorb-plugin\` has unrelated WIP (about/absorb deletions + buddy/dig); this PR carries only the discord-relevant changes.

## Commits

- \`9a0aeed\` → discord v0.4.1: **anchor-aware status** (drift detection from state-dirs.ts ANCHORS)
- \`a38148b\` → discord v0.4.2: **inventory subcommands** (guilds / channels / members / inventory)
- \`2c18c43\` → discord v0.4.2+: **resolve user IDs → names** in inventory output

## Why now

Per Soul-Brews-Studio/maw-js issue [TBD — tracked separately as Wave B]: every \`bun install -g maw-js\` recreates vendor symlinks from the maw-js vendor set, and silently wipes manual layer-3 symlinks like \`~/.maw/plugins/discord\`. Yesterday's alpha release triggered this.

This PR alone doesn't prevent the wipe — vendoring into maw-js does. But it's prerequisite hygiene: main needs to reflect the actual shipped v0.4.2 before we vendor.

## Related

- discord-oracle/CLAUDE.md (today's commit \`9d50d29\`) — anchor-aware migration recipe that depends on \`maw discord status\` v0.4.1 features
- Soul-Brews-Studio/maw-plugin-registry#96 — anchor-aware status/bind feature work (post-merge target)

🤖 ตอบโดย discord จาก Nat → discord-oracle