### PR TITLE
fix(contacts): make resolvePsiPath() cwd-independent (align with team resolver)

### DIFF
--- a/plugins/contacts/impl.ts
+++ b/plugins/contacts/impl.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { loadConfig } from "maw-js/config";
 import { parseFlags } from "maw-js/cli/parse-args";
@@ -18,12 +18,30 @@ interface ContactsFile {
   updated: string;
 }
 
+/**
+ * Resolve the ψ/ vault, cwd-INDEPENDENT first, so contacts.json lands in the
+ * same vault the team plugin uses (see plugins/team/team-helpers.resolvePsi):
+ *   1. config.psiPath  — explicit config (contacts-specific, kept first).
+ *   2. MAW_PSI env      — explicit override; works from any cwd / daemon.
+ *   3. walk UP from cwd for an oracle root (CLAUDE.md + ψ/ both present).
+ *   4. ~/ψ              — stable fallback; never cwd-relative (which orphans).
+ */
 function resolvePsiPath(): string {
   const config = loadConfig();
   if (config.psiPath) return config.psiPath;
-  const cwd = process.cwd();
-  if (existsSync(join(cwd, "ψ"))) return join(cwd, "ψ");
-  return join(cwd, "psi");
+
+  const env = process.env.MAW_PSI?.trim();
+  if (env) return env;
+
+  let dir = process.cwd();
+  while (true) {
+    const psi = join(dir, "ψ");
+    if (existsSync(psi) && existsSync(join(dir, "CLAUDE.md"))) return psi;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached filesystem root
+    dir = parent;
+  }
+  return join(homedir(), "ψ");
 }
 
 function loadContacts(): ContactsFile {

--- a/plugins/contacts/plugin.json
+++ b/plugins/contacts/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "contacts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "entry": "./index.ts",
   "sdk": "^1.0.0",
   "description": "Manage oracle contacts — add, remove, list",

--- a/plugins/contacts/registry.meta.json
+++ b/plugins/contacts/registry.meta.json
@@ -1,7 +1,7 @@
 {
-  "version": "0.1.0",
-  "source": "soul-brews-studio/maw-plugin-registry/contacts@v0.1.0-contacts",
-  "sha256": "07d9153d378eb4150ac3b4a1d836177980473b764f2a233f46d1ed37aa5c8da2",
+  "version": "0.1.1",
+  "source": "soul-brews-studio/maw-plugin-registry/contacts@v0.1.1-contacts",
+  "sha256": null,
   "summary": "Manage oracle contacts \u2014 add, remove, list",
   "author": "Soul-Brews-Studio",
   "license": "MIT",

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-22T17:17:10Z",
+  "updated": "2026-06-01T06:14:20Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -155,9 +155,9 @@
       "tier": "extra"
     },
     "contacts": {
-      "version": "0.1.0",
-      "source": "soul-brews-studio/maw-plugin-registry/contacts@v0.1.0-contacts",
-      "sha256": "07d9153d378eb4150ac3b4a1d836177980473b764f2a233f46d1ed37aa5c8da2",
+      "version": "0.1.1",
+      "source": "soul-brews-studio/maw-plugin-registry/contacts@v0.1.1-contacts",
+      "sha256": null,
       "summary": "Manage oracle contacts \u2014 add, remove, list",
       "author": "Soul-Brews-Studio",
       "license": "MIT",


### PR DESCRIPTION
## Summary

`contacts.json` is read/written under `resolvePsiPath()`, which resolved
`config.psiPath → cwd/ψ → cwd/psi`. With no `config.psiPath` set, this
**disagreed with the team plugin's `resolvePsi()`** (which walks up for an
oracle root), so contacts could land in a different vault than the rest of
maw — and the `cwd/psi` (latin) fallback wrote `contacts.json` to a stray
cwd-relative dir, never the `ψ` vault.

Sibling of #102, which applies the same cwd-independence fix to the team
resolver. This makes the third (and last) divergent ψ-resolver consistent.

> Note: plugins are distributed self-contained (see `scripts/lint-imports.sh`
> — no cross-plugin imports), so the resolvers can't share one module; this
> aligns *behavior*, not code.

## What's new

`resolvePsiPath()` precedence — **`config.psiPath` primacy kept**, the rest added:

| Order | Source | Status |
|-------|--------|--------|
| 1 | `config.psiPath` | unchanged (kept first) |
| 2 | `MAW_PSI` env | **new** — explicit; works from any cwd / launchd daemon |
| 3 | walk up for an oracle root (`CLAUDE.md` + `ψ/`) | **new** — matches team resolver |
| 4 | `~/ψ` | **changed** — stable fallback; was `cwd/psi` |

## ⚠️ Reviewer note (behavior change)

The no-config / no-marker fallback changes from `process.cwd()/psi` → `~/ψ`.
For users with no `config.psiPath` and no `MAW_PSI` running outside an oracle
root, `contacts.json` now resolves under `~/ψ` instead of a cwd-relative
`psi/` dir. Deliberate (stable + agrees with the team vault; stops the stray
`psi/` dir) but worth a conscious ack on merge.

## Test plan

- [x] Existing `plugins/contacts/contacts.test.ts` green (5 pass / 0 fail).
- [x] Precedence logic mirrors the team resolver covered by
      `plugins/team/team-helpers.test.ts` in #102 (env / fallback-not-orphan / walk-up).
- [ ] Maintainer: recompute `sha256` + tag `v0.1.1-contacts` on merge
      (nulled in-PR, same as #102's team bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)