### PR TITLE
fix(team): remove vault manifest on `maw team delete`

### DIFF
--- a/plugins/cleanup/internal/team-helpers.ts
+++ b/plugins/cleanup/internal/team-helpers.ts
@@ -37,14 +37,21 @@ export function loadTeam(name: string): TeamConfig | null {
 }
 
 /**
- * Resolve ψ/ directory by walking UP from cwd looking for an oracle root
- * (marked by CLAUDE.md + ψ/). Falls back to cwd/ψ for backward compat when
- * no marker is found. Prevents rogue nested vaults when the CLI is run from
- * a sub-directory (#393 — Bug A).
+ * Resolve the ψ/ vault directory, cwd-INDEPENDENT first so that create and
+ * delete (and launchd daemons with an arbitrary cwd) always agree on one vault:
+ *   1. MAW_PSI env override — explicit; works from any cwd.
+ *   2. Walk UP from cwd for an oracle root (CLAUDE.md + ψ/ both present).
+ *   3. ~/ψ — stable fallback; never mints a stray ψ in an arbitrary cwd.
+ * Prevents rogue nested vaults when the CLI is run from a sub-directory
+ * (#393 — Bug A) and vault-orphans when run from outside any oracle root.
  */
 export function resolvePsi(): string {
+  // 1. Explicit override — the unconditional binding.
+  const env = process.env.MAW_PSI?.trim();
+  if (env) return env;
+
+  // 2. Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
   let dir = process.cwd();
-  // Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
   while (true) {
     const psi = join(dir, "ψ");
     if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
@@ -52,8 +59,8 @@ export function resolvePsi(): string {
     if (parent === dir) break; // reached filesystem root
     dir = parent;
   }
-  // Fallback: legacy behavior — cwd/ψ, callers mkdir as needed
-  return join(process.cwd(), "ψ");
+  // 3. Stable fallback: ~/ψ — not process.cwd()/ψ, which silently orphans.
+  return join(homedir(), "ψ");
 }
 
 /**

--- a/plugins/team/plugin.json
+++ b/plugins/team/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "team",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
-  "description": "Agent reincarnation engine — create, spawn, send, shutdown, resume, lives.",
+  "description": "Agent reincarnation engine \u2014 create, spawn, send, shutdown, resume, lives.",
   "author": "Soul-Brews-Studio",
   "cli": {
     "command": "team",

--- a/plugins/team/registry.meta.json
+++ b/plugins/team/registry.meta.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.1.1",
-  "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.1-team",
+  "version": "0.1.2",
+  "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.2-team",
   "sha256": null,
   "summary": "Agent team engine with worktree cwd spawn, inbox send, status, tasks, and pane submit.",
   "author": "Soul-Brews-Studio",

--- a/plugins/team/team-cleanup.ts
+++ b/plugins/team/team-cleanup.ts
@@ -2,6 +2,7 @@ import { existsSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { cmdTeamTaskDeleteAll } from "./task-ops";
+import { resolvePsi } from "./team-helpers";
 
 const TEAMS_DIR = join(homedir(), ".claude/teams");
 
@@ -17,6 +18,16 @@ export async function cmdTeamDelete(teamName: string): Promise<void> {
     console.log(`  \x1b[32m✓\x1b[0m team dir removed: ${teamDir}`);
   } else {
     console.log(`  \x1b[90mℹ team dir not found (already clean)\x1b[0m`);
+  }
+
+  // 3. Remove the durable vault manifest created by `maw team create`,
+  //    so vault-only manifests are not orphaned after delete.
+  const vaultTeamDir = join(resolvePsi(), "memory", "mailbox", "teams", teamName);
+  if (existsSync(vaultTeamDir)) {
+    rmSync(vaultTeamDir, { recursive: true, force: true });
+    console.log(`  \x1b[32m✓\x1b[0m vault manifest removed: ${vaultTeamDir}`);
+  } else {
+    console.log(`  \x1b[90mℹ vault manifest not found (already clean)\x1b[0m`);
   }
 
   console.log(`\x1b[32m✓\x1b[0m team "${teamName}" deleted`);

--- a/plugins/team/team-helpers.test.ts
+++ b/plugins/team/team-helpers.test.ts
@@ -1,0 +1,65 @@
+/**
+ * resolvePsi — cwd-independent vault resolution.
+ *
+ * Regression cover for the #102 follow-through: `maw team delete` removes the
+ * vault manifest via resolvePsi(), so resolution MUST agree with `create`
+ * regardless of the process cwd (interactive shell vs launchd daemon).
+ *
+ * Precedence under test:
+ *   1. MAW_PSI env override — explicit, works from any cwd.
+ *   2. walk UP for an oracle root (CLAUDE.md + ψ/ both present).
+ *   3. ~/ψ stable fallback — never mints a stray ψ in an arbitrary cwd.
+ *
+ * realpathSync() normalizes mkdtemp paths because macOS symlinks
+ * /var/folders → /private/var/folders, which process.cwd() resolves.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, realpathSync } from "fs";
+import { join } from "path";
+import { tmpdir, homedir } from "os";
+import { resolvePsi } from "./team-helpers";
+
+describe("resolvePsi — cwd-independent vault resolution", () => {
+  const origCwd = process.cwd();
+  const origEnv = process.env.MAW_PSI;
+  const made: string[] = [];
+
+  const sandbox = (prefix: string) => {
+    const d = realpathSync(mkdtempSync(join(tmpdir(), prefix)));
+    made.push(d);
+    return d;
+  };
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    if (origEnv === undefined) delete process.env.MAW_PSI;
+    else process.env.MAW_PSI = origEnv;
+    for (const d of made.splice(0)) rmSync(d, { recursive: true, force: true });
+  });
+
+  it("honors MAW_PSI override from a cwd with no oracle root", () => {
+    process.chdir(sandbox("psi-noroot-"));
+    process.env.MAW_PSI = "/explicit/vault/ψ";
+    expect(resolvePsi()).toBe("/explicit/vault/ψ");
+  });
+
+  it("falls back to ~/ψ — never cwd/ψ — when no oracle root is found", () => {
+    const dir = sandbox("psi-noroot-");
+    delete process.env.MAW_PSI;
+    process.chdir(dir);
+    const r = resolvePsi();
+    expect(r).toBe(join(homedir(), "ψ"));
+    expect(r).not.toBe(join(dir, "ψ")); // the orphan the old fallback produced
+  });
+
+  it("walks up to the nearest oracle root (CLAUDE.md + ψ/)", () => {
+    const root = sandbox("psi-oracle-");
+    mkdirSync(join(root, "ψ"));
+    writeFileSync(join(root, "CLAUDE.md"), "# test oracle\n");
+    const sub = join(root, "a", "b");
+    mkdirSync(sub, { recursive: true });
+    delete process.env.MAW_PSI;
+    process.chdir(sub);
+    expect(resolvePsi()).toBe(join(root, "ψ"));
+  });
+});

--- a/plugins/team/team-helpers.ts
+++ b/plugins/team/team-helpers.ts
@@ -37,14 +37,21 @@ export function loadTeam(name: string): TeamConfig | null {
 }
 
 /**
- * Resolve ψ/ directory by walking UP from cwd looking for an oracle root
- * (marked by CLAUDE.md + ψ/). Falls back to cwd/ψ for backward compat when
- * no marker is found. Prevents rogue nested vaults when the CLI is run from
- * a sub-directory (#393 — Bug A).
+ * Resolve the ψ/ vault directory, cwd-INDEPENDENT first so that create and
+ * delete (and launchd daemons with an arbitrary cwd) always agree on one vault:
+ *   1. MAW_PSI env override — explicit; works from any cwd.
+ *   2. Walk UP from cwd for an oracle root (CLAUDE.md + ψ/ both present).
+ *   3. ~/ψ — stable fallback; never mints a stray ψ in an arbitrary cwd.
+ * Prevents rogue nested vaults when the CLI is run from a sub-directory
+ * (#393 — Bug A) and vault-orphans when run from outside any oracle root.
  */
 export function resolvePsi(): string {
+  // 1. Explicit override — the unconditional binding.
+  const env = process.env.MAW_PSI?.trim();
+  if (env) return env;
+
+  // 2. Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
   let dir = process.cwd();
-  // Walk up looking for an oracle root (CLAUDE.md + ψ/ both present)
   while (true) {
     const psi = join(dir, "ψ");
     if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
@@ -52,8 +59,8 @@ export function resolvePsi(): string {
     if (parent === dir) break; // reached filesystem root
     dir = parent;
   }
-  // Fallback: legacy behavior — cwd/ψ, callers mkdir as needed
-  return join(process.cwd(), "ψ");
+  // 3. Stable fallback: ~/ψ — not process.cwd()/ψ, which silently orphans.
+  return join(homedir(), "ψ");
 }
 
 /**

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-22T17:17:10Z",
+  "updated": "2026-05-31T10:14:09Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -767,8 +767,8 @@
       "tier": "extra"
     },
     "team": {
-      "version": "0.1.1",
-      "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.1-team",
+      "version": "0.1.2",
+      "source": "soul-brews-studio/maw-plugin-registry/team@v0.1.2-team",
       "sha256": null,
       "summary": "Agent team engine with worktree cwd spawn, inbox send, status, tasks, and pane submit.",
       "author": "Soul-Brews-Studio",


### PR DESCRIPTION
## Summary

`maw team create` writes a durable vault manifest under `ψ/memory/mailbox/teams/<team>/manifest.json` in addition to the tool config under `~/.claude/teams/<team>/`. But `maw team delete` only removed the tool dir — leaving the vault manifest orphaned, so a deleted team lingers as a vault-only ghost.

## What's new

- **Vault-manifest cleanup on delete** — `cmdTeamDelete` now also removes `resolvePsi()/memory/mailbox/teams/<team>` after the tool dir, using the same "removed / already clean" logging style as the existing steps.

### Files changed (4 files)

**Modified files (4):**

| File | Change |
|------|--------|
| `plugins/team/team-cleanup.ts` | delete now removes the vault manifest dir via `resolvePsi()` |
| `plugins/team/plugin.json` | version 2.0.1 → 2.0.2 |
| `plugins/team/registry.meta.json` | version 0.1.1 → 0.1.2, source tag → `v0.1.2-team` |
| `registry.json` | rebuilt via `scripts/build-registry.py` |

## Test plan

- [x] Repro (pre-fix): `maw team create probe` creates the vault manifest; `maw team delete probe` left `ψ/memory/mailbox/teams/probe/` orphaned.
- [x] Post-fix: `delete` removes both `~/.claude/teams/<team>` and the vault dir (verified on a local install of this change).
- [ ] Maintainer: tag `v0.1.2-team` on merge (referenced by `registry.meta.json` source).

> Note: `@types/node` editor errors in the changed file are environmental (no deps installed in the registry checkout), not introduced by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update — root-cause: make `resolvePsi()` cwd-independent (commit `b89f5df`)

The delete-cleanup above calls `resolvePsi()`, which derived the vault from `process.cwd()`. So `delete` run from a different cwd than `create` (e.g. a launchd daemon at cwd `/`) resolved a *different* `ψ`, logged "already clean", and left the orphan — and the legacy fallback `process.cwd()/ψ` could itself **mint** a stray vault. The delete fix only fired when run from the same oracle root as create.

`resolvePsi()` now resolves cwd-independent first (both copies — `plugins/team/` + `plugins/cleanup/internal/`):

1. `MAW_PSI` env override — explicit, works from any cwd / daemon
2. walk up for an oracle root (`CLAUDE.md` + `ψ/`) — **unchanged**
3. `~/ψ` stable fallback — **never** `process.cwd()/ψ`

Added `plugins/team/team-helpers.test.ts` (bun:test, 3 pass): env-override / fallback-is-not-an-orphan / walk-up.

**⚠️ Reviewer note (behavior change):** the no-marker fallback changes from `cwd/ψ` → `~/ψ`. For users with no `MAW_PSI` running outside any oracle root, resolution now points at `~/ψ` instead of a cwd-relative dir. This is deliberate (stable over surprising; stops orphan-minting) but is a behavior change worth a conscious ack on merge. Version intentionally left at `0.1.2` since `v0.1.2-team` isn't tagged yet.
