### PR TITLE
add plugin: team-agent v1.2.0

### DIFF
--- a/plugins/team-agent/cmd/bring.ts
+++ b/plugins/team-agent/cmd/bring.ts
@@ -1,0 +1,87 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+
+export async function cmdBring(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  if (!team) {
+    throw new Error("usage: maw team-agent bring <team> [<role>] [--split|--switch|--list]");
+  }
+
+  if (!existsSync(configPath(team))) {
+    throw new Error(`team not found: ${team}`);
+  }
+
+  const cfg = readConfig(team);
+  const workers = cfg.members.filter((m: any) => m.agentType !== "shell");
+
+  if (workers.length === 0) {
+    throw new Error(`no workers in team ${team}`);
+  }
+
+  // --list → just show
+  if (flags["--list"] === true) {
+    console.log(`\x1b[36mteam:\x1b[0m \x1b[1m${team}\x1b[0m`);
+    for (let i = 0; i < workers.length; i++) {
+      const w = workers[i];
+      console.log(`  ${i + 1}. ${team}-${w.name}  \x1b[90m(${w.color}, ssn=${(w.sessionId || "").slice(0, 8)})\x1b[0m`);
+    }
+    return;
+  }
+
+  // Resolve target role: positional or prompt
+  let role = args[1];
+  if (!role) {
+    if (!process.stdin.isTTY) {
+      throw new Error(`missing role — usage: maw team-agent bring ${team} <role>`);
+    }
+    console.log(`\x1b[36mteam:\x1b[0m \x1b[1m${team}\x1b[0m`);
+    for (let i = 0; i < workers.length; i++) {
+      const w = workers[i];
+      console.log(`  ${i + 1}. ${team}-${w.name}  \x1b[90m(${w.color})\x1b[0m`);
+    }
+    const answer = (prompt(`\x1b[36mPick [1-${workers.length}]:\x1b[0m`) || "").trim();
+    const idx = parseInt(answer, 10);
+    if (idx < 1 || idx > workers.length) {
+      console.log(`\x1b[90m  cancelled\x1b[0m`);
+      return;
+    }
+    role = workers[idx - 1].name;
+  }
+
+  // Verify worker exists
+  const worker = workers.find((m: any) => m.name === role);
+  if (!worker) {
+    throw new Error(`worker not found in team: ${role} (valid: ${workers.map((m: any) => m.name).join(", ")})`);
+  }
+
+  const sessionName = `${team}-${role}`;
+
+  // Verify tmux session exists
+  const check = spawnSync("tmux", ["has-session", "-t", sessionName], { stdio: "pipe" });
+  if (check.status !== 0) {
+    throw new Error(`tmux session not found: ${sessionName} (worker may have exited)`);
+  }
+
+  const inTmux = !!process.env.TMUX;
+  const split = flags["--split"] === true;
+  const switchClient = flags["--switch"] === true;
+
+  if (split) {
+    if (!inTmux) throw new Error(`--split requires being inside tmux`);
+    console.log(`\x1b[36m→ split:\x1b[0m new pane → ${sessionName}`);
+    spawnSync("tmux", ["split-window", "-h", `tmux attach -t ${sessionName}`], { stdio: "inherit" });
+  } else if (switchClient || inTmux) {
+    console.log(`\x1b[36m→ switch:\x1b[0m ${sessionName}`);
+    spawnSync("tmux", ["switch-client", "-t", sessionName], { stdio: "inherit" });
+  } else {
+    console.log(`\x1b[36m→ attach:\x1b[0m ${sessionName}`);
+    spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
+  }
+}

--- a/plugins/team-agent/cmd/charter.ts
+++ b/plugins/team-agent/cmd/charter.ts
@@ -1,0 +1,279 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+import { cmdCreate, cmdSpawn } from "./team";
+
+export async function cmdFrom(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const filePath = args[0];
+  if (!filePath) throw new Error("usage: maw team-agent from <team.yaml>");
+  if (!existsSync(filePath)) throw new Error(`file not found: ${filePath}`);
+
+  // Pass 1: built-in vars
+  const flagSessionId = (flags["--session-id"] as string) || undefined;
+  const gen = generateReadableUuid();
+  const builtins: Record<string, string> = {
+    SESSION_ID: flagSessionId || gen.uuid,
+    PROJECT_ROOT: process.cwd(),
+    PROJECT_NAME: process.cwd().split("/").pop() || "project",
+    HOME: homedir(),
+    USER: process.env.USER || process.env.USERNAME || "user",
+    DATE: new Date().toISOString().slice(0, 10),
+    TIME: new Date().toTimeString().slice(0, 5),
+    COUNTER: String(gen.counter),
+  };
+
+  // Pass 2: resolve builtins first, then parse to extract vars:
+  const raw = readFileSync(filePath, "utf-8");
+  const pass1 = resolveTemplate(raw, builtins);
+  const preparse = parseSimpleYaml(pass1);
+
+  // Pass 3: merge user-defined vars: section → re-resolve
+  if (preparse.vars && typeof preparse.vars === "object") {
+    for (const [k, v] of Object.entries(preparse.vars as Record<string, string>)) {
+      builtins[k] = String(v);
+    }
+  }
+  // Also support top-level key: value pairs as vars (simple strings)
+  // vars: block is parsed specially by parseSimpleYaml — handle inline "vars-KEY: val" too
+  const text = resolveTemplate(pass1, builtins);
+  const charter = parseSimpleYaml(text);
+
+  if (!charter.name) throw new Error("charter missing 'name' field");
+  if (!charter.members || charter.members.length === 0) throw new Error("charter missing 'members'");
+
+  // Top-level cwd as default for members
+  const defaultCwd = charter.cwd || process.cwd();
+
+  const dryRun = flags["--dry-run"] === true;
+  const resolvedSessionId = builtins.SESSION_ID;
+
+  console.log(`\x1b[36m📋 charter:\x1b[0m ${filePath}`);
+  console.log(`  name:       ${charter.name}`);
+  console.log(`  members:    ${charter.members.length}`);
+  console.log(`  session-id: ${resolvedSessionId}`);
+  if (charter.description) console.log(`  description: ${charter.description}`);
+  console.log(``);
+
+  await cmdCreate([charter.name, charter.description || ""], {
+    "--session-id": resolvedSessionId,
+    "--dry-run": dryRun,
+    "--force": flags["--force"] === true,
+    "--yes": flags["--yes"] === true,
+    "-y": flags["-y"] === true,
+  });
+  console.log(``);
+
+  for (const member of charter.members) {
+    let cwd = member.cwd || defaultCwd;
+    const color = member.color || "cyan";
+
+    // Auto worktree: if member has `branch:`, create git worktree
+    if (member.branch) {
+      const branch = member.branch as string;
+      const wtName = member["worktree-name"] || `.wt-${member.role}`;
+      const wtPath = join(defaultCwd, wtName);
+
+      if (dryRun) {
+        console.log(`\x1b[33mdry-run\x1b[0m would create worktree: ${wtPath} (branch: ${branch})`);
+      } else if (existsSync(wtPath)) {
+        console.log(`\x1b[36m🌳\x1b[0m worktree exists: ${wtPath}`);
+      } else {
+        console.log(`\x1b[36m🌳\x1b[0m creating worktree: ${wtPath} (branch: ${branch})`);
+        const wtResult = spawnSync("git", ["worktree", "add", wtPath, "-b", branch], {
+          stdio: "pipe",
+          cwd: defaultCwd,
+        });
+        if (wtResult.status !== 0) {
+          // Branch might exist — try without -b
+          const wtRetry = spawnSync("git", ["worktree", "add", wtPath, branch], {
+            stdio: "pipe",
+            cwd: defaultCwd,
+          });
+          if (wtRetry.status !== 0) {
+            const err = wtRetry.stderr?.toString().trim() || "unknown error";
+            throw new Error(`git worktree add failed for ${member.role}: ${err}`);
+          }
+        }
+        console.log(`\x1b[32m✓\x1b[0m worktree created`);
+      }
+      cwd = wtPath;
+    }
+
+    const spec = `${member.role}@${cwd}:${color}`;
+    const spawnFlags: Record<string, unknown> = {
+      "--model": member.model || "sonnet",
+      "--dry-run": dryRun,
+      "--split": flags["--split"] === true,
+    };
+    if (member["system-prompt"]) spawnFlags["--system-prompt"] = member["system-prompt"];
+    if (member.mission) spawnFlags["--mission"] = member.mission;
+
+    await cmdSpawn([charter.name, spec], spawnFlags);
+    console.log(``);
+  }
+
+  // If --split was used, retile to main-vertical so the operator stays
+  // big-left and all newly-spawned teammates stack on the right.
+  if (flags["--split"] === true && process.env.TMUX && !dryRun) {
+    try {
+      spawnSync("tmux", ["select-layout", "main-vertical"], { stdio: "ignore" });
+      console.log(`\x1b[32m✓\x1b[0m retiled main-vertical (operator left, teammates right)`);
+    } catch {}
+  }
+
+  console.log(`\x1b[32m✓\x1b[0m charter loaded: ${charter.members.length} members spawned from ${filePath}`);
+
+  // Offer to attach if outside tmux + interactive
+  const inTmux = !!process.env.TMUX;
+  const noAttach = flags["--no-attach"] === true;
+  if (!inTmux && !dryRun && !noAttach && process.stdin.isTTY) {
+    console.log(``);
+    console.log(`\x1b[36mAttach to a worker?\x1b[0m`);
+    for (let i = 0; i < charter.members.length; i++) {
+      const m = charter.members[i];
+      console.log(`  ${i + 1}. ${charter.name}-${m.role}`);
+    }
+    console.log(`  0. skip (manually: tmux attach -t ${charter.name}-<role>)`);
+    const answer = (prompt(`\x1b[36mPick [1-${charter.members.length}]:\x1b[0m`) || "").trim();
+    const idx = parseInt(answer, 10);
+    if (idx >= 1 && idx <= charter.members.length) {
+      const sessionName = `${charter.name}-${charter.members[idx - 1].role}`;
+      console.log(`\x1b[36m→ attaching to ${sessionName}...\x1b[0m`);
+      spawnSync("tmux", ["attach", "-t", sessionName], { stdio: "inherit" });
+    } else {
+      console.log(`\x1b[90m  skipped — sessions still running in background\x1b[0m`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// cmdInit — generate YAML charter scaffold
+// ---------------------------------------------------------------------------
+
+
+export async function cmdQuick(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const name = args[0];
+  if (!name) throw new Error("usage: maw team-agent quick <name> [<role>@<cwd>[:<color>] ...] [--preset <name>]");
+
+  const memberArgs = args.slice(1);
+
+  let yaml: string;
+  let modeDesc: string;
+
+  if (memberArgs.length > 0) {
+    // Inline mode: positional member specs
+    const lines: string[] = [
+      `name: ${name}`,
+      `description: "Inline quick team"`,
+      `session-id: \${SESSION_ID}`,
+      `cwd: \${PROJECT_ROOT}`,
+      ``,
+      `members:`,
+    ];
+    for (let i = 0; i < memberArgs.length; i++) {
+      const m = parseMemberSpec(memberArgs[i]!, i);
+      lines.push(`  - role: ${m.role}`);
+      lines.push(`    cwd: ${m.cwd}`);
+      lines.push(`    color: ${m.color}`);
+      lines.push(`    model: sonnet`);
+      lines.push(`    system-prompt: "You are ${m.role}."`);
+      lines.push(``);
+    }
+    yaml = lines.join("\n");
+    modeDesc = `inline (${memberArgs.length} members)`;
+  } else {
+    // Preset mode
+    const presetName = (flags["--preset"] as string) || "pair";
+    if (!(presetName in PRESETS)) {
+      throw new Error(`unknown preset: ${presetName}\n  valid: ${Object.keys(PRESETS).join(", ")}`);
+    }
+    yaml = renderCharterYaml(name, presetName);
+    modeDesc = `preset: ${presetName}`;
+  }
+
+  const tmpPath = join("/tmp", `team-agent-quick-${Date.now()}-${name}.yaml`);
+  writeFileSync(tmpPath, yaml);
+
+  console.log(`\x1b[36m⚡ start\x1b[0m: ${name} (${modeDesc})`);
+  console.log(`  tmp charter: ${tmpPath}`);
+  console.log(``);
+
+  await cmdFrom([tmpPath], flags);
+}
+
+export async function cmdInit(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const name = args[0];
+  if (!name) throw new Error("usage: maw team-agent init <name> [--preset blank|solo|pair|trio|review|stack] [--force]");
+
+  const presetName = (flags["--preset"] as string) || "blank";
+  if (!(presetName in PRESETS)) {
+    throw new Error(`unknown preset: ${presetName}\n  valid: ${Object.keys(PRESETS).join(", ")}`);
+  }
+
+  // Output path resolution:
+  //   --out <path>  → exact path (file or dir)
+  //   --here        → current dir
+  //   default       → ψ/teams/ if exists in git root, else current dir
+  let outPath: string;
+  const outFlag = flags["--out"] as string | undefined;
+  const hereFlag = flags["--here"] === true;
+
+  if (outFlag) {
+    outPath = outFlag.endsWith(".yaml") ? outFlag : join(outFlag, `${name}.yaml`);
+  } else if (hereFlag) {
+    outPath = join(process.cwd(), `${name}.yaml`);
+  } else {
+    // Try ψ/teams/ in git root
+    let gitRoot = process.cwd();
+    try {
+      const result = spawnSync("git", ["rev-parse", "--show-toplevel"], { stdio: "pipe", cwd: process.cwd() });
+      if (result.status === 0) gitRoot = result.stdout.toString().trim();
+    } catch {}
+    const psiTeams = join(gitRoot, "ψ", "teams");
+    if (existsSync(psiTeams)) {
+      outPath = join(psiTeams, `${name}.yaml`);
+    } else {
+      outPath = join(process.cwd(), `${name}.yaml`);
+    }
+  }
+
+  const force = flags["--force"] === true;
+  if (existsSync(outPath) && !force) {
+    throw new Error(`file already exists: ${outPath} (use --force to overwrite)`);
+  }
+
+  const yaml = renderCharterYaml(name, presetName);
+
+  const dryRun = flags["--dry-run"] === true;
+  if (dryRun) {
+    console.log(`\x1b[33mdry-run\x1b[0m would write: ${outPath}`);
+    console.log(`---`);
+    console.log(yaml);
+    return;
+  }
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, yaml);
+
+  const preset = PRESETS[presetName];
+  console.log(`\x1b[32m✓\x1b[0m charter generated: \x1b[1m${outPath}\x1b[0m`);
+  console.log(`  preset:   ${presetName}`);
+  console.log(`  members:  ${preset.members.length} (${preset.members.map((m: { role: string }) => m.role).join(", ")})`);
+  console.log(`  size:     ${yaml.length} bytes`);
+  console.log(``);
+  console.log(`\x1b[36mNext:\x1b[0m`);
+  console.log(`  1. Edit ${outPath} — fill in TODOs, set cwd paths, customize prompts`);
+  console.log(`  2. Preview:  maw team-agent from ${outPath} --dry-run`);
+  console.log(`  3. Launch:   maw team-agent from ${outPath}`);
+}
+
+// ---------------------------------------------------------------------------
+// cmdWizard — interactive step-by-step team setup
+// ---------------------------------------------------------------------------
+

--- a/plugins/team-agent/cmd/cleanup.ts
+++ b/plugins/team-agent/cmd/cleanup.ts
@@ -1,0 +1,155 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync, execSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+
+export async function cmdCleanup(args: string[], flags: Record<string, unknown>): Promise<void> {
+  // Kill all team-agent-spawned panes + optionally remove team dirs.
+  // Usage:
+  //   maw team-agent cleanup                 — list what would happen (dry-run by default)
+  //   maw team-agent cleanup --confirm       — actually do it (keeps team dirs)
+  //   maw team-agent cleanup --confirm --all — also delete all team dirs
+  //   maw team-agent cleanup <team> --confirm — only clean up one team
+  const target = args[0]; // optional team name
+  const confirm = flags["--confirm"] === true;
+  const all = flags["--all"] === true;
+  const noDryRun = confirm;
+
+  if (!existsSync(TEAMS_DIR)) {
+    console.log("(no teams — ~/.claude/teams/ does not exist)");
+    return;
+  }
+
+  const teams = target
+    ? [target].filter((t: string) => existsSync(configPath(t)))
+    : readdirSync(TEAMS_DIR).filter((d: string) => existsSync(configPath(d)));
+
+  if (teams.length === 0) {
+    console.log(target ? `team not found: ${target}` : "(no teams to clean up)");
+    return;
+  }
+
+  console.log(`\x1b[36m🧹\x1b[0m cleanup target: ${teams.length} team(s)`);
+
+  // Plan: collect pane IDs to kill + team dirs to remove
+  const plan: Array<{ team: string; role: string; paneId?: string; sessionId?: string }> = [];
+  for (const t of teams) {
+    const cfg = readConfig(t);
+    for (const m of cfg.members) {
+      if (m.agentType === "shell") continue; // skip shell-lead (it's us!)
+      plan.push({
+        team: t,
+        role: m.name,
+        paneId: m.tmuxPaneId || undefined,
+        sessionId: m.sessionId || undefined,
+      });
+    }
+  }
+
+  console.log(`  panes to kill: ${plan.length}`);
+  for (const p of plan) {
+    const idTag = p.sessionId ? ` ssn=${p.sessionId.slice(0, 8)}` : "";
+    const paneTag = p.paneId ? ` pane=${p.paneId}` : " (no pane-id stored — title-search fallback)";
+    console.log(`    ${p.team}/${p.role}${idTag}${paneTag}`);
+  }
+  console.log(`  team dirs to remove: ${all ? teams.length : 0}${all ? "" : " (pass --all to also rm team dirs)"}`);
+  if (all) {
+    for (const t of teams) console.log(`    ${teamDir(t)}`);
+  }
+
+  if (!noDryRun) {
+    console.log(``);
+    console.log(`\x1b[33mdry-run (default)\x1b[0m — pass --confirm to actually do it.`);
+    return;
+  }
+
+  // Execute — three fallbacks for finding panes/sessions to kill:
+  //   1. stored pane-id (most reliable)
+  //   2. tmux session named "<team>-<role>" (default from `maw new <name>`)
+  //   3. pane title containing the role name (last resort)
+  console.log(``);
+  console.log(`\x1b[36m→\x1b[0m killing panes/sessions...`);
+  let killed = 0;
+  for (const p of plan) {
+    let done = false;
+
+    // (1) try stored pane-id
+    if (p.paneId) {
+      try {
+        execSync(`tmux kill-pane -t ${p.paneId} 2>/dev/null`);
+        console.log(`  \x1b[32m✓\x1b[0m killed pane ${p.paneId} (${p.team}/${p.role})`);
+        killed++;
+        done = true;
+      } catch {
+        // fall through to next fallback
+      }
+    }
+
+    // (2) try tmux session named "<team>-<role>"
+    if (!done) {
+      const sessName = `${p.team}-${p.role}`;
+      try {
+        execSync(`tmux has-session -t ${sessName} 2>/dev/null`);
+        execSync(`tmux kill-session -t ${sessName} 2>/dev/null`);
+        console.log(`  \x1b[32m✓\x1b[0m killed session ${sessName} (${p.team}/${p.role})`);
+        killed++;
+        done = true;
+      } catch {
+        // session doesn't exist — try next fallback
+      }
+    }
+
+    // (3) last resort: pane title contains the role name
+    if (!done) {
+      try {
+        const out = execSync(`tmux list-panes -s -F "#{pane_id} #{pane_title}" 2>/dev/null | grep "${p.role}" | head -1`, { encoding: "utf-8" }).trim();
+        if (out) {
+          const id = out.split(" ")[0];
+          execSync(`tmux kill-pane -t ${id} 2>/dev/null`);
+          console.log(`  \x1b[32m✓\x1b[0m killed ${id} (${p.team}/${p.role}, by title)`);
+          killed++;
+          done = true;
+        }
+      } catch {}
+    }
+
+    if (!done) {
+      console.log(`  \x1b[33m⚠\x1b[0m ${p.team}/${p.role} — no pane/session found (already gone?)`);
+    }
+  }
+
+  // (4) sweep any orphan tmux sessions matching "<team>-*" (e.g. from prior
+  //     spawns where config got removed but the session lingered).
+  for (const t of teams) {
+    try {
+      const orphans = execSync(`tmux list-sessions -F "#{session_name}" 2>/dev/null | grep "^${t}-" || true`, { encoding: "utf-8" }).trim();
+      if (orphans) {
+        for (const s of orphans.split("\n").filter(Boolean)) {
+          try {
+            execSync(`tmux kill-session -t ${s} 2>/dev/null`);
+            console.log(`  \x1b[32m✓\x1b[0m killed orphan session ${s}`);
+            killed++;
+          } catch {}
+        }
+      }
+    } catch {}
+  }
+
+  if (all) {
+    console.log(``);
+    console.log(`\x1b[36m→\x1b[0m removing team dirs...`);
+    for (const t of teams) {
+      rmSync(teamDir(t), { recursive: true, force: true });
+      console.log(`  \x1b[32m✓\x1b[0m removed ${teamDir(t)}`);
+    }
+  }
+
+  console.log(``);
+  console.log(`\x1b[32m✓ done\x1b[0m — killed ${killed} pane(s)${all ? `, removed ${teams.length} team dir(s)` : ""}`);
+}
+

--- a/plugins/team-agent/cmd/help.ts
+++ b/plugins/team-agent/cmd/help.ts
@@ -1,0 +1,122 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+
+export async function cmdHelp(): Promise<void> {
+  console.log(`\x1b[36mmaw team-agent\x1b[0m — manual team-agent spawn (no Claude tools required)
+
+\x1b[1mUSAGE\x1b[0m
+  maw team-agent <subcommand> [args] [flags]
+
+\x1b[1mSUBCOMMANDS\x1b[0m
+  create <name> [description]
+      Register a team — writes ~/.claude/teams/<name>/config.json with the
+      invoking shell as the lead.
+
+  spawn <team> <role>@<cwd>[:<color>] [--mission "<text>"] [--parent <uuid>] [--session-id <uuid>]
+      Spawn a new claude.exe teammate via 'maw tile --path --cmd' with the
+      8 canonical TeamCreate flags (incl. --session-id for deterministic
+      teammate UUIDs). Adds the member to config.json. If --mission is given,
+      writes it to the teammate's inbox immediately.
+
+      AUTO-GENERATED session ID format (counter-first, eyeball-readable):
+        CCCCCCCC-yymm-ddhh-mmss-RRRRRRRRRRRR
+        ^^^^^^^^
+        run counter (1,2,3,...) — first 8 hex chars, zero-padded
+        Example: 00000007-2605-2216-4530-a3b21c4d5e6f = run #7, 2026-05-22 16:45:30
+      Counter persists at ~/.claude/team-agent-counter — survives across sessions.
+      Sort UUIDs lexically = creation order.
+
+      PARENT resolution (in order): --parent flag → $CLAUDE_SESSION_ID env →
+      newest .jsonl in ~/.claude/projects/<encoded-pwd>/.
+
+  ls [<team>]
+      Without args: list all teams.
+      With team: show members + inbox counts for that team.
+
+  msg <team> <role> "<text>" [--by <sender>]
+      Append a message envelope to inboxes/<role>.json. Mimics SendMessage.
+      Default sender is "shell".
+
+  shutdown <team> <role>
+      Append {"type":"shutdown_request"} envelope to inboxes/<role>.json.
+
+  kill <team> <role>
+      tmux kill-pane on the teammate's pane (looked up from config.json).
+      Does NOT remove the member from config — use 'delete' for that.
+
+  delete <team> --confirm
+      Remove ~/.claude/teams/<team>/. Requires --confirm. Use --dry-run first.
+
+  uuid [N] [--bare] [--json]
+      Generate N counter-first readable UUIDs (default N=1, max 100).
+      Each call increments the persisted counter at ~/.claude/team-agent-counter.
+
+      Format: CCCCCCCC-yymm-ddhh-mmss-RRRRRRRRRRRR  (run #N, decimal timestamp prefix)
+      Use --bare for plain UUIDs (no #N prefix), --json for structured output.
+
+      Aliases: 'gen', 'generate'.
+
+  help
+      Show this message.
+
+\x1b[1mFLAGS\x1b[0m
+  --mission <text>      Initial mission text for spawn (delivered to inbox)
+  --color <color>       Override color (red|green|yellow|blue|purple|cyan|magenta|white)
+  --model <id>          claude.exe model (default: sonnet)
+  --parent <uuid>       --parent-session-id for claude.exe (default: $CLAUDE_SESSION_ID)
+  --by <sender>         Sender label for msg (default: "shell")
+  --confirm             Required for destructive ops
+  --dry-run             Print what would happen
+  --json                Machine-readable output
+
+\x1b[1mEXAMPLES — parent ID flow\x1b[0m
+  # 1. Create a team. A fixed Team UUID is generated automatically
+  #    (counter-first decimal) and stored in config.json as 'teamId'.
+  maw team-agent create my-demo "Quick test team"
+  # → ✓ team created: my-demo
+  #   team-id: 00000091-2026-0522-0730-260522073005   ← THE PARENT UUID
+  #   config:  ~/.claude/teams/my-demo/config.json
+
+  # 2. Spawn a teammate. --parent is auto-set to the team's teamId
+  #    (the lookup is config.json → teamId). You can override explicitly.
+  maw team-agent spawn my-demo reader-a@/opt/Code/foo:magenta \\
+                       --mission "Read README.md and reply with title"
+  # → ⚡ team-agent spawn my-demo/reader-a (magenta) in /opt/Code/foo
+  #   parent uuid:    00000091-2026-0522-0730-260522073005 (resolved via team-id) ← USES THE TEAM-ID
+  #   teammate uuid:  00000092-2026-0522-0731-260522073155 [run #92]
+
+  # 3. Explicit parent override (rare — uses team-id by default)
+  maw team-agent spawn my-demo reader-b@/opt/Code/bar:cyan \\
+                       --parent 00000091-2026-0522-0730-260522073005
+
+  # 4. Fixed team-id at create (for reproducibility / cross-host pairing)
+  TEAM_ID=\$(maw team-agent uuid --bare | head -1)
+  maw team-agent create scripted-team --team-id "\$TEAM_ID"
+
+  # other ops
+  maw team-agent ls my-demo            # shows team-id + members
+  maw team-agent msg my-demo reader-a "Quick follow-up question"
+  maw team-agent shutdown my-demo reader-a
+  maw team-agent kill my-demo reader-a
+  maw team-agent delete my-demo --confirm
+
+\x1b[1mSTORAGE\x1b[0m
+  Teams:     ~/.claude/teams/<name>/config.json
+  Inboxes:   ~/.claude/teams/<name>/inboxes/<role>.json
+  Same on-disk format used by Claude Code's TeamCreate/SendMessage tools
+  — interoperable from both sides.
+
+\x1b[1mWIRE FORMAT\x1b[0m
+  See ψ/ralph/55-teammate-message-wire.md for the <teammate-message> XML
+  schema. Messages written by this CLI WILL be rendered as XML in any
+  Claude session whose teammate-receiver was spawned with --agent-id env.
+`);
+}
+

--- a/plugins/team-agent/cmd/team.ts
+++ b/plugins/team-agent/cmd/team.ts
@@ -1,0 +1,422 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync, execSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+
+export async function cmdCreate(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const name = args[0];
+  if (!name) throw new Error("usage: maw team-agent create <name> [description] [--session-id <uuid>]");
+  const description = args.slice(1).join(" ") || `Team created by maw team-agent at ${nowISO()}`;
+  const dryRun = flags["--dry-run"] === true;
+
+  if (existsSync(configPath(name))) {
+    const force = flags["--force"] === true;
+    const yes = flags["--yes"] === true || flags["-y"] === true;
+    const existing = readConfig(name);
+    const existingSid = existing.sessionId || existing.teamId;
+    const newSidPreview = (flags["--session-id"] as string) || "(auto-generated)";
+
+    console.log(`\x1b[33m⚠\x1b[0m team already exists: \x1b[1m${name}\x1b[0m`);
+    console.log(`  existing:`);
+    console.log(`    session-id: ${existingSid}`);
+    console.log(`    description: ${existing.description || "—"}`);
+    console.log(`    members: ${existing.members.length} (${existing.members.map((m: any) => m.name).join(", ")})`);
+    console.log(`    created: ${existing.createdAtIso || "?"}`);
+    console.log(`  new:`);
+    console.log(`    session-id: ${newSidPreview}`);
+    console.log(`    description: ${description}`);
+
+    const doOverwrite = () => {
+      // Kill ALL tmux sessions matching <team>-* (covers orphans not in config)
+      let killed = 0;
+      try {
+        const list = spawnSync("tmux", ["list-sessions", "-F", "#{session_name}"], { stdio: "pipe" });
+        const sessions = (list.stdout?.toString() || "").split("\n").filter((s: string) => s.startsWith(`${name}-`));
+        for (const s of sessions) {
+          spawnSync("tmux", ["kill-session", "-t", s], { stdio: "pipe" });
+          killed++;
+        }
+      } catch {}
+      rmSync(teamDir(name), { recursive: true, force: true });
+      console.log(`\x1b[90m  killed ${killed} session(s) matching '${name}-*', removed team dir\x1b[0m`);
+    };
+
+    if (force || yes) {
+      console.log(`\x1b[33m→ --force/--yes set, overwriting...\x1b[0m`);
+      doOverwrite();
+    } else if (process.stdin.isTTY) {
+      const answer = prompt(`\x1b[36mOverwrite? [y/N]\x1b[0m`) || "";
+      if (!/^y(es)?$/i.test(answer.trim())) {
+        console.log(`\x1b[90m  cancelled — existing team kept\x1b[0m`);
+        return;
+      }
+      doOverwrite();
+    } else {
+      throw new Error(`team already exists: ${name} — pass --force to overwrite (or --yes for non-interactive)`);
+    }
+  }
+
+  // Lead's session-id. This IS the team identity — every teammate spawn
+  // references it via --parent-session-id. Counter-first decimal format.
+  let sessionId = (flags["--session-id"] || flags["--team-id"]) as string | undefined;
+  let shortRef = "";
+  if (sessionId && !UUID_RE.test(sessionId)) {
+    throw new Error(`--session-id must be a valid UUID (got: ${sessionId})`);
+  }
+  if (!sessionId) {
+    const gen = generateReadableUuid();
+    sessionId = gen.uuid;
+    shortRef = gen.shortRef;
+  }
+
+  const cfg = {
+    name,
+    sessionId,                                 // lead's session-id = team identity
+    teamId: sessionId,                         // backward compat alias
+    description,
+    createdAt: nowMs(),
+    createdAtIso: nowISO(),
+    leadAgentId: `shell-lead@${name}`,
+    leadSessionId: sessionId,
+    members: [
+      {
+        agentId: `shell-lead@${name}`,
+        name: "shell-lead",
+        agentType: "shell",
+        model: "n/a",
+        sessionId,
+        parentSessionId: null,
+        joinedAt: nowMs(),
+        tmuxPaneId: process.env.TMUX_PANE || "",
+        cwd: process.cwd(),
+        subscriptions: [],
+      },
+    ],
+  };
+
+  if (dryRun) {
+    console.log(`\x1b[33mdry-run\x1b[0m would write: ${configPath(name)}`);
+    console.log(JSON.stringify(cfg, null, 2));
+    return;
+  }
+  writeConfig(name, cfg);
+  mkdirSync(inboxesDir(name), { recursive: true });
+  console.log(`\x1b[32m✓\x1b[0m team created: \x1b[1m${name}\x1b[0m`);
+  console.log(`  session-id: \x1b[1m${sessionId}\x1b[0m${shortRef ? `  \x1b[33m[${shortRef}]\x1b[0m` : ""}`);
+  console.log(`  config:     ${configPath(name)}`);
+  console.log(`  lead:       shell-lead (cwd=${process.cwd()})`);
+  console.log(``);
+  console.log(`\x1b[36mTip:\x1b[0m every spawn auto-uses this session-id as --parent-session-id.`);
+  console.log(`     Manual override:  maw team-agent spawn ${name} <role>@<cwd> --parent ${sessionId}`);
+}
+
+export async function cmdSpawn(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  const memberSpec = args[1];
+  if (!team || !memberSpec) {
+    throw new Error("usage: maw team-agent spawn <team> <role>@<cwd>[:<color>] [--mission \"<text>\"]");
+  }
+  const cfg = readConfig(team);
+  const idx = cfg.members.length; // for color rotation
+  const overrideColor = flags["--color"] as string | undefined;
+  const m = parseMemberSpec(memberSpec, idx);
+  if (overrideColor) m.color = overrideColor;
+
+  const mission = flags["--mission"] as string | undefined;
+  const systemPrompt = flags["--system-prompt"] as string | undefined;
+  const model = (flags["--model"] as string) || "sonnet";
+
+  // Parent UUID — 4-tier resolution:
+  //   1. explicit --parent flag
+  //   2. team's sessionId from config.json (THE NATURAL DEFAULT — lead IS the parent)
+  //   3. $CLAUDE_SESSION_ID env var
+  //   4. JSONL scan of current cwd
+  let parent = flags["--parent"] as string | undefined;
+  let parentSource = "flag";
+  const teamSessionId = cfg.sessionId || cfg.teamId; // backward compat
+  if (!parent && teamSessionId && UUID_RE.test(teamSessionId)) {
+    parent = teamSessionId;
+    parentSource = "session-id";
+  }
+  if (!parent) {
+    parent = process.env.CLAUDE_SESSION_ID;
+    parentSource = "env";
+  }
+  if (!parent) {
+    parent = resolveParentUuid() || undefined;
+    parentSource = "jsonl-scan";
+  }
+  if (!parent) {
+    throw new Error("could not resolve parent UUID (tried --parent flag, team-id, $CLAUDE_SESSION_ID, JSONL scan). Pass --parent <uuid> explicitly.");
+  }
+  if (!UUID_RE.test(parent)) {
+    throw new Error(`--parent must be uuid (got: ${parent})`);
+  }
+
+  // Teammate session ID — optional explicit, otherwise auto-generate (counter-first readable UUID)
+  let teammateSessionId = flags["--session-id"] as string | undefined;
+  let teammateShortRef = "";
+  let teammateCounter = 0;
+  if (teammateSessionId && !UUID_RE.test(teammateSessionId)) {
+    throw new Error(`--session-id must be uuid (got: ${teammateSessionId})`);
+  }
+  if (!teammateSessionId) {
+    const gen = generateReadableUuid();
+    teammateSessionId = gen.uuid;
+    teammateShortRef = gen.shortRef;
+    teammateCounter = gen.counter;
+  }
+
+  if (cfg.members.find((mem: any) => mem.name === m.role)) {
+    throw new Error(`member already exists in team: ${m.role}`);
+  }
+  // No TMUX requirement — maw new creates a new tmux session standalone.
+  // User can `tmux attach -t <team>-<role>` after spawn to see the worker.
+  const inTmux = !!process.env.TMUX;
+
+  const claudeBin = findClaudeBin();
+  const env = `CLAUDECODE=1 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`;
+  const cmdParts = [
+    `env ${env} ${shellQuote(claudeBin)}`,
+    `--session-id ${teammateSessionId}`,
+    `--agent-id ${m.role}@${team}`,
+    `--agent-name ${m.role}`,
+    `--team-name ${team}`,
+    `--agent-color ${m.color}`,
+    `--parent-session-id ${parent}`,
+    `--model ${model}`,
+  ];
+  if (systemPrompt) cmdParts.push(`--system-prompt ${shellQuote(systemPrompt)}`);
+  cmdParts.push(`--dangerously-skip-permissions`);
+  const cmd = cmdParts.join(" \\\n");
+
+  const dryRun = flags["--dry-run"] === true;
+  console.log(`\x1b[36m⚡\x1b[0m team-agent spawn ${team}/${m.role} (${m.color}) in ${m.cwd}`);
+  console.log(`  parent uuid:    ${parent} (resolved via ${parentSource})`);
+  const refTag = teammateShortRef ? ` \x1b[1m\x1b[33m[run ${teammateShortRef}]\x1b[0m` : "";
+  console.log(`  teammate uuid:  ${teammateSessionId}${refTag}`);
+  if (teammateShortRef) {
+    console.log(`                    ↑ counter #${teammateCounter} (8-hex prefix, decimal: ${teammateCounter})`);
+  }
+  // Always show the claude.exe command (learning + debug)
+  const cmdOneLine = cmdParts.join(" ");
+  console.log(`  \x1b[90mcmd: ${cmdOneLine}\x1b[0m`);
+
+  if (dryRun) {
+    console.log(`  \x1b[33mdry-run\x1b[0m — not spawned`);
+    return;
+  }
+
+  // Run maw new — two modes:
+  //   default:   new tmux SESSION named "<team>-<role>" (deterministic, unique per teammate)
+  //   --split:   new tmux PANE in the current window (no separate session)
+  const useSplit = flags["--split"] === true;
+  const sessionName = `${team}-${m.role}`;
+  const mawArgs = useSplit
+    ? ["new", "--split", "--path", m.cwd, "--cmd", cmd]
+    : ["new", sessionName, "--path", m.cwd, "--cmd", cmd, "--no-attach"];
+  const result = spawnSync("maw", mawArgs, {
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(useSplit
+      ? `maw new --split failed (exit ${result.status}) — are you in tmux?`
+      : `maw new failed (exit ${result.status}) — session may already exist: ${sessionName}`);
+  }
+
+  // Hint how to view the worker if outside tmux
+  if (!inTmux) {
+    console.log(`  \x1b[90m→ attach: tmux attach -t ${sessionName}\x1b[0m`);
+  }
+
+  // Record the member in config.json
+  cfg.members.push({
+    agentId: `${m.role}@${team}`,
+    name: m.role,
+    agentType: "claude.exe",
+    model,
+    color: m.color,
+    sessionId: teammateSessionId,
+    parentSessionId: parent,
+    systemPrompt: systemPrompt || null,
+    runCounter: teammateCounter || null,
+    shortRef: teammateShortRef || null,
+    joinedAt: nowMs(),
+    tmuxPaneId: "",
+    cwd: m.cwd,
+    subscriptions: [],
+  });
+  writeConfig(team, cfg);
+
+  // If mission provided, write to inbox immediately
+  if (mission) {
+    appendInbox(team, m.role, {
+      from: "shell-lead",
+      text: mission,
+      summary: mission.split(/\s+/).slice(0, 8).join(" ").slice(0, 60),
+      timestamp: nowISO(),
+      color: m.color,
+      read: false,
+    });
+    console.log(`\x1b[32m✓\x1b[0m member added + mission queued (inbox: ${inboxPath(team, m.role)})`);
+  } else {
+    console.log(`\x1b[32m✓\x1b[0m member added to config`);
+  }
+  console.log(`  tip: 'maw team-agent ls ${team}' shows the team state`);
+}
+
+export async function cmdLs(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  const json = flags["--json"] === true;
+  if (!existsSync(TEAMS_DIR)) {
+    if (json) console.log("[]");
+    else console.log("(no teams — ~/.claude/teams/ does not exist)");
+    return;
+  }
+
+  if (!team) {
+    const teams = readdirSync(TEAMS_DIR).filter((d: string) => existsSync(configPath(d)));
+    if (json) {
+      console.log(JSON.stringify(teams));
+      return;
+    }
+    console.log(`\x1b[36m${teams.length}\x1b[0m teams in ~/.claude/teams/`);
+    for (const t of teams) {
+      const cfg = readConfig(t);
+      console.log(`  \x1b[32m●\x1b[0m ${t}  (${cfg.members.length} members)`);
+    }
+    return;
+  }
+
+  const cfg = readConfig(team);
+  if (json) {
+    const inboxes: Record<string, number> = {};
+    for (const m of cfg.members) {
+      inboxes[m.name] = readInbox(team, m.name).length;
+    }
+    console.log(JSON.stringify({ team: cfg.name, description: cfg.description, members: cfg.members, inbox_counts: inboxes }, null, 2));
+    return;
+  }
+
+  console.log(`\x1b[36mteam:\x1b[0m \x1b[1m${cfg.name}\x1b[0m`);
+  const displaySid = cfg.sessionId || cfg.teamId;
+  if (displaySid) console.log(`  session-id: \x1b[1m${displaySid}\x1b[0m`);
+  console.log(`  description: ${cfg.description}`);
+  console.log(`  lead: ${cfg.leadAgentId} (session: ${cfg.leadSessionId})`);
+  console.log(`  members:`);
+  for (const m of cfg.members) {
+    const inboxCount = readInbox(team, m.name).length;
+    const color = m.color ? `\x1b[3${VALID_COLORS.indexOf(m.color) + 1}m●\x1b[0m ` : "  ";
+    const ref = m.shortRef ? ` \x1b[33m${m.shortRef}\x1b[0m` : "";
+    const sid = m.sessionId ? ` \x1b[90mssn=${m.sessionId.slice(0, 8)}\x1b[0m` : "";
+    console.log(`    ${color}${m.name.padEnd(28)} ${m.agentType.padEnd(12)} inbox: ${inboxCount}${ref}${sid}`);
+  }
+}
+
+export async function cmdMsg(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  const role = args[1];
+  const text = args.slice(2).join(" ");
+  if (!team || !role || !text) {
+    throw new Error("usage: maw team-agent msg <team> <role> \"<text>\" [--by <sender>]");
+  }
+  readConfig(team); // verify team exists
+  const by = (flags["--by"] as string) || "shell";
+  const summary = text.split(/\s+/).slice(0, 8).join(" ").slice(0, 60);
+
+  const entry = {
+    from: by,
+    text,
+    summary,
+    timestamp: nowISO(),
+    color: undefined,
+    read: false,
+  };
+  appendInbox(team, role, entry);
+  console.log(`\x1b[32m✓\x1b[0m message queued to ${team}/${role} inbox`);
+  console.log(`  ${inboxPath(team, role)}`);
+}
+
+export async function cmdShutdown(args: string[], _flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  const role = args[1];
+  if (!team || !role) throw new Error("usage: maw team-agent shutdown <team> <role>");
+  readConfig(team);
+  const requestId = `shutdown-${Date.now()}@${role}`;
+  const envelope = {
+    type: "shutdown_request",
+    request_id: requestId,
+    from: "shell-lead",
+    text: JSON.stringify({ type: "shutdown_request", request_id: requestId }),
+    summary: "shutdown request",
+    timestamp: nowISO(),
+    read: false,
+  };
+  appendInbox(team, role, envelope);
+  console.log(`\x1b[32m✓\x1b[0m shutdown_request queued to ${team}/${role}`);
+  console.log(`  request_id: ${requestId}`);
+  console.log(`  inbox: ${inboxPath(team, role)}`);
+}
+
+export async function cmdKill(args: string[], _flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  const role = args[1];
+  if (!team || !role) throw new Error("usage: maw team-agent kill <team> <role>");
+  const cfg = readConfig(team);
+  const member = cfg.members.find((m: any) => m.name === role);
+  if (!member) throw new Error(`member not found: ${role} in team ${team}`);
+  const paneId = member.tmuxPaneId;
+  if (!paneId) {
+    console.log(`\x1b[33m⚠\x1b[0m no tmuxPaneId stored for ${role} — trying fallbacks`);
+    // Fallback 1: tmux session named "<team>-<role>" (default from `maw new <name>`)
+    const sessName = `${team}-${role}`;
+    try {
+      execSync(`tmux has-session -t ${sessName} 2>/dev/null`);
+      execSync(`tmux kill-session -t ${sessName} 2>/dev/null`);
+      console.log(`\x1b[32m✓\x1b[0m killed session ${sessName}`);
+      return;
+    } catch {
+      // session doesn't exist — try next fallback
+    }
+    // Fallback 2: search tmux panes for one with the role name in its title
+    try {
+      const out = execSync(`tmux list-panes -s -F "#{pane_id} #{pane_title}" 2>/dev/null | grep "${role}" | head -1`, { encoding: "utf-8" }).trim();
+      if (out) {
+        const id = out.split(" ")[0];
+        execSync(`tmux kill-pane -t ${id} 2>/dev/null`);
+        console.log(`\x1b[32m✓\x1b[0m killed pane ${id} (matched by title)`);
+        return;
+      }
+    } catch {}
+    throw new Error(`could not locate pane or session for ${team}/${role}`);
+  }
+  execSync(`tmux kill-pane -t ${paneId} 2>/dev/null`);
+  console.log(`\x1b[32m✓\x1b[0m killed pane ${paneId}`);
+}
+
+export async function cmdDelete(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const team = args[0];
+  if (!team) throw new Error("usage: maw team-agent delete <team> --confirm");
+  if (!existsSync(teamDir(team))) throw new Error(`team not found: ${team}`);
+  const confirm = flags["--confirm"] === true;
+  const dryRun = flags["--dry-run"] === true;
+
+  if (!confirm && !dryRun) {
+    throw new Error("destructive op — pass --confirm to proceed, or --dry-run to preview");
+  }
+  if (dryRun) {
+    console.log(`\x1b[33mdry-run\x1b[0m would rm: ${teamDir(team)}`);
+    const cfg = readConfig(team);
+    console.log(`  team has ${cfg.members.length} members + inboxes`);
+    return;
+  }
+  rmSync(teamDir(team), { recursive: true, force: true });
+  console.log(`\x1b[32m✓\x1b[0m deleted ${teamDir(team)}`);
+}
+
+

--- a/plugins/team-agent/cmd/tutorial.ts
+++ b/plugins/team-agent/cmd/tutorial.ts
@@ -1,0 +1,367 @@
+/**
+ * cmdTutorial — generic Claude Code team protocol tutorial.
+ *
+ * Teaches the RAW claude.exe + session-id + parent-session-id mechanics.
+ * Each step shows the bare command — maw team-agent shortcut shown for reference.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+import { spawnSync } from "child_process";
+import { generateReadableUuid } from "../lib/uuid";
+import { findClaudeBin, expandTilde } from "../lib/helpers";
+
+const STATE_FILE = join(homedir(), ".claude", "team-agent-tutorial-state.json");
+
+function readState(): Record<string, string> {
+  if (!existsSync(STATE_FILE)) return {};
+  try { return JSON.parse(readFileSync(STATE_FILE, "utf-8")); } catch { return {}; }
+}
+
+function writeState(state: Record<string, string>): void {
+  mkdirSync(dirname(STATE_FILE), { recursive: true });
+  writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}
+
+const blue = "\x1b[36m"; const dim = "\x1b[90m"; const grn = "\x1b[32m"; const rst = "\x1b[0m"; const yel = "\x1b[33m"; const bold = "\x1b[1m"; const mag = "\x1b[35m";
+
+function header(n: number, title: string): void {
+  console.log(`${blue}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${rst}`);
+  console.log(`${blue}  TUTORIAL — Step ${n}${rst}  ${bold}${title}${rst}`);
+  console.log(`${blue}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${rst}`);
+  console.log(``);
+}
+
+function section(label: string, lines: string[]): void {
+  console.log(`  ${grn}${label}${rst}`);
+  for (const l of lines) console.log(`    ${l}`);
+  console.log(``);
+}
+
+function shortcut(line: string): void {
+  console.log(`  ${mag}maw team-agent shortcut:${rst}  ${dim}${line}${rst}`);
+  console.log(``);
+}
+
+export async function cmdTutorial(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const stepNum = args[0] || "0";
+  const claudeBin = findClaudeBin();
+  const apply = flags["--apply"] === true;
+
+  switch (stepNum) {
+    case "reset":
+    case "clear": {
+      writeState({});
+      console.log(`${grn}✓${rst} tutorial state cleared (${STATE_FILE})`);
+      return;
+    }
+    case "state":
+    case "status": {
+      const s = readState();
+      console.log(`${bold}tutorial state:${rst}`);
+      console.log(JSON.stringify(s, null, 2));
+      return;
+    }
+    case "0":
+    case "list":
+    case "":
+      console.log(`${bold}Claude Code Team Protocol — tutorial${rst}`);
+      console.log(`${dim}Learn the raw mechanics. Copy-paste your way through.${rst}`);
+      console.log(``);
+      console.log(`  ${yel}maw team-agent tutorial 1 [team-name]${rst}     ${dim}— lead creates team (1×)${rst}`);
+      console.log(`  ${yel}maw team-agent tutorial 2 [role] [cwd] [color]${rst}  ${dim}— add a teammate (N×)${rst}`);
+      console.log(`  ${yel}maw team-agent tutorial 3 [role]${rst}          ${dim}— send a message${rst}`);
+      console.log(`  ${yel}maw team-agent tutorial 4${rst}                  ${dim}— how teammate sees it (XML wire)${rst}`);
+      console.log(`  ${yel}maw team-agent tutorial 5 [role]${rst}          ${dim}— graceful shutdown${rst}`);
+      console.log(`  ${yel}maw team-agent tutorial 6${rst}                  ${dim}— cleanup (kill + rm config)${rst}`);
+      console.log(``);
+      console.log(`${dim}Add ${rst}${yel}--apply${rst}${dim} to any step to actually execute (instead of just printing).${rst}`);
+      console.log(`${dim}State persists in ${STATE_FILE} — reset with: ${rst}${yel}maw team-agent tutorial reset${rst}`);
+      return;
+
+    case "1": {
+      const teamName = args[1] || "my-team";
+      const { uuid } = generateReadableUuid();
+      writeState({ leadSessionId: uuid, teamName });
+      header(1, "Lead creates the team");
+      console.log(`${dim}  The lead's session-id IS the team identity.${rst}`);
+      console.log(`${dim}  Lead does TWO things:${rst}`);
+      console.log(`${dim}    a) start claude.exe with --session-id <uuid>${rst}`);
+      console.log(`${dim}    b) register the team in ~/.claude/teams/<team>/config.json${rst}`);
+      console.log(`${dim}  Then teammates can JOIN the team in step 2 (repeatable, one per member).${rst}`);
+      console.log(``);
+      section("(a) start lead claude.exe (minimum: 5 flags + 2 env vars):", [
+        `${yel}env CLAUDECODE=1 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 \\${rst}`,
+        `${yel}  ${claudeBin} \\${rst}`,
+        `${yel}    --session-id ${uuid} \\${rst}`,
+        `${yel}    --team-name ${teamName} \\${rst}`,
+        `${yel}    --agent-id shell-lead@${teamName} \\${rst}`,
+        `${yel}    --agent-name shell-lead${rst}`,
+        ``,
+        `${dim}# flags explained:${rst}`,
+        `${dim}#   CLAUDECODE=1                          enter agent mode${rst}`,
+        `${dim}#   CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1  enable team protocol${rst}`,
+        `${dim}#   --session-id  lead's UUID — IS the team identity${rst}`,
+        `${dim}#   --team-name   binds claude.exe to this team's config.json${rst}`,
+        `${dim}#   --agent-id    unique slot: <role>@<team>${rst}`,
+        `${dim}#   --agent-name  display name (shown in status bar)${rst}`,
+        ``,
+        `${dim}# optional cosmetic/behavior flags:${rst}`,
+        `${dim}#   --agent-color magenta                tmux status bar color${rst}`,
+        `${dim}#   --model sonnet                       defaults vary by setup${rst}`,
+        `${dim}#   --dangerously-skip-permissions       headless mode${rst}`,
+        ``,
+        `${dim}# (running just 'claude --session-id ${uuid}' is NOT enough —${rst}`,
+        `${dim}#  without --team-name + --agent-id the process won't join the team)${rst}`,
+      ]);
+      section(`(b) register team "${teamName}" (raw — file write):`, [
+        `${yel}mkdir -p ~/.claude/teams/${teamName}/inboxes${rst}`,
+        `${yel}cat > ~/.claude/teams/${teamName}/config.json <<EOF${rst}`,
+        `${yel}{${rst}`,
+        `${yel}  "name": "${teamName}",${rst}`,
+        `${yel}  "sessionId": "${uuid}",${rst}`,
+        `${yel}  "teamId": "${uuid}",${rst}`,
+        `${yel}  "leadAgentId": "shell-lead@${teamName}",${rst}`,
+        `${yel}  "leadSessionId": "${uuid}",${rst}`,
+        `${yel}  "members": [${rst}`,
+        `${yel}    { "agentId": "shell-lead@${teamName}", "name": "shell-lead", "agentType": "shell" }${rst}`,
+        `${yel}  ]${rst}`,
+        `${yel}}${rst}`,
+        `${yel}EOF${rst}`,
+      ]);
+      console.log(`  ${grn}team identity:${rst}  ${bold}${uuid}${rst}`);
+      console.log(`  ${dim}saved to ${STATE_FILE}${rst}`);
+      console.log(``);
+      shortcut(`maw team-agent create ${teamName} --session-id ${uuid}    (does (b) — file write)`);
+      if (apply) {
+        console.log(`${blue}━━ --apply ━━${rst}  ${dim}registering team now...${rst}`);
+        const create = spawnSync("maw", ["team-agent", "create", teamName, "--session-id", uuid, "--force"], { stdio: "inherit" });
+        if (create.status !== 0) throw new Error(`maw team-agent create failed (exit ${create.status})`);
+        console.log(``);
+        console.log(`${grn}✓ team "${teamName}" registered. Lead is shell-lead. Now spawn teammates in step 2.${rst}`);
+      }
+      console.log(`${dim}Next: ${rst}${yel}maw team-agent tutorial 2 [role] [cwd] [color]${rst}  ${dim}(repeat for each teammate)${rst}`);
+      return;
+    }
+
+    case "2": {
+      const state = readState();
+      const teamName = state.teamName || "my-team";
+      const parentSid = state.leadSessionId || "(run step 1 first!)";
+      const memberCount = (state.memberCount ? parseInt(state.memberCount) : 0) + 1;
+
+      // Defaults — prefilled, user can override
+      const defaultColors = ["yellow", "green", "cyan", "magenta", "blue", "purple", "red", "white"];
+      let role = args[1] || `member-${memberCount}`;
+      let cwd = args[2] || process.cwd();
+      let color = args[3] || defaultColors[(memberCount - 1) % defaultColors.length];
+
+      header(2, "Add a teammate (interactive)");
+      console.log(`${dim}  Each call adds ONE teammate. Repeat with different role for more members.${rst}`);
+      console.log(`${dim}  Press Enter to keep default, or type a new value.${rst}`);
+      console.log(``);
+
+      // Interactive prompts (only if TTY) — echo confirmed value after each
+      if (process.stdin.isTTY) {
+        const r = (prompt(`  ${grn}role${rst}    [${role}]:`) || "").trim();
+        if (r) role = r;
+        console.log(`    ${dim}→ ${rst}${bold}${role}${rst}${r ? `  ${dim}(changed)${rst}` : `  ${dim}(kept default)${rst}`}`);
+
+        const c = (prompt(`  ${grn}cwd${rst}     [${cwd}]:`) || "").trim();
+        if (c) cwd = expandTilde(c);
+        console.log(`    ${dim}→ ${rst}${bold}${cwd}${rst}${c ? `  ${dim}(changed)${rst}` : `  ${dim}(kept default)${rst}`}`);
+
+        const col = (prompt(`  ${grn}color${rst}   [${color}]:`) || "").trim();
+        if (col) color = col;
+        console.log(`    ${dim}→ ${rst}${bold}${color}${rst}${col ? `  ${dim}(changed)${rst}` : `  ${dim}(kept default)${rst}`}`);
+        console.log(``);
+      }
+
+      const { uuid: childSid } = generateReadableUuid();
+      writeState({ ...state, lastRole: role, memberCount: String(memberCount) });
+
+      console.log(`${dim}  Adding member #${memberCount}:  ${rst}${bold}${role}${rst}${dim} in ${cwd} (${color})${rst}`);
+      console.log(`${dim}  Joining team: ${rst}${bold}${teamName}${rst}${dim} (parent ${parentSid})${rst}`);
+      console.log(``);
+      console.log(`${dim}  Each call adds ONE teammate. Run this N times for N members.${rst}`);
+      console.log(`${dim}  Each teammate gets:${rst}`);
+      console.log(`${dim}    - its OWN --session-id${rst}`);
+      console.log(`${dim}    - --parent-session-id = lead's uuid (from step 1)${rst}`);
+      console.log(`${dim}    - appended to ~/.claude/teams/${teamName}/config.json members${rst}`);
+      console.log(``);
+      console.log(`${dim}  Adding:  ${rst}${bold}${role}${rst}${dim} in ${cwd} (${color})${rst}`);
+      console.log(`${dim}  Joining team: ${rst}${bold}${teamName}${rst}${dim} (parent ${parentSid})${rst}`);
+      console.log(``);
+      console.log(`${dim}  Teammate has its OWN session-id. parent-session-id points back to the lead.${rst}`);
+      console.log(`${dim}  --agent-id / --agent-name / --team-name / --agent-color teach Claude this is a team member.${rst}`);
+      console.log(``);
+      section("raw command (copy-paste into the teammate's terminal):", [
+        `${yel}cd ${cwd} && \\${rst}`,
+        `${yel}  env CLAUDECODE=1 CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 \\${rst}`,
+        `${yel}  ${claudeBin} \\${rst}`,
+        `${yel}    --session-id ${childSid} \\${rst}`,
+        `${yel}    --agent-id ${role}@${teamName} \\${rst}`,
+        `${yel}    --agent-name ${role} \\${rst}`,
+        `${yel}    --team-name ${teamName} \\${rst}`,
+        `${yel}    --agent-color ${color} \\${rst}`,
+        `${yel}    --parent-session-id ${parentSid} \\${rst}`,
+        `${yel}    --model sonnet \\${rst}`,
+        `${yel}    --dangerously-skip-permissions${rst}`,
+      ]);
+      console.log(`  ${grn}flag breakdown:${rst}`);
+      console.log(`    ${dim}--session-id        teammate's OWN uuid (this run)${rst}`);
+      console.log(`    ${dim}--parent-session-id lead's uuid (from step 1)${rst}`);
+      console.log(`    ${dim}--agent-id          unique key: <role>@<team>${rst}`);
+      console.log(`    ${dim}--agent-name        display name${rst}`);
+      console.log(`    ${dim}--team-name         team registry key${rst}`);
+      console.log(`    ${dim}--agent-color       tmux status bar color${rst}`);
+      console.log(``);
+      console.log(`  ${grn}(a) append member to config.json:${rst}`);
+      console.log(`    ${dim}jq '.members += [...]' ~/.claude/teams/${teamName}/config.json${rst}`);
+      console.log(`    ${dim}— see 'maw team-agent ls ${teamName}' for current members${rst}`);
+      console.log(``);
+      shortcut(`maw team-agent spawn ${teamName} ${role}@${cwd}:${color} --mission "..."  (writes config + spawns)`);
+
+      // Interactive apply prompt if TTY and --apply not explicit
+      let doApply = apply;
+      if (!apply && process.stdin.isTTY) {
+        const ans = (prompt(`  ${grn}apply now?${rst} [Y/n]:`) || "").trim();
+        doApply = !/^n(o)?$/i.test(ans);
+      }
+
+      if (doApply) {
+        console.log(``);
+        console.log(`${blue}━━ apply ━━${rst}  ${dim}adding ${role} to ${teamName}...${rst}`);
+        const spawn = spawnSync("maw", ["team-agent", "spawn", teamName, `${role}@${cwd}:${color}`], { stdio: "inherit" });
+        if (spawn.status !== 0) throw new Error(`maw team-agent spawn failed (exit ${spawn.status})`);
+        console.log(``);
+        console.log(`${grn}✓ ${role} added to ${teamName}. Lead's SendMessage can now find them.${rst}`);
+        console.log(`${dim}  → repeat ${rst}${yel}maw team-agent tutorial 2${rst}${dim} to add more members${rst}`);
+      } else {
+        console.log(`${dim}  not applied — copy the raw command above to do it manually${rst}`);
+      }
+
+      console.log(``);
+      console.log(`${dim}Next: ${rst}${yel}maw team-agent tutorial 3${rst}  ${dim}(send a message) or ${rst}${yel}tutorial 2${rst}${dim} again for more${rst}`);
+      return;
+    }
+
+    case "3": {
+      const state = readState();
+      const teamName = args[1] || state.teamName || "my-team";
+      const role = args[2] || state.role || "architect";
+      const inboxPath = `~/.claude/teams/${teamName}/inboxes/${role}.json`;
+
+      header(3, "Send a message (inbox JSON envelope)");
+      console.log(`${dim}  Claude Code reads messages from ~/.claude/teams/<team>/inboxes/<role>.json${rst}`);
+      console.log(`${dim}  It's a JSON array of envelopes. Append to send.${rst}`);
+      console.log(``);
+      section("envelope format:", [
+        `${yel}{${rst}`,
+        `${yel}  "from": "shell-lead",${rst}`,
+        `${yel}  "text": "Review the auth flow",${rst}`,
+        `${yel}  "summary": "auth review",${rst}`,
+        `${yel}  "timestamp": "${new Date().toISOString()}",${rst}`,
+        `${yel}  "color": "yellow",${rst}`,
+        `${yel}  "read": false${rst}`,
+        `${yel}}${rst}`,
+      ]);
+      section("append via shell (raw):", [
+        `${yel}mkdir -p ~/.claude/teams/${teamName}/inboxes${rst}`,
+        `${yel}jq '. += [{from: "shell", text: "your msg", timestamp: "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'", read: false}]' \\${rst}`,
+        `${yel}   ${inboxPath} > /tmp/inbox.tmp && mv /tmp/inbox.tmp ${inboxPath}${rst}`,
+      ]);
+      shortcut(`maw team-agent msg ${teamName} ${role} "your msg here"`);
+      console.log(`${dim}Next: ${rst}${yel}maw team-agent tutorial 4${rst}  ${dim}(how teammate sees it)${rst}`);
+      return;
+    }
+
+    case "4": {
+      header(4, "How the teammate sees the message");
+      console.log(`${dim}  When the teammate's claude.exe reads the inbox, it renders each envelope as XML:${rst}`);
+      console.log(``);
+      section("rendered as XML in teammate's context:", [
+        `${yel}<teammate-message teammate_id="shell-lead" color="yellow" summary="auth review">${rst}`,
+        `${yel}Review the auth flow${rst}`,
+        `${yel}</teammate-message>${rst}`,
+      ]);
+      console.log(`  ${grn}where this happens:${rst}`);
+      console.log(`    ${dim}- Regex baked into claude.exe binary (5 body shapes: text/json/shutdown/idle/error)${rst}`);
+      console.log(`    ${dim}- See ψ/ralph/55-teammate-message-wire.md for the literal regex${rst}`);
+      console.log(``);
+      console.log(`  ${grn}teammate's REPLY appears in the LEAD's context the same way:${rst}`);
+      console.log(`    ${yel}<teammate-message teammate_id="architect" color="yellow" summary="...">${rst}`);
+      console.log(`    ${yel}reply text${rst}`);
+      console.log(`    ${yel}</teammate-message>${rst}`);
+      console.log(``);
+      console.log(`${dim}Next: ${rst}${yel}maw team-agent tutorial 5${rst}  ${dim}(graceful shutdown)${rst}`);
+      return;
+    }
+
+    case "5": {
+      const state = readState();
+      const teamName = args[1] || state.teamName || "my-team";
+      const role = args[2] || state.role || "architect";
+
+      header(5, "Graceful shutdown (shutdown_request envelope)");
+      console.log(`${dim}  Append a special envelope. Claude.exe sees it, replies shutdown_approved, then exits.${rst}`);
+      console.log(``);
+      section("envelope format:", [
+        `${yel}{${rst}`,
+        `${yel}  "type": "shutdown_request",${rst}`,
+        `${yel}  "request_id": "shutdown-${Date.now()}@${role}",${rst}`,
+        `${yel}  "from": "shell-lead",${rst}`,
+        `${yel}  "text": "{\\"type\\":\\"shutdown_request\\"}",${rst}`,
+        `${yel}  "timestamp": "${new Date().toISOString()}",${rst}`,
+        `${yel}  "read": false${rst}`,
+        `${yel}}${rst}`,
+      ]);
+      console.log(`  ${grn}teammate replies with:${rst}`);
+      console.log(`    ${yel}<teammate-message teammate_id="${role}">${rst}`);
+      console.log(`    ${yel}{"type":"shutdown_approved","requestId":"..."}${rst}`);
+      console.log(`    ${yel}</teammate-message>${rst}`);
+      console.log(``);
+      shortcut(`maw team-agent shutdown ${teamName} ${role}`);
+      console.log(`${dim}Next: ${rst}${yel}maw team-agent tutorial 6${rst}  ${dim}(cleanup)${rst}`);
+      return;
+    }
+
+    case "6": {
+      const state = readState();
+      const teamName = args[1] || state.teamName || "my-team";
+      const role = args[2] || state.role || "architect";
+
+      header(6, "Cleanup (kill + rm config)");
+      console.log(`${dim}  Force-kill claude.exe process (if shutdown didn't work), remove team dir.${rst}`);
+      console.log(``);
+      section("kill the tmux session running claude.exe:", [
+        `${yel}tmux kill-session -t ${teamName}-${role}${rst}`,
+      ]);
+      section("or kill all sessions matching team:", [
+        `${yel}for s in $(tmux list-sessions -F "#{session_name}" | grep "^${teamName}-"); do${rst}`,
+        `${yel}  tmux kill-session -t "$s"${rst}`,
+        `${yel}done${rst}`,
+      ]);
+      section("remove team dir:", [
+        `${yel}rm -rf ~/.claude/teams/${teamName}${rst}`,
+      ]);
+      shortcut(`maw team-agent cleanup ${teamName} --confirm --all`);
+      console.log(`${grn}✓ tutorial complete!${rst}`);
+      console.log(``);
+      console.log(`${dim}You now know the raw Claude Code team protocol:${rst}`);
+      console.log(`  ${dim}1. --session-id locks lead's identity${rst}`);
+      console.log(`  ${dim}2. --parent-session-id + team flags spawn a teammate${rst}`);
+      console.log(`  ${dim}3. Inbox JSON envelopes deliver messages${rst}`);
+      console.log(`  ${dim}4. <teammate-message> XML is how Claude sees them${rst}`);
+      console.log(`  ${dim}5. shutdown_request envelope = graceful exit${rst}`);
+      console.log(`  ${dim}6. tmux kill-session + rm = cleanup${rst}`);
+      console.log(``);
+      console.log(`${dim}Production wrapper: ${rst}${yel}maw team-agent start <name> --preset trio${rst}  ${dim}(does steps 1-2 in 1 command)${rst}`);
+      return;
+    }
+
+    default:
+      throw new Error(`unknown step: ${stepNum} — valid: 1-6, or 'list'`);
+  }
+}

--- a/plugins/team-agent/cmd/uuid.ts
+++ b/plugins/team-agent/cmd/uuid.ts
@@ -1,0 +1,52 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+
+export async function cmdUuid(args: string[], flags: Record<string, unknown>): Promise<void> {
+  const count = Math.max(1, Math.min(parseInt(args[0] || "1", 10) || 1, 100));
+  const json = flags["--json"] === true;
+  const bare = flags["--bare"] === true || flags["--quiet"] === true;
+  const human = flags["--human"] === true || flags["--decimal"] === true;
+  const marker = (flags["--marker"] as string) || "00000000";
+
+  const out: Array<{ uuid: string; counter: number; shortRef: string; human: string }> = [];
+  for (let i = 0; i < count; i++) {
+    const g = generateReadableUuid(marker);
+    // Human format: #<counter>@<ISO timestamp>  — parseable from the new layout:
+    //   NNNNNNNN-YYYY-MMDD-HHMM-YYMMDDHHMMSS
+    // Example: "#91@2026-05-22T01:07:42"
+    const m = g.uuid.match(/^\d{8}-(\d{4})-(\d{2})(\d{2})-(\d{2})(\d{2})-\d{6}(\d{2})\d{2}$/);
+    let humanStr = g.shortRef;
+    if (m) {
+      const [, yyyy, mm, dd, hh, mi, ss] = m;
+      humanStr = `#${g.counter}@${yyyy}-${mm}-${dd}T${hh}:${mi}:${ss}`;
+    }
+    out.push({ ...g, human: humanStr });
+  }
+
+  if (json) {
+    console.log(JSON.stringify(out, null, 2));
+    return;
+  }
+  if (bare) {
+    for (const g of out) console.log(human ? g.human : g.uuid);
+    return;
+  }
+  for (const g of out) {
+    if (human) {
+      console.log(`\x1b[33m${g.human}\x1b[0m`);
+    } else {
+      console.log(`\x1b[33m${g.shortRef.padEnd(7)}\x1b[0m ${g.uuid}  \x1b[90m${g.human}\x1b[0m`);
+    }
+  }
+  if (count > 1) {
+    console.log(`\x1b[90m  → counter at ~/.claude/team-agent-counter (now: ${out[out.length - 1].counter})\x1b[0m`);
+  }
+}
+

--- a/plugins/team-agent/cmd/wizard.ts
+++ b/plugins/team-agent/cmd/wizard.ts
@@ -1,0 +1,90 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync, rmSync, readdirSync } from "fs";
+import { join, dirname } from "path";
+import { spawnSync } from "child_process";
+import { homedir } from "os";
+import { generateReadableUuid, resolveParentUuid, UUID_RE } from "../lib/uuid";
+import { TEAMS_DIR, teamDir, configPath, inboxesDir, inboxPath, readConfig, writeConfig, readInbox, appendInbox } from "../lib/config";
+import { VALID_COLORS, findClaudeBin, shellQuote, parseMemberSpec, nowMs, nowISO } from "../lib/helpers";
+import { parseSimpleYaml, resolveTemplate } from "../lib/yaml";
+import { PRESETS, renderCharterYaml } from "../lib/presets";
+import { cmdQuick } from "./charter";
+
+export async function cmdWizard(_args: string[], flags: Record<string, unknown>): Promise<void> {
+  if (!process.stdin.isTTY) {
+    throw new Error("wizard requires interactive terminal (TTY)");
+  }
+
+  const dryRun = flags["--dry-run"] === true;
+  const blue = "\x1b[36m"; const dim = "\x1b[90m"; const grn = "\x1b[32m"; const rst = "\x1b[0m"; const yel = "\x1b[33m";
+
+  console.log(`${blue}┌─────────────────────────────────────────┐${rst}`);
+  console.log(`${blue}│  maw team-agent wizard                  │${rst}`);
+  console.log(`${blue}│  step-by-step team setup                │${rst}`);
+  console.log(`${blue}└─────────────────────────────────────────┘${rst}`);
+  console.log(``);
+
+  console.log(`${blue}Step 1/6 — Verify plugin${rst}`);
+  console.log(`${dim}  ✓ you're running maw team-agent (this command)${rst}`);
+  console.log(``);
+
+  console.log(`${blue}Step 2/6 — Team name${rst}`);
+  const defaultName = `team-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}`;
+  const name = (prompt(`  team name [${defaultName}]:`) || "").trim() || defaultName;
+  console.log(`${dim}  → ${name}${rst}`);
+  console.log(``);
+
+  console.log(`${blue}Step 3/6 — Preset${rst}`);
+  console.log(`  1. blank   (1 TODO member)`);
+  console.log(`  2. solo    (1 helper)`);
+  console.log(`  3. pair    (reviewer + writer)  ${dim}← default${rst}`);
+  console.log(`  4. trio    (reviewer + writer + lead)`);
+  console.log(`  5. review  (security + docs)`);
+  console.log(`  6. stack   (architect + frontend + backend + tester)`);
+  const presetMap: Record<string, string> = { "1": "blank", "2": "solo", "3": "pair", "4": "trio", "5": "review", "6": "stack" };
+  const pAns = (prompt(`  pick [1-6, default 3]:`) || "").trim() || "3";
+  const presetName = presetMap[pAns] || "pair";
+  console.log(`${dim}  → ${presetName}${rst}`);
+  console.log(``);
+
+  console.log(`${blue}Step 4/6 — Session ID${rst}`);
+  const sidGen = generateReadableUuid();
+  console.log(`${dim}  generated: ${sidGen.uuid} (${sidGen.shortRef})${rst}`);
+  console.log(``);
+
+  console.log(`${blue}Step 5/6 — Review${rst}`);
+  console.log(`  ${grn}command to run:${rst}`);
+  console.log(`    ${yel}maw team-agent start ${name} --preset ${presetName} --force --session-id ${sidGen.uuid}${rst}`);
+  console.log(``);
+  const goAhead = (prompt(`  proceed? [Y/n]:`) || "").trim();
+  if (/^n(o)?$/i.test(goAhead)) {
+    console.log(`${dim}  cancelled — nothing changed${rst}`);
+    return;
+  }
+  console.log(``);
+
+  console.log(`${blue}Step 6/6 — Launch${rst}`);
+  if (dryRun) {
+    console.log(`${yel}  dry-run — would execute:${rst}`);
+    console.log(`    maw team-agent start ${name} --preset ${presetName} --force --session-id ${sidGen.uuid}`);
+    return;
+  }
+
+  await cmdQuick([name], {
+    "--preset": presetName,
+    "--force": true,
+    "--session-id": sidGen.uuid,
+  });
+
+  console.log(``);
+  console.log(`${grn}✓ wizard complete${rst}`);
+  console.log(`${dim}  next:${rst}`);
+  console.log(`    maw team-agent ls ${name}`);
+  console.log(`    maw team-agent bring ${name} --list`);
+  console.log(`    maw team-agent bring ${name} <role>`);
+  console.log(`    maw team-agent cleanup ${name} --confirm --all`);
+}
+
+// ---------------------------------------------------------------------------
+// cmdBring — attach/split/switch to a worker's tmux session
+// ---------------------------------------------------------------------------
+

--- a/plugins/team-agent/impl.test.ts
+++ b/plugins/team-agent/impl.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Bun unit tests for team-agent plugin.
+ * Run: cd ~/.maw/plugins/team-agent && bun test
+ */
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  generateReadableUuid,
+  parseMemberSpec,
+  parseSimpleYaml,
+  resolveTemplate,
+  renderCharterYaml,
+  PRESETS,
+} from "./impl";
+
+// ---------------------------------------------------------------------------
+// generateReadableUuid
+// ---------------------------------------------------------------------------
+
+describe("generateReadableUuid", () => {
+  test("format: NNNNNNNN-HHMM-YYYY-MMDD-YYMMDDHHMMSS", () => {
+    const { uuid } = generateReadableUuid();
+    expect(uuid).toMatch(/^\d{8}-\d{4}-\d{4}-\d{4}-\d{12}$/);
+  });
+
+  test("all digits 0-9 (RFC-valid hex)", () => {
+    const { uuid } = generateReadableUuid();
+    expect(uuid.replace(/-/g, "")).toMatch(/^\d+$/);
+  });
+
+  test("counter increments on each call", () => {
+    const a = generateReadableUuid();
+    const b = generateReadableUuid();
+    expect(b.counter).toBeGreaterThan(a.counter);
+  });
+
+  test("shortRef format", () => {
+    const { counter, shortRef } = generateReadableUuid();
+    expect(shortRef).toBe(`#${counter}`);
+  });
+
+  test("counter prefix matches counter value", () => {
+    const { uuid, counter } = generateReadableUuid();
+    const prefix = uuid.slice(0, 8);
+    expect(parseInt(prefix, 10)).toBe(counter);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseMemberSpec
+// ---------------------------------------------------------------------------
+
+describe("parseMemberSpec", () => {
+  let tmpDir: string;
+  beforeAll(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "tap-test-"));
+  });
+  afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("role only → defaults to pwd + auto color", () => {
+    const m = parseMemberSpec("alpha", 0);
+    expect(m.role).toBe("alpha");
+    expect(m.cwd).toBe(process.cwd());
+    expect(m.color).toBe("red");
+  });
+
+  test("role:color → defaults cwd to pwd", () => {
+    const m = parseMemberSpec("beta:cyan");
+    expect(m.role).toBe("beta");
+    expect(m.cwd).toBe(process.cwd());
+    expect(m.color).toBe("cyan");
+  });
+
+  test("role@cwd → auto color", () => {
+    const m = parseMemberSpec(`gamma@${tmpDir}`, 1);
+    expect(m.role).toBe("gamma");
+    expect(m.cwd).toBe(tmpDir);
+    expect(m.color).toBe("green");
+  });
+
+  test("role@cwd:color → all specified", () => {
+    const m = parseMemberSpec(`delta@${tmpDir}:yellow`);
+    expect(m.role).toBe("delta");
+    expect(m.cwd).toBe(tmpDir);
+    expect(m.color).toBe("yellow");
+  });
+
+  test("default color rotates by index", () => {
+    const a = parseMemberSpec("x", 0);
+    const b = parseMemberSpec("x", 1);
+    expect(a.color).not.toBe(b.color);
+  });
+
+  test("bad color throws", () => {
+    expect(() => parseMemberSpec(`x@${tmpDir}:rainbow`)).toThrow(/bad color/);
+  });
+
+  test("nonexistent cwd throws", () => {
+    expect(() => parseMemberSpec("x@/nonexistent-path-xyz:green")).toThrow(/cwd does not exist/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseSimpleYaml
+// ---------------------------------------------------------------------------
+
+describe("parseSimpleYaml", () => {
+  test("top-level scalar fields", () => {
+    const yaml = `name: test\ndescription: "hello world"\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.name).toBe("test");
+    expect(parsed.description).toBe("hello world");
+  });
+
+  test("members list", () => {
+    const yaml = `name: t\nmembers:\n  - role: a\n    color: green\n  - role: b\n    color: cyan\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.members).toHaveLength(2);
+    expect(parsed.members[0].role).toBe("a");
+    expect(parsed.members[1].color).toBe("cyan");
+  });
+
+  test("vars block", () => {
+    const yaml = `name: t\nvars:\n  FOO: bar\n  BAZ: qux\nmembers: []\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.vars).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  test("comments are stripped", () => {
+    const yaml = `name: test  # this is a comment\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.name).toBe("test");
+  });
+
+  test("missing 'name' field returns empty members", () => {
+    const yaml = `description: orphan\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.members).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTemplate
+// ---------------------------------------------------------------------------
+
+describe("resolveTemplate", () => {
+  test("substitutes ${VAR}", () => {
+    const out = resolveTemplate("hello ${NAME}", { NAME: "world" });
+    expect(out).toBe("hello world");
+  });
+
+  test("multiple vars", () => {
+    const out = resolveTemplate("${A}-${B}-${A}", { A: "1", B: "2" });
+    expect(out).toBe("1-2-1");
+  });
+
+  test("falls back to process.env", () => {
+    process.env.MY_TEST_VAR = "envval";
+    const out = resolveTemplate("${MY_TEST_VAR}", {});
+    expect(out).toBe("envval");
+    delete process.env.MY_TEST_VAR;
+  });
+
+  test("leaves unknown vars literal", () => {
+    const out = resolveTemplate("${UNKNOWN_XYZ_123}", {});
+    expect(out).toBe("${UNKNOWN_XYZ_123}");
+  });
+
+  test("provided vars override env", () => {
+    process.env.OVERRIDE_TEST = "fromEnv";
+    const out = resolveTemplate("${OVERRIDE_TEST}", { OVERRIDE_TEST: "fromVars" });
+    expect(out).toBe("fromVars");
+    delete process.env.OVERRIDE_TEST;
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PRESETS + renderCharterYaml
+// ---------------------------------------------------------------------------
+
+describe("PRESETS", () => {
+  test("has all 6 presets", () => {
+    expect(Object.keys(PRESETS).sort()).toEqual(
+      ["blank", "pair", "review", "solo", "stack", "trio"]
+    );
+  });
+
+  test("each preset has description and members", () => {
+    for (const [, preset] of Object.entries(PRESETS)) {
+      expect(preset.description).toBeTruthy();
+      expect(Array.isArray(preset.members)).toBe(true);
+      expect(preset.members.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("stack preset has 4 members", () => {
+    expect(PRESETS.stack.members).toHaveLength(4);
+  });
+
+  test("solo preset has 1 member", () => {
+    expect(PRESETS.solo.members).toHaveLength(1);
+  });
+
+  test("trio preset has 3 members", () => {
+    expect(PRESETS.trio.members).toHaveLength(3);
+  });
+});
+
+describe("renderCharterYaml", () => {
+  test("renders valid YAML for each preset", () => {
+    for (const presetName of Object.keys(PRESETS)) {
+      const yaml = renderCharterYaml("test-team", presetName);
+      expect(yaml).toContain("name: test-team");
+      expect(yaml).toContain("session-id: ${SESSION_ID}");
+      expect(yaml).toContain("cwd: ${PROJECT_ROOT}");
+      expect(yaml).toContain("members:");
+    }
+  });
+
+  test("includes generation timestamp", () => {
+    const yaml = renderCharterYaml("x", "blank");
+    expect(yaml).toMatch(/Generated \d{4}-\d{2}-\d{2} \d{2}:\d{2}/);
+  });
+
+  test("pair preset renders 2 members", () => {
+    const yaml = renderCharterYaml("x", "pair");
+    const roleLines = yaml.split("\n").filter(l => l.match(/^\s+- role:/));
+    expect(roleLines).toHaveLength(2);
+  });
+
+  test("throws on unknown preset", () => {
+    expect(() => renderCharterYaml("x", "nonsense")).toThrow(/unknown preset/);
+  });
+
+  test("rendered YAML round-trips through parser", () => {
+    const yaml = renderCharterYaml("rt-test", "trio");
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.name).toBe("rt-test");
+    expect(parsed.members).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: template + parser
+// ---------------------------------------------------------------------------
+
+describe("template + parser integration", () => {
+  test("resolveTemplate then parseSimpleYaml", () => {
+    const tpl = `name: \${NAME}\nsession-id: \${SID}\nmembers:\n  - role: \${ROLE}\n    color: green\n`;
+    const resolved = resolveTemplate(tpl, { NAME: "demo", SID: "abc-123", ROLE: "alpha" });
+    const parsed = parseSimpleYaml(resolved);
+    expect(parsed.name).toBe("demo");
+    expect(parsed["session-id"]).toBe("abc-123");
+    expect(parsed.members[0].role).toBe("alpha");
+  });
+
+  test("vars: section can reference each other via builtins", () => {
+    const yaml = `name: t\nvars:\n  SRC: /tmp/src\n  TESTS: /tmp/tests\nmembers: []\n`;
+    const parsed = parseSimpleYaml(yaml);
+    expect(parsed.vars.SRC).toBe("/tmp/src");
+    expect(parsed.vars.TESTS).toBe("/tmp/tests");
+  });
+});

--- a/plugins/team-agent/impl.ts
+++ b/plugins/team-agent/impl.ts
@@ -1,0 +1,25 @@
+/**
+ * team-agent — aggregator. Re-exports all cmd* + lib utilities.
+ *
+ * Module structure:
+ *   lib/      — pure utilities (uuid, config, helpers, yaml, presets)
+ *   cmd/      — subcommand implementations
+ *   index.ts  — entry router (dispatches to cmd/*)
+ *   impl.ts   — this file (re-export aggregator)
+ */
+
+// Re-export lib utilities (used by tests + external callers)
+export { generateReadableUuid, resolveParentUuid, UUID_RE } from "./lib/uuid";
+export { parseSimpleYaml, resolveTemplate } from "./lib/yaml";
+export { PRESETS, renderCharterYaml } from "./lib/presets";
+export { parseMemberSpec } from "./lib/helpers";
+
+// Re-export subcommands
+export { cmdHelp } from "./cmd/help";
+export { cmdCreate, cmdSpawn, cmdLs, cmdMsg, cmdShutdown, cmdKill, cmdDelete } from "./cmd/team";
+export { cmdUuid } from "./cmd/uuid";
+export { cmdCleanup } from "./cmd/cleanup";
+export { cmdFrom, cmdQuick, cmdInit } from "./cmd/charter";
+export { cmdWizard } from "./cmd/wizard";
+export { cmdBring } from "./cmd/bring";
+export { cmdTutorial } from "./cmd/tutorial";

--- a/plugins/team-agent/index.ts
+++ b/plugins/team-agent/index.ts
@@ -1,0 +1,170 @@
+/**
+ * team-agent — manual team-agent spawn (no Claude tools required).
+ *
+ * Shell-driven TeamCreate teammate lifecycle:
+ *   create  — write ~/.claude/teams/<name>/config.json
+ *   spawn   — maw tile --path --cmd with the 7 canonical claude.exe team flags
+ *   ls      — list teams + members + inbox counts
+ *   msg     — write JSON envelope to inboxes/<role>.json (mimics SendMessage)
+ *   shutdown — write {type:"shutdown_request"} envelope
+ *   kill    — tmux kill-pane on the teammate's pane (from config.json tmuxPaneId)
+ *   delete  — remove team dir (requires --confirm)
+ *   help    — show usage
+ *
+ * No maw-js imports (standalone-friendly plugin, like maw-cell-plugin/packages/50-bud).
+ * Just bun + tmux + maw tile (via shell).
+ */
+
+// Local types — no maw-js dep
+type InvokeContext = {
+  source: "cli" | string;
+  args: string[];
+  flags?: Record<string, unknown>;
+  writer?: (...a: any[]) => void;
+};
+type InvokeResult = { ok: boolean; output?: string; error?: string };
+
+import { cmdCreate, cmdSpawn, cmdLs, cmdMsg, cmdShutdown, cmdKill, cmdDelete, cmdHelp, cmdUuid, cmdCleanup, cmdFrom, cmdInit, cmdQuick, cmdBring, cmdWizard, cmdTutorial } from "./impl";
+
+export const command = {
+  name: "team-agent",
+  description: "Manual team-agent spawn — shell-driven TeamCreate teammates without Claude tools.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  console.log = (...a: any[]) => { if (ctx.writer) ctx.writer(...a); else logs.push(a.map(String).join(" ")); };
+  console.error = (...a: any[]) => { if (ctx.writer) ctx.writer(...a); else logs.push(a.map(String).join(" ")); };
+
+  try {
+    // maw loader sends raw argv in ctx.args but never populates ctx.flags (#1885).
+    // Parse flags from args ourselves so `maw team-agent --bare` works.
+    const rawArgs = ctx.source === "cli" ? (ctx.args as string[]) : [];
+    const flags: Record<string, unknown> = { ...(ctx.flags ?? {}) };
+    const positional: string[] = [];
+    for (let i = 0; i < rawArgs.length; i++) {
+      const a = rawArgs[i];
+      if (a?.startsWith("--")) {
+        const next = rawArgs[i + 1];
+        if (next && !next.startsWith("--")) { flags[a] = next; i++; }
+        else { flags[a] = true; }
+      } else {
+        positional.push(a!);
+      }
+    }
+    const args = positional;
+    const sub = args[0];
+    const rest = args.slice(1);
+
+    if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
+      cmdHelp();
+      return { ok: true, output: logs.join("\n") };
+    }
+
+    switch (sub) {
+      case "create":
+        await cmdCreate(rest, flags);
+        break;
+      case "spawn":
+        await cmdSpawn(rest, flags);
+        break;
+      case "ls":
+      case "list":
+        await cmdLs(rest, flags);
+        break;
+      case "msg":
+      case "message":
+      case "send":
+        await cmdMsg(rest, flags);
+        break;
+      case "shutdown":
+        await cmdShutdown(rest, flags);
+        break;
+      case "kill":
+        await cmdKill(rest, flags);
+        break;
+      case "delete":
+      case "rm":
+        await cmdDelete(rest, flags);
+        break;
+      case "uuid":
+      case "gen":
+      case "generate":
+        await cmdUuid(rest, flags);
+        break;
+      case "from":
+      case "charter":
+      case "yaml":
+        await cmdFrom(rest, flags);
+        break;
+      case "init":
+      case "scaffold":
+      case "template":
+        await cmdInit(rest, flags);
+        break;
+      case "start":
+      case "go":
+      case "run":
+      case "quick":
+      case "fast":
+      case "now":
+        await cmdQuick(rest, flags);
+        break;
+      case "bring":
+      case "attach":
+      case "join":
+        await cmdBring(rest, flags);
+        break;
+      case "wizard":
+      case "setup":
+      case "guide":
+        await cmdWizard(rest, flags);
+        break;
+      case "tutorial":
+      case "lesson":
+      case "step":
+        await cmdTutorial(rest, flags);
+        break;
+      case "cleanup":
+      case "nuke":
+      case "reset":
+        await cmdCleanup(rest, flags);
+        break;
+      default:
+        throw new Error(`unknown subcommand: ${sub} — run 'maw team-agent help' for usage`);
+    }
+    return { ok: true, output: logs.join("\n") };
+  } catch (e: any) {
+    return { ok: false, error: e.message ?? String(e), output: logs.join("\n") };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}
+
+// Allow direct invocation: `bun ~/.maw/plugins/team-agent/index.ts <subcommand> ...`
+if (import.meta.main) {
+  // Capture the ORIGINAL console.log BEFORE the handler can override it.
+  const realLog = console.log.bind(console);
+  const realErr = console.error.bind(console);
+  const args = process.argv.slice(2);
+  const flags: Record<string, unknown> = {};
+  const positional: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a?.startsWith("--")) {
+      const next = args[i + 1];
+      if (next && !next.startsWith("--")) { flags[a] = next; i++; }
+      else { flags[a] = true; }
+    } else {
+      positional.push(a!);
+    }
+  }
+  const result = await handler({ source: "cli", args: positional, flags, writer: (...a) => realLog(...a) });
+  if (!result.ok) {
+    realErr(`\x1b[31merror:\x1b[0m ${result.error}`);
+    process.exit(1);
+  }
+}

--- a/plugins/team-agent/lib/config.ts
+++ b/plugins/team-agent/lib/config.ts
@@ -1,0 +1,37 @@
+/**
+ * Team config + inbox IO.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export const TEAMS_DIR = join(homedir(), ".claude", "teams");
+
+export function teamDir(name: string): string { return join(TEAMS_DIR, name); }
+export function configPath(name: string): string { return join(teamDir(name), "config.json"); }
+export function inboxesDir(name: string): string { return join(teamDir(name), "inboxes"); }
+export function inboxPath(team: string, role: string): string { return join(inboxesDir(team), `${role}.json`); }
+
+export function readConfig(team: string): any {
+  if (!existsSync(configPath(team))) throw new Error(`team not found: ${team} (no ${configPath(team)})`);
+  return JSON.parse(readFileSync(configPath(team), "utf-8"));
+}
+
+export function writeConfig(team: string, cfg: any): void {
+  mkdirSync(teamDir(team), { recursive: true });
+  writeFileSync(configPath(team), JSON.stringify(cfg, null, 2));
+}
+
+export function readInbox(team: string, role: string): any[] {
+  const p = inboxPath(team, role);
+  if (!existsSync(p)) return [];
+  return JSON.parse(readFileSync(p, "utf-8"));
+}
+
+export function appendInbox(team: string, role: string, entry: any): void {
+  mkdirSync(inboxesDir(team), { recursive: true });
+  const inbox = readInbox(team, role);
+  inbox.push(entry);
+  writeFileSync(inboxPath(team, role), JSON.stringify(inbox, null, 2));
+}

--- a/plugins/team-agent/lib/helpers.ts
+++ b/plugins/team-agent/lib/helpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Helpers: types, colors, shell-quote, member-spec parser, find-claude-bin.
+ */
+
+import { existsSync } from "fs";
+import { homedir } from "os";
+
+export function expandTilde(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return homedir() + p.slice(1);
+  return p;
+}
+
+export type InvokeContext = {
+  source: "cli" | string;
+  args: string[];
+  flags?: Record<string, unknown>;
+  writer?: (...a: any[]) => void;
+};
+export type InvokeResult = { ok: boolean; output?: string; error?: string };
+
+export const VALID_COLORS = ["red", "green", "yellow", "blue", "purple", "cyan", "magenta", "white"];
+
+export function findClaudeBin(): string {
+  const candidates = [
+    `${homedir()}/.nvm/versions/node/v24.15.0/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`,
+    `/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe`,
+    `${homedir()}/.bun/install/global/node_modules/@anthropic-ai/claude-code/bin/claude.exe`,
+  ];
+  for (const c of candidates) if (existsSync(c)) return c;
+  return "claude";
+}
+
+export function shellQuote(s: string): string {
+  if (/^[A-Za-z0-9_@.\-\/:]+$/.test(s)) return s;
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Member spec formats:
+ *   role                       → cwd=pwd, color=auto
+ *   role:color                 → cwd=pwd, color=specified
+ *   role@cwd                   → cwd=specified, color=auto
+ *   role@cwd:color             → all specified
+ */
+export function parseMemberSpec(spec: string, defaultColorIdx = 0): { role: string; cwd: string; color: string } {
+  let role: string, cwd: string, color: string | undefined;
+  const atIdx = spec.indexOf("@");
+  if (atIdx < 0) {
+    const colonIdx = spec.indexOf(":");
+    if (colonIdx >= 0) {
+      role = spec.slice(0, colonIdx);
+      color = spec.slice(colonIdx + 1) || undefined;
+    } else {
+      role = spec;
+    }
+    cwd = process.cwd();
+  } else {
+    role = spec.slice(0, atIdx);
+    const rest = spec.slice(atIdx + 1);
+    const colonIdx = rest.indexOf(":");
+    if (colonIdx >= 0) {
+      cwd = rest.slice(0, colonIdx);
+      color = rest.slice(colonIdx + 1) || undefined;
+    } else {
+      cwd = rest;
+    }
+  }
+  if (!role) throw new Error(`bad member spec: missing role in "${spec}"`);
+  if (!color) color = VALID_COLORS[defaultColorIdx % VALID_COLORS.length];
+  if (!VALID_COLORS.includes(color)) throw new Error(`bad color "${color}" — valid: ${VALID_COLORS.join(",")}`);
+  cwd = expandTilde(cwd);
+  if (!existsSync(cwd)) throw new Error(`cwd does not exist: ${cwd}`);
+  return { role, cwd, color };
+}
+
+export function nowMs(): number { return Date.now(); }
+export function nowISO(): string { return new Date().toISOString(); }

--- a/plugins/team-agent/lib/presets.ts
+++ b/plugins/team-agent/lib/presets.ts
@@ -1,0 +1,86 @@
+/**
+ * Charter presets + YAML scaffold generator.
+ */
+
+export const PRESETS: Record<string, {
+  description: string;
+  members: Array<{ role: string; color: string; "system-prompt": string; mission?: string }>;
+}> = {
+  blank: {
+    description: "TODO: describe team purpose",
+    members: [
+      { role: "TODO-role", color: "green", "system-prompt": "TODO: describe role identity", mission: "TODO: first task (optional)" },
+    ],
+  },
+  solo: {
+    description: "Single-agent helper team",
+    members: [
+      { role: "helper", color: "green", "system-prompt": "You are a helpful assistant.", mission: "TODO: first task" },
+    ],
+  },
+  pair: {
+    description: "Reviewer + Writer pair",
+    members: [
+      { role: "reviewer", color: "green", "system-prompt": "You are a code reviewer. Flag issues, suggest improvements." },
+      { role: "writer", color: "cyan", "system-prompt": "You are a technical writer. Be concise." },
+    ],
+  },
+  trio: {
+    description: "Reviewer + Writer + Lead",
+    members: [
+      { role: "reviewer", color: "green", "system-prompt": "You are a code reviewer." },
+      { role: "writer", color: "cyan", "system-prompt": "You are a technical writer." },
+      { role: "lead", color: "yellow", "system-prompt": "You are the team lead. Coordinate and synthesize." },
+    ],
+  },
+  review: {
+    description: "Security review team",
+    members: [
+      { role: "security", color: "green", "system-prompt": "You are a security auditor. Flag OWASP top 10 issues.", mission: "Review the codebase for security issues" },
+      { role: "docs", color: "cyan", "system-prompt": "You are a documentation reviewer. Check for clarity and completeness.", mission: "Review the documentation" },
+    ],
+  },
+  stack: {
+    description: "Full-stack team",
+    members: [
+      { role: "architect", color: "yellow", "system-prompt": "You are a software architect. Focus on system design." },
+      { role: "frontend", color: "cyan", "system-prompt": "You are a frontend engineer. Focus on UI/UX." },
+      { role: "backend", color: "green", "system-prompt": "You are a backend engineer. Focus on APIs and data." },
+      { role: "tester", color: "magenta", "system-prompt": "You are a QA engineer. Focus on test coverage." },
+    ],
+  },
+};
+
+export function renderCharterYaml(name: string, presetName: string): string {
+  const preset = PRESETS[presetName];
+  if (!preset) throw new Error(`unknown preset: ${presetName} (valid: ${Object.keys(PRESETS).join(", ")})`);
+
+  const now = new Date().toISOString().slice(0, 16).replace("T", " ");
+  const lines: string[] = [
+    `# ψ/teams/${name}.yaml`,
+    `# Generated ${now} by 'maw team-agent init --preset ${presetName}'`,
+    ``,
+    `name: ${name}`,
+    `description: "${preset.description}"`,
+    `session-id: \${SESSION_ID}`,
+    `cwd: \${PROJECT_ROOT}`,
+    ``,
+    `vars:`,
+    `  # Define custom paths here`,
+    `  # WORK: \${PROJECT_ROOT}/src`,
+    ``,
+    `members:`,
+  ];
+
+  for (const m of preset.members) {
+    lines.push(`  - role: ${m.role}`);
+    lines.push(`    color: ${m.color}`);
+    lines.push(`    model: sonnet`);
+    lines.push(`    # cwd: \${PROJECT_ROOT}  # uncomment to override default`);
+    lines.push(`    system-prompt: "${m["system-prompt"]}"`);
+    if (m.mission) lines.push(`    mission: "${m.mission}"`);
+    lines.push(``);
+  }
+
+  return lines.join("\n");
+}

--- a/plugins/team-agent/lib/uuid.ts
+++ b/plugins/team-agent/lib/uuid.ts
@@ -1,0 +1,81 @@
+/**
+ * UUID generation + parent resolution.
+ *
+ * Format: NNNNNNNN-HHMM-YYYY-MMDD-YYMMDDHHMMSS
+ *   counter   time   year  date   compact timestamp
+ *
+ * All digits 0-9 → RFC-valid hex UUID. Counter persisted at ~/.claude/team-agent-counter.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+export const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+export const COUNTER_FILE = join(homedir(), ".claude", "team-agent-counter");
+
+export function generateReadableUuid(
+  _marker: string = "000000000000",
+): { uuid: string; counter: number; shortRef: string } {
+  const now = new Date();
+  const yyyy = String(now.getFullYear());
+  const yy   = yyyy.slice(2);
+  const mm   = String(now.getMonth() + 1).padStart(2, "0");
+  const dd   = String(now.getDate()).padStart(2, "0");
+  const hh   = String(now.getHours()).padStart(2, "0");
+  const mi   = String(now.getMinutes()).padStart(2, "0");
+  const ss   = String(now.getSeconds()).padStart(2, "0");
+
+  let counter = 0;
+  try {
+    if (existsSync(COUNTER_FILE)) {
+      counter = parseInt(readFileSync(COUNTER_FILE, "utf-8").trim(), 10) || 0;
+    }
+  } catch {}
+  counter += 1;
+  try {
+    mkdirSync(dirname(COUNTER_FILE), { recursive: true });
+    writeFileSync(COUNTER_FILE, String(counter));
+  } catch {}
+  const ctr = String(counter % 100000000).padStart(8, "0");
+
+  const g1 = ctr;
+  const g2 = `${hh}${mi}`;
+  const g3 = yyyy;
+  const g4 = `${mm}${dd}`;
+  const g5 = `${yy}${mm}${dd}${hh}${mi}${ss}`;
+
+  return {
+    uuid: `${g1}-${g2}-${g3}-${g4}-${g5}`,
+    counter,
+    shortRef: `#${counter}`,
+  };
+}
+
+function encodePath(p: string): string {
+  return p.replace(/^\//, "-").replace(/[/.]/g, "-");
+}
+
+/**
+ * Resolve the parent (lead) session UUID.
+ *   1. $CLAUDE_SESSION_ID env var
+ *   2. Newest .jsonl in ~/.claude/projects/<encoded-pwd>/
+ */
+export function resolveParentUuid(cwd: string = process.cwd()): string | null {
+  const env = process.env.CLAUDE_SESSION_ID;
+  if (env && UUID_RE.test(env)) return env;
+
+  const projectDir = join(homedir(), ".claude", "projects", encodePath(cwd));
+  if (!existsSync(projectDir)) return null;
+  try {
+    const files = readdirSync(projectDir)
+      .filter((f: string) => f.endsWith(".jsonl"))
+      .map((f: string) => ({ name: f, mtime: statSync(join(projectDir, f)).mtimeMs }))
+      .sort((a: { mtime: number }, b: { mtime: number }) => b.mtime - a.mtime);
+    if (files.length === 0) return null;
+    const newest = files[0].name.replace(/\.jsonl$/, "");
+    return UUID_RE.test(newest) ? newest : null;
+  } catch {
+    return null;
+  }
+}

--- a/plugins/team-agent/lib/yaml.ts
+++ b/plugins/team-agent/lib/yaml.ts
@@ -1,0 +1,94 @@
+/**
+ * Minimal YAML parser + template resolver.
+ *
+ * Supports:
+ *   - top-level key: value
+ *   - block scalars (key: |)
+ *   - vars: section (2-space indent key-value)
+ *   - members: array (- role: ... with 4-space indent fields)
+ *   - # comments
+ *
+ * Template: ${VAR} → vars[VAR] || process.env[VAR] || literal
+ */
+
+export function parseSimpleYaml(text: string): Record<string, any> {
+  const lines = text.split(/\r?\n/);
+  const root: Record<string, any> = {};
+  const members: Record<string, any>[] = [];
+  let currentMember: Record<string, any> | null = null;
+  let blockKey: string | null = null;
+  let blockLines: string[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    const stripped = line.replace(/#.*$/, "");
+    if (!stripped.trim()) { i++; continue; }
+
+    if (blockKey && /^\S/.test(line)) {
+      if (currentMember) currentMember[blockKey] = blockLines.join("\n").trim();
+      else root[blockKey] = blockLines.join("\n").trim();
+      blockKey = null;
+      blockLines = [];
+    }
+    if (blockKey) {
+      blockLines.push(stripped.replace(/^ {4,6}/, ""));
+      i++; continue;
+    }
+
+    const topMatch = stripped.match(/^([a-z][a-z0-9-]*):\s*(.*)$/);
+
+    if (topMatch && topMatch[1] === "vars") {
+      const vars: Record<string, string> = {};
+      i++;
+      while (i < lines.length) {
+        const vl = lines[i]!.replace(/#.*$/, "");
+        if (!vl.trim()) { i++; continue; }
+        if (/^\S/.test(vl)) break;
+        const vm = vl.match(/^\s{2}([A-Za-z_][A-Za-z0-9_]*):\s*(.+)$/);
+        if (vm) vars[vm[1]!] = vm[2]!.replace(/^["']|["']$/g, "").trim();
+        i++;
+      }
+      root.vars = vars;
+      continue;
+    }
+
+    if (topMatch && topMatch[1] === "members") { i++; continue; }
+
+    if (topMatch) {
+      const val = topMatch[2]!.replace(/^["']|["']$/g, "").trim();
+      if (val === "|") { blockKey = topMatch[1]!; blockLines = []; }
+      else root[topMatch[1]!] = val;
+      i++; continue;
+    }
+
+    const memberStart = stripped.match(/^\s+-\s+role:\s*(.+)$/);
+    if (memberStart) {
+      if (currentMember) members.push(currentMember);
+      currentMember = { role: memberStart[1]!.replace(/^["']|["']$/g, "").trim() };
+      i++; continue;
+    }
+
+    if (currentMember) {
+      const field = stripped.match(/^\s{4}([a-z][a-z0-9-]*):\s*(.*)$/);
+      if (field) {
+        const val = field[2]!.replace(/^["']|["']$/g, "").trim();
+        if (val === "|") { blockKey = field[1]!; blockLines = []; }
+        else currentMember[field[1]!] = val;
+      }
+    }
+    i++;
+  }
+  if (blockKey && currentMember) currentMember[blockKey] = blockLines.join("\n").trim();
+  if (currentMember) members.push(currentMember);
+  root.members = members;
+  return root;
+}
+
+export function resolveTemplate(text: string, vars: Record<string, string>): string {
+  return text.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)}/g, (match, name) => {
+    if (name in vars) return vars[name];
+    if (name in process.env) return process.env[name]!;
+    return match;
+  });
+}

--- a/plugins/team-agent/package.json
+++ b/plugins/team-agent/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "maw-team-agent-plugin",
+  "private": true,
+  "type": "module",
+  "description": "maw plugin: team-agent — manual TeamCreate spawn + tutorial",
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bunx tsc --noEmit && bun test"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/bun": "latest",
+    "@types/node": "latest"
+  }
+}

--- a/plugins/team-agent/plugin.json
+++ b/plugins/team-agent/plugin.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
+  "name": "team-agent",
+  "version": "1.2.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "target": "js",
+  "tier": "extra",
+  "description": "Manual team-agent spawn — shell-driven TeamCreate teammates without needing Claude tools. Wraps maw tile --path --cmd + writes ~/.claude/teams/<name>/ config + inboxes directly.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "capabilities": [
+    "fs:read",
+    "fs:write",
+    "sdk:plugin"
+  ],
+  "cli": {
+    "command": "team-agent",
+    "help": "maw team-agent <subcommand> [args] — manual team-agent spawn (no Claude needed). Subcommands: create | spawn | ls | msg | shutdown | kill | delete | help",
+    "flags": {
+      "--mission": "string",
+      "--color": "string",
+      "--model": "string",
+      "--parent": "string",
+      "--session-id": "string",
+      "--by": "string",
+      "--confirm": "boolean",
+      "--dry-run": "boolean",
+      "--json": "boolean",
+      "--bare": "boolean",
+      "--quiet": "boolean",
+      "--human": "boolean",
+      "--decimal": "boolean",
+      "--marker": "string",
+      "--system-prompt": "string",
+      "--all": "boolean",
+      "--preset": "string",
+      "--roles": "string",
+      "--force": "boolean",
+      "--here": "boolean",
+      "--yes": "boolean",
+      "-y": "boolean",
+      "--no-attach": "boolean",
+      "--list": "boolean",
+      "--split": "boolean",
+      "--switch": "boolean",
+      "--apply": "boolean",
+      "--out": "string"
+    }
+  },
+  "weight": 50,
+  "schemaVersion": 1
+}

--- a/plugins/team-agent/registry.meta.json
+++ b/plugins/team-agent/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.2.0",
+  "source": "soul-brews-studio/maw-plugin-registry/team-agent@v1.2.0",
+  "sha256": null,
+  "summary": "Manual team-agent spawn — create Claude Code teams from the shell without needing TeamCreate tool; CLI wraps team-agent tutorial, presets, and SendMessage-equivalent msg verb.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/digger-oracle",
+  "addedAt": "2026-05-23T00:10:00Z",
+  "tier": "extra"
+}

--- a/plugins/team-agent/tsconfig.json
+++ b/plugins/team-agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["bun", "node"],
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "allowJs": true,
+    "esModuleInterop": true
+  },
+  "include": ["*.ts", "lib/**/*.ts", "cmd/**/*.ts"]
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-22T01:15:37Z",
+  "updated": "2026-05-22T17:17:10Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -775,6 +775,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:40:04Z",
+      "tier": "extra"
+    },
+    "team-agent": {
+      "version": "1.2.0",
+      "source": "soul-brews-studio/maw-plugin-registry/team-agent@v1.2.0",
+      "sha256": null,
+      "summary": "Manual team-agent spawn \u2014 create Claude Code teams from the shell without needing TeamCreate tool; CLI wraps team-agent tutorial, presets, and SendMessage-equivalent msg verb.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/digger-oracle",
+      "addedAt": "2026-05-23T00:10:00Z",
       "tier": "extra"
     },
     "token": {


### PR DESCRIPTION
## Summary

- Manual team-agent spawn for Claude Code teams — shell-driven alternative to `SendMessage` / `TeamCreate` tools
- 6-step interactive tutorial (`maw team-agent tutorial`) that teaches the raw protocol
- Preset spawn (`pair`/`trio`/`review`/`stack`) with optional `--split` for inline panes

## What it does

Lets you create + manage Claude Code teams from the shell:

```bash
# 1-line trio team, spawned as inline panes in current tmux
maw team-agent start my-team --preset trio --force --split

# Send to any teammate (works regardless of liveness)
maw team-agent msg my-team architect "review the auth flow"

# Read replies
cat ~/.claude/teams/my-team/inboxes/shell-lead.json | jq -r '.[].text'

# Cleanup (kills tmux panes/sessions + removes config)
maw team-agent cleanup my-team --confirm --all
```

## Why

`SendMessage` (the Claude tool) requires the calling Claude session to be the team lead with the teammate alive in the runtime registry. `team-agent msg` (this plugin's verb) just appends a JSON envelope to `~/.claude/teams/<team>/inboxes/<role>.json` — works regardless of who/what is alive. Useful for:

- Pre-staging messages before spawning teammates
- Cross-team messaging (one team's shell talks to another team's inbox)
- Debugging the team protocol from outside any claude.exe process

## Files

- 19 source files: `index.ts` + `impl.ts` + 8 `cmd/*.ts` + 5 `lib/*.ts` + tests + config
- 34 unit tests, 0 failures
- TypeScript clean (`bunx tsc --noEmit` exit 0)
- `bun run test` wired with typecheck-first gate

## Source / homepage

- Active development: https://github.com/Soul-Brews-Studio/digger-oracle (ψ/teams/plugin-snapshot-v1.1/)
- Gist installer (alt deployment): https://gist.github.com/nazt/0296da00a2471a82e3d29947ae081c09

## Registry hygiene

- `plugins/team-agent/registry.meta.json` added
- `registry.json` regenerated via `python3 scripts/build-registry.py` (82 plugins total, +1)

## Test plan

- [ ] `python3 scripts/build-registry.py` produces clean output (verified locally)
- [ ] `plugins/team-agent/` contains all 19 source files
- [ ] No conflicts with existing plugins (new `team-agent` namespace, not the existing `team` plugin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)