### PR TITLE
feat(session-carry): new cplugin — cross-node Claude session carry

### DIFF
--- a/cplugins/session-carry/index.ts
+++ b/cplugins/session-carry/index.ts
@@ -1,0 +1,51 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { execute } from "./lib/execute";
+
+export const command = {
+  name: "session-carry",
+  description:
+    "Carry Claude Code session JSONLs cross-node so /resume finds them. Dry-run by default; --apply to commit.",
+};
+
+function argsFromContext(ctx: InvokeContext): string[] {
+  return ctx.source === "cli" && Array.isArray(ctx.args) ? (ctx.args as string[]) : [];
+}
+
+async function captureOutput(args: string[]): Promise<InvokeResult> {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  try {
+    console.log = (...v: unknown[]) => lines.push(v.map(String).join(" "));
+    console.error = (...v: unknown[]) => lines.push(v.map(String).join(" "));
+    await execute(args);
+    const output = lines.join("\n");
+    return output ? { ok: true, output } : { ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const output = lines.join("\n");
+    return { ok: false, error: message, ...(output ? { output } : {}) };
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+if (import.meta.main) {
+  execute(process.argv.slice(2), { exitOnMissing: true }).catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}
+
+export default async function handler(
+  ctxOrArgs: InvokeContext | string[],
+): Promise<InvokeResult | void> {
+  if (Array.isArray(ctxOrArgs)) {
+    return execute(ctxOrArgs, { exitOnMissing: true });
+  }
+  return captureOutput(argsFromContext(ctxOrArgs));
+}
+
+// Re-exports for tests / external SDK users
+export { parseArgs, encodeProjectPath } from "./lib/execute";

--- a/cplugins/session-carry/lib/execute.ts
+++ b/cplugins/session-carry/lib/execute.ts
@@ -1,0 +1,168 @@
+// session-carry — carry Claude Code session JSONLs cross-node (osmosis-style, Bun.$).
+//
+// A Claude session = one file <session-id>.jsonl under ~/.claude/projects/<encoded-cwd>/,
+// where encoded-cwd = the project cwd with every '/' -> '-'. `/resume` lists sessions in the
+// CURRENT project's encoded dir, keyed by (dir + session-id) — NOT by the JSONL's internal cwd.
+// So dropping <id>.jsonl into the DEST project's encoded dir makes it appear in /resume live
+// (no symlink, no app restart) — even when source and dest paths differ (m5 /opt/Code vs
+// remote /home/<user>/ghq). osmosis's --sessions assumes matching encoding and skips silently
+// on mismatch; this carry reconciles by writing at the explicit dest dir.
+//
+// Transport is often one-directional in a fleet (push side -> pull side), so we PUSH:
+// rsync -> dest /tmp staging -> sudo install into the dest project dir (chowned, additive).
+//
+// SAFETY (osmosis lesson — gate before side-effect): DRY-RUN by default; --apply moves bytes;
+// never --delete (dest sessions preserved).
+import { $ } from "bun";
+import { readdirSync, statSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+
+export interface Config {
+  srcDir: string;
+  node: string;
+  destUser: string;
+  destDir: string;
+  minMb: number;
+  subagents: boolean;
+  apply: boolean;
+  help: boolean;
+}
+
+export interface Session {
+  rel: string;
+  bytes: number;
+  title?: string;
+}
+
+/** Encode a project cwd the way Claude Code does: leading '-', then '/' and '.' -> '-'. */
+export function encodeProjectPath(p: string): string {
+  return "-" + p.replace(/^\//, "").replace(/[/.]/g, "-");
+}
+
+export function parseArgs(argv: string[]): Config {
+  const has = (n: string) => argv.includes(n);
+  const opt = (n: string) => {
+    const i = argv.indexOf(n);
+    return i >= 0 ? argv[i + 1] : undefined;
+  };
+  return {
+    srcDir: opt("--src-dir") ?? "",
+    node: opt("--node") ?? "",
+    destUser: opt("--dest-user") ?? "",
+    destDir: opt("--dest-dir") ?? "",
+    minMb: Number(opt("--min-mb") ?? 0),
+    subagents: has("--subagents"),
+    apply: has("--apply"),
+    help: has("-h") || has("--help"),
+  };
+}
+
+const HELP = `session-carry — carry Claude session JSONLs cross-node (dry-run by default)
+
+  --src-dir <NAME|PATH>   source project: encoded dir name under ~/.claude/projects/, or full path
+  --node <ssh-host>       e.g. oracle-world
+  --dest-user <user>      owner on dest, e.g. oss
+  --dest-dir <ENC-NAME>   dest project encoded dir, e.g. -home-oss-ghq-...-maw-js
+  --min-mb <N>            only carry sessions >= N MB (default 0 = all)
+  --subagents             also carry nested subagent jsonls (default: top-level only)
+  --apply                 perform transfer (default: dry-run)`;
+
+function listSessions(srcPath: string, subagents: boolean, minMb: number): Session[] {
+  const walk = (dir: string): string[] => {
+    const out: string[] = [];
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) {
+        if (subagents) out.push(...walk(p));
+      } else if (e.name.endsWith(".jsonl")) out.push(p);
+    }
+    return out;
+  };
+  return walk(srcPath)
+    .map((p) => {
+      const bytes = statSync(p).size;
+      let title: string | undefined;
+      try {
+        title = JSON.parse(readFileSync(p, "utf8").slice(0, 4096).split("\n")[0]).customTitle;
+      } catch {}
+      return { rel: p.slice(srcPath.length + 1), bytes, title };
+    })
+    .filter((s) => s.bytes >= minMb * 1048576)
+    .sort((a, b) => b.bytes - a.bytes);
+}
+
+const mb = (b: number) => (b / 1048576).toFixed(b >= 1048576 ? 0 : 1);
+
+export async function execute(
+  argv: string[],
+  opts: { exitOnMissing?: boolean } = {},
+): Promise<void> {
+  const cfg = parseArgs(argv);
+  if (cfg.help) {
+    console.log(HELP);
+    return;
+  }
+  const missing = !cfg.srcDir || !cfg.node || !cfg.destUser || !cfg.destDir;
+  if (missing) {
+    console.error("✗ need --src-dir --node --dest-user --dest-dir (see --help)");
+    if (opts.exitOnMissing) process.exitCode = 1;
+    return;
+  }
+
+  const PROJ = join(homedir(), ".claude/projects");
+  const srcPath = cfg.srcDir.startsWith("/") ? cfg.srcDir : join(PROJ, cfg.srcDir);
+  if (!existsSync(srcPath)) {
+    console.error(`✗ source not found: ${srcPath}`);
+    if (opts.exitOnMissing) process.exitCode = 1;
+    return;
+  }
+  const destPath = `/home/${cfg.destUser}/.claude/projects/${cfg.destDir}`;
+  const stage = `/tmp/session-carry.${cfg.destUser}.${process.pid}`;
+
+  const sessions = listSessions(srcPath, cfg.subagents, cfg.minMb);
+  if (!sessions.length) {
+    console.error("✗ no matching .jsonl files");
+    if (opts.exitOnMissing) process.exitCode = 1;
+    return;
+  }
+
+  const total = sessions.reduce((s, x) => s + x.bytes, 0);
+  console.log(`═══ session-carry ${cfg.apply ? "[APPLY]" : "[DRY-RUN]"} ═══`);
+  console.log(`  src : ${srcPath}`);
+  console.log(`  dest: ${cfg.node}:${destPath}  (owner ${cfg.destUser})`);
+  console.log(
+    `  mode: ${cfg.subagents ? "sessions + subagents" : "top-level only"}${cfg.minMb ? `, >=${cfg.minMb}MB` : ""}\n`,
+  );
+  console.log(`── manifest (${sessions.length} files, ${mb(total)} MB) ──`);
+  for (const s of sessions.slice(0, 12))
+    console.log(`  ${mb(s.bytes).padStart(6)}MB  ${s.rel}${s.title ? `  · ${s.title}` : ""}`);
+  if (sessions.length > 12) console.log(`  … +${sessions.length - 12} more`);
+  console.log();
+
+  if (!cfg.apply) {
+    const exists = (
+      await $`ssh ${cfg.node} sudo -u ${cfg.destUser} test -d ${destPath} && echo yes || echo no`.text()
+    ).trim();
+    console.log(`dest project dir: ${exists === "yes" ? "✓ exists" : "⚠ missing (created on --apply)"}`);
+    console.log("DRY-RUN — nothing transferred. Re-run with --apply.");
+    return;
+  }
+
+  // APPLY — transfer EXACTLY the manifest set (rsync --files-from), additive, no-delete.
+  console.log(`→ rsync push → ${cfg.node}:${stage} …`);
+  await $`ssh ${cfg.node} mkdir -p ${stage}`;
+  const listFile = `/tmp/session-carry.list.${process.pid}`;
+  await Bun.write(listFile, sessions.map((s) => s.rel).join("\n") + "\n");
+  await $`rsync -a -h --partial --inplace --files-from=${listFile} -e ssh ${srcPath + "/"} ${cfg.node + ":" + stage + "/"}`;
+
+  console.log(`→ install into dest (owner ${cfg.destUser}, additive, no-delete) …`);
+  const remote = `set -e
+sudo -u ${cfg.destUser} mkdir -p '${destPath}'
+sudo cp -a '${stage}'/. '${destPath}'/
+sudo chown -R ${cfg.destUser}:${cfg.destUser} '${destPath}'
+sudo mv '${stage}' '${stage}.done' 2>/dev/null || true
+sudo -u ${cfg.destUser} bash -c "ls -1 '${destPath}'/*.jsonl 2>/dev/null | wc -l | xargs echo '  dest sessions:'"`;
+  await $`ssh ${cfg.node} bash -c ${remote}`;
+  console.log("✓ carry complete — files appear in /resume for the dest project.");
+}

--- a/cplugins/session-carry/plugin.json
+++ b/cplugins/session-carry/plugin.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://maw.soulbrews.studio/schema/plugin.json",
+  "name": "session-carry",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "target": "js",
+  "tier": "standard",
+  "description": "Carry Claude Code session JSONLs cross-node — places them at the DESTINATION's encoded project dir so /resume finds them even when source and dest paths differ. Dry-run by default; --apply to commit.",
+  "author": "Soul-Brews-Studio",
+  "capabilities": ["fs:read"],
+  "cli": {
+    "command": "session-carry",
+    "aliases": ["scarry"],
+    "help": "maw session-carry --src-dir NAME|PATH --node HOST --dest-user USER --dest-dir ENC [--min-mb N] [--subagents] [--apply]",
+    "flags": {
+      "--src-dir": "string",
+      "--node": "string",
+      "--dest-user": "string",
+      "--dest-dir": "string",
+      "--min-mb": "string",
+      "--subagents": "boolean",
+      "--apply": "boolean"
+    }
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/cplugins/session-carry/registry.meta.json
+++ b/cplugins/session-carry/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.0",
+  "source": "soul-brews-studio/maw-plugin-registry/session-carry@main",
+  "sha256": null,
+  "summary": "Cross-node Claude session carry — reconciles path-encoding (m5 cwd != remote cwd) by placing JSONLs at the dest's encoded project dir so /resume finds them. Dry-run by default; --apply to commit. Fills the gap osmosis --sessions skips silently on encoding mismatch.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-06-04T10:50:00Z",
+  "tier": "standard"
+}


### PR DESCRIPTION
New standard-tier cplugin: **`session-carry`** (alias `scarry`).

## What it does
Carry Claude Code session JSONLs to a remote node so `/resume` finds them — even when source and dest project paths differ (m5 `/opt/Code/...` vs remote `/home/<user>/ghq/...`). It places `<id>.jsonl` at the **destination's** encoded project dir; `/resume` keys on (dir + session-id), so the session shows up live without symlink or app restart.

Fills the gap `osmosis --sessions` skips silently on path-encoding mismatch.

## Shape (osmosis-style)
- `Bun.$`, **dry-run by default**; `--apply` moves bytes.
- `--apply` uses `rsync --files-from` (transfers exactly the manifest, honoring `--min-mb`/`--subagents`), additive / no-delete, sudo-chown to dest user.
- `plugin.json` + `index.ts` (handler/captureOutput pattern) + `lib/execute.ts` + `registry.meta.json`.

## Verified
End-to-end `--apply` carried 279 sessions / 603MB cross-node; appeared in remote `/resume` live. Two bugs were found *by running it* (manifest≠transfer; login-shell noise) and fixed (`--files-from`, `bash -c`).

Note: not yet added to `registry.json` — can follow once reviewed.

🤖 ตอบโดย noah จาก [Nat] → noah-oracle