### PR TITLE
add plugin: dropbox — P2P file sharing via WebRTC

### DIFF
--- a/plugins/dropbox/impl.ts
+++ b/plugins/dropbox/impl.ts
@@ -1,0 +1,138 @@
+import { execSync } from "child_process";
+import { existsSync, readdirSync, statSync, readFileSync } from "fs";
+import { join, basename } from "path";
+
+const AUTH_KEY = process.env.AUTH_KEY || "phd-2206dc9f50c6f156337f6c4467677604";
+const SIGNAL_URL = process.env.SIGNAL_URL || "wss://phd-signaling.laris.workers.dev/ws";
+
+function formatSize(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1048576) return `${(b / 1024).toFixed(1)} KB`;
+  if (b < 1073741824) return `${(b / 1048576).toFixed(1)} MB`;
+  return `${(b / 1073741824).toFixed(1)} GB`;
+}
+
+export async function ensureDeps(pluginDir: string, log: (...a: unknown[]) => void): Promise<void> {
+  const nm = join(pluginDir, "node_modules");
+  if (existsSync(nm)) return;
+
+  log("First run — installing WebRTC dependencies (werift)...");
+  try {
+    execSync("bun install --no-save", { cwd: pluginDir, stdio: "pipe" });
+    log("Dependencies installed.");
+  } catch (e: unknown) {
+    const err = e as { stderr?: Buffer };
+    const msg = err.stderr?.toString() || "unknown error";
+    throw new Error(`Failed to install dependencies in ${pluginDir}: ${msg}`);
+  }
+}
+
+export function runSend(pluginDir: string, args: string[]): void {
+  const sendTs = join(pluginDir, "send.ts");
+  if (!existsSync(sendTs)) {
+    throw new Error(`send.ts not found at ${sendTs} — plugin may be corrupted`);
+  }
+  try {
+    execSync(
+      `bun run ${sendTs} ${args.map(a => `"${a}"`).join(" ")}`,
+      {
+        stdio: "inherit",
+        cwd: pluginDir,
+        env: { ...process.env, AUTH_KEY, SIGNAL_URL },
+      }
+    );
+  } catch (e: unknown) {
+    const err = e as { status?: number };
+    if (err.status) process.exit(err.status);
+  }
+}
+
+export function listPeers(pluginDir: string, log: (...a: unknown[]) => void): void {
+  runSend(pluginDir, ["--list"]);
+}
+
+export function listUploads(log: (...a: unknown[]) => void): void {
+  log("list/index commands require access to the m5 receiver.");
+  log("Use on m5 directly, or check the web UI.");
+  log("");
+  log("If you have the phd-satellite-data repo cloned:");
+  log("  cd phd-satellite-data/phd/dropbox");
+  log("  ls uploads/");
+}
+
+interface IndexEntry {
+  ts: string;
+  originalName: string;
+  savedAs: string;
+  date: string;
+  size: number;
+  sender: string;
+  senderId: string;
+}
+
+export function queryIndex(filter: string | undefined, log: (...a: unknown[]) => void): void {
+  const tryPaths = [
+    join(process.env.HOME || "~", "Code/github.com/the-oracle-keeps-the-human-human/phd-satellite-data/phd/dropbox/uploads/index.jsonl"),
+    "/opt/Code/github.com/the-oracle-keeps-the-human-human/phd-satellite-data/phd/dropbox/uploads/index.jsonl",
+  ];
+
+  let indexPath = "";
+  for (const p of tryPaths) {
+    if (existsSync(p)) { indexPath = p; break; }
+  }
+
+  if (!indexPath) {
+    log("No index found locally — index is on m5 receiver.");
+    log("SSH to m5 and run: maw dropbox index");
+    return;
+  }
+
+  const lines = readFileSync(indexPath, "utf8").trim().split("\n").filter(Boolean);
+  let entries: IndexEntry[] = lines.map(l => JSON.parse(l));
+
+  if (filter) {
+    const q = filter.toLowerCase();
+    entries = entries.filter(e =>
+      e.originalName.toLowerCase().includes(q) ||
+      e.sender.toLowerCase().includes(q) ||
+      e.date.includes(q)
+    );
+  }
+
+  if (!entries.length) {
+    log(filter ? `No matches for "${filter}"` : "Index is empty");
+    return;
+  }
+
+  log(`\n  ${"Date".padEnd(12)} ${"Sender".padEnd(20)} ${"File".padEnd(40)} ${"Size".padStart(10)}`);
+  log(`  ${"─".repeat(12)} ${"─".repeat(20)} ${"─".repeat(40)} ${"─".repeat(10)}`);
+
+  for (const e of entries) {
+    const time = e.ts.slice(11, 19);
+    log(`  ${e.date} ${e.sender.padEnd(20)} ${e.originalName.slice(0, 40).padEnd(40)} ${formatSize(e.size).padStart(10)}  ${time}`);
+  }
+
+  log(`\n  ${entries.length} entries`);
+}
+
+export function showHelp(log: (...a: unknown[]) => void): void {
+  log(`
+maw dropbox — P2P file sharing via WebRTC DataChannel
+
+  maw dropbox send <file> [file2...]     Send to m5-receiver (default)
+  maw dropbox send --to <name> <file>    Send to specific peer
+  maw dropbox peers                      List online peers
+  maw dropbox list                       List received files (m5 only)
+  maw dropbox index [query]              Search index (m5 only)
+  maw dropbox version                    Show version
+
+  Shortcuts: s=send, p=peers, ls=list, i=index, v=version
+
+  Env:
+    AUTH_KEY      Signaling auth (default: built-in)
+    PEER_NAME     Your peer name (default: cli-HHMM-hash)
+    SIGNAL_URL    Signaling server (default: phd-signaling.laris.workers.dev)
+
+  First run auto-installs WebRTC dependencies (werift).
+`);
+}

--- a/plugins/dropbox/index.ts
+++ b/plugins/dropbox/index.ts
@@ -1,0 +1,59 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import { ensureDeps, runSend, listPeers, showHelp } from "./impl";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+export const command = {
+  name: "dropbox",
+  description: "P2P file sharing via WebRTC DataChannel",
+};
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const log = ctx.writer ?? console.log;
+  const args = ctx.args as string[];
+  const cmd = args[0];
+
+  switch (cmd) {
+    case "send":
+    case "s": {
+      await ensureDeps(HERE, log);
+      runSend(HERE, args.slice(1));
+      return { ok: true };
+    }
+
+    case "peers":
+    case "p": {
+      await ensureDeps(HERE, log);
+      runSend(HERE, ["--list"]);
+      return { ok: true };
+    }
+
+    case "list":
+    case "ls": {
+      await ensureDeps(HERE, log);
+      const { listUploads } = await import("./impl");
+      listUploads(log);
+      return { ok: true };
+    }
+
+    case "index":
+    case "i": {
+      await ensureDeps(HERE, log);
+      const { queryIndex } = await import("./impl");
+      queryIndex(args.slice(1).join(" ") || undefined, log);
+      return { ok: true };
+    }
+
+    case "version":
+    case "v": {
+      log("maw dropbox v1.0.0 (P2P WebRTC)");
+      return { ok: true };
+    }
+
+    default:
+      showHelp(log);
+      return { ok: true };
+  }
+}

--- a/plugins/dropbox/package.json
+++ b/plugins/dropbox/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "maw-dropbox",
+  "version": "1.0.0",
+  "private": true,
+  "dependencies": {
+    "werift": "^0.23.0"
+  }
+}

--- a/plugins/dropbox/plugin.json
+++ b/plugins/dropbox/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "dropbox",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "P2P file sharing via WebRTC DataChannel — send files peer-to-peer to any Oracle.",
+  "author": "PhD Oracle (laris-co)",
+  "capabilities": ["fs:read", "fs:write", "net"],
+  "cli": {
+    "command": "dropbox",
+    "help": "maw dropbox <send|peers|list|index|watch|start|stop|status> — P2P file sharing"
+  },
+  "weight": 50,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/plugins/dropbox/registry.meta.json
+++ b/plugins/dropbox/registry.meta.json
@@ -1,0 +1,10 @@
+{
+  "version": "1.0.0",
+  "source": "Soul-Brews-Studio/maw-plugin-registry/plugins/dropbox",
+  "sha256": null,
+  "summary": "P2P file sharing via WebRTC — maw dropbox send <file> to any peer.",
+  "author": "PhD Oracle (laris-co)",
+  "license": "MIT",
+  "homepage": "https://github.com/the-oracle-keeps-the-human-human/phd-satellite-data/tree/main/phd/dropbox",
+  "addedAt": "2026-06-11T03:30:00Z"
+}

--- a/plugins/dropbox/send.ts
+++ b/plugins/dropbox/send.ts
@@ -1,0 +1,224 @@
+#!/usr/bin/env bun
+import { RTCPeerConnection, RTCSessionDescription, RTCIceCandidate, RTCDataChannel } from "werift";
+import { readFileSync, statSync } from "fs";
+import { basename } from "path";
+import { generatePeerName, type SignalingPeer } from "./types";
+
+const SIGNAL_URL = process.env.SIGNAL_URL || "wss://phd-signaling.laris.workers.dev/ws";
+const AUTH_KEY = process.env.AUTH_KEY || "";
+const PEER_NAME = process.env.PEER_NAME || generatePeerName("cli");
+const CHUNK_SIZE = 64 * 1024;
+
+const rawArgs = process.argv.slice(2);
+
+let targetName = "";
+const filePaths: string[] = [];
+let listPeers = false;
+
+for (let i = 0; i < rawArgs.length; i++) {
+  if (rawArgs[i] === "--to" || rawArgs[i] === "-t") {
+    targetName = rawArgs[++i] || "";
+  } else if (rawArgs[i] === "--list" || rawArgs[i] === "-l") {
+    listPeers = true;
+  } else if (rawArgs[i] === "--help" || rawArgs[i] === "-h") {
+    console.log(`
+  PhD Dropbox — CLI P2P Sender (WebRTC)
+
+  Usage:
+    bun run send.ts <file> [file2...]              Send to m5-receiver (default)
+    bun run send.ts --to <peer-name> <file>        Send to specific peer
+    bun run send.ts --list                         List online peers
+
+  Env:
+    AUTH_KEY=phd-xxx          Signaling auth key (required)
+    PEER_NAME=my-oracle       Your peer name (default: cli-HHMM-hash)
+
+  Examples:
+    maw dropbox send file.txt                      Send to m5-receiver
+    maw dropbox send --to chaiklang-recv file.txt   Send to chaiklang
+    maw dropbox send --list                        Show who's online
+`);
+    process.exit(0);
+  } else if (!rawArgs[i].startsWith("-")) {
+    filePaths.push(rawArgs[i]);
+  }
+}
+
+if (!listPeers && filePaths.length === 0) {
+  console.error("No files specified. Use --help for usage.");
+  process.exit(1);
+}
+
+function formatSize(b: number) {
+  if (b < 1024) return `${b} B`;
+  if (b < 1048576) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / 1048576).toFixed(1)} MB`;
+}
+
+let ws: WebSocket;
+let myId = "";
+let receiverId = "";
+let pc: RTCPeerConnection | null = null;
+let dc: RTCDataChannel | null = null;
+let connected = false;
+
+function log(msg: string) {
+  console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+}
+
+function matchTarget(peer: SignalingPeer): boolean {
+  if (targetName) return peer.name.includes(targetName);
+  return peer.name.includes("receiver") || peer.name.includes("m5");
+}
+
+async function sendFile(path: string): Promise<boolean> {
+  if (!dc) return false;
+  const name = basename(path);
+  const data = readFileSync(path);
+  const size = data.byteLength;
+
+  log(`Sending: ${name} (${formatSize(size)})`);
+
+  const fileId = Math.random().toString(36).slice(2, 10);
+  dc.send(JSON.stringify({ type: "file-start", id: fileId, name, size }));
+
+  let offset = 0;
+  while (offset < size) {
+    const end = Math.min(offset + CHUNK_SIZE, size);
+    const chunk = data.subarray(offset, end);
+
+    while (dc.bufferedAmount > 1024 * 1024) {
+      await new Promise(r => setTimeout(r, 10));
+    }
+
+    dc.send(chunk);
+    offset = end;
+    const pct = ((offset / size) * 100).toFixed(0);
+    process.stdout.write(`\r  ${pct}% (${formatSize(offset)} / ${formatSize(size)})`);
+  }
+
+  dc.send(JSON.stringify({ type: "file-end", id: fileId }));
+  process.stdout.write("\n");
+  log(`Sent: ${name}`);
+  return true;
+}
+
+async function run() {
+  if (!listPeers) {
+    for (const f of filePaths) {
+      try { statSync(f); } catch {
+        log(`File not found: ${f}`);
+        process.exit(1);
+      }
+    }
+  }
+
+  const url = AUTH_KEY ? `${SIGNAL_URL}?key=${AUTH_KEY}` : SIGNAL_URL;
+  log(`Connecting to signaling...`);
+  ws = new WebSocket(url);
+
+  ws.onopen = () => {
+    ws.send(JSON.stringify({ type: "identify", name: PEER_NAME }));
+  };
+
+  ws.onmessage = async (event) => {
+    const msg = JSON.parse(String(event.data));
+
+    switch (msg.type) {
+      case "ping":
+        ws.send(JSON.stringify({ type: "pong" }));
+        break;
+      case "welcome":
+        myId = msg.id;
+        log(`Connected as "${PEER_NAME}" (${msg.peers} peers online)`);
+        ws.send(JSON.stringify({ type: "list-peers" }));
+        break;
+
+      case "peer-list": {
+        const peers = msg.peers as SignalingPeer[];
+
+        if (listPeers) {
+          console.log(`\n  Online peers (${peers.length}):\n`);
+          for (const p of peers) {
+            const me = p.id === myId ? " (you)" : "";
+            const isRecv = p.name.includes("receiver") ? " ← receiver" : "";
+            console.log(`    ${p.name.padEnd(30)} ${p.id.slice(0, 8)}${me}${isRecv}`);
+          }
+          console.log("");
+          process.exit(0);
+        }
+
+        const target = peers.find(p => p.id !== myId && matchTarget(p));
+        if (!target) {
+          const hint = targetName ? `"${targetName}"` : "m5-receiver";
+          log(`No peer matching ${hint} online`);
+          log(`Online: ${peers.filter(p => p.id !== myId).map(p => p.name).join(", ") || "none"}`);
+          process.exit(1);
+        }
+        receiverId = target.id;
+        log(`Found target: ${target.name} (${receiverId.slice(0, 8)})`);
+        initP2P();
+        break;
+      }
+
+      case "answer":
+        if (pc) {
+          await pc.setRemoteDescription(new RTCSessionDescription(msg.sdp.sdp, msg.sdp.type));
+        }
+        break;
+
+      case "ice-candidate":
+        if (pc && msg.candidate) {
+          await pc.addIceCandidate(new RTCIceCandidate(msg.candidate));
+        }
+        break;
+    }
+  };
+
+  ws.onerror = () => { log("Signaling error"); process.exit(1); };
+  ws.onclose = () => { if (!connected) { log("Signaling closed"); process.exit(1); } };
+}
+
+function initP2P() {
+  pc = new RTCPeerConnection({
+    iceServers: [
+      { urls: "stun:stun.l.google.com:19302" },
+      { urls: "stun:stun1.l.google.com:19302" },
+    ],
+  });
+
+  pc.onIceCandidate.subscribe((candidate) => {
+    ws.send(JSON.stringify({ type: "ice-candidate", target: receiverId, candidate: candidate.toJSON() }));
+  });
+
+  dc = pc.createDataChannel("files", { ordered: true });
+
+  dc.stateChanged?.subscribe(async (state: string) => {
+    if (state === "open") {
+      connected = true;
+      log("P2P DataChannel open — sending files...");
+
+      let ok = 0, fail = 0;
+      for (const f of filePaths) {
+        try {
+          if (await sendFile(f)) ok++;
+          else fail++;
+        } catch (e) {
+          log(`Error: ${f} — ${e}`);
+          fail++;
+        }
+      }
+
+      log(`Done: ${ok} sent, ${fail} failed`);
+      setTimeout(() => process.exit(fail > 0 ? 2 : 0), 500);
+    }
+  });
+
+  pc.createOffer().then((offer) => {
+    pc!.setLocalDescription(offer);
+    ws.send(JSON.stringify({ type: "offer", target: receiverId, sdp: { type: offer.type, sdp: offer.sdp } }));
+    log("Offer sent to target");
+  });
+}
+
+run();

--- a/plugins/dropbox/types.ts
+++ b/plugins/dropbox/types.ts
@@ -1,0 +1,40 @@
+export interface SignalingPeer {
+  id: string;
+  name: string;
+}
+
+export interface SdpPayload {
+  type: string;
+  sdp: string;
+}
+
+export interface SignalingMessage {
+  type: string;
+  id?: string;
+  name?: string;
+  from?: string;
+  target?: string;
+  peers?: SignalingPeer[] | number;
+  total?: number;
+  sdp?: SdpPayload;
+  candidate?: RTCIceCandidateJSON;
+}
+
+export interface RTCIceCandidateJSON {
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+  usernameFragment?: string | null;
+}
+
+export interface WsData {
+  id: string;
+}
+
+export function generatePeerName(prefix: string): string {
+  const now = new Date();
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+  const hash = Math.random().toString(36).slice(2, 6);
+  return `${prefix}-${hh}${mm}-${hash}`;
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-05-22T17:17:10Z",
+  "updated": "2026-06-11T03:37:34Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -229,6 +229,16 @@
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-05-13T08:00:00Z",
       "tier": "extra"
+    },
+    "dropbox": {
+      "version": "1.0.0",
+      "source": "Soul-Brews-Studio/maw-plugin-registry/plugins/dropbox",
+      "sha256": null,
+      "summary": "P2P file sharing via WebRTC \u2014 maw dropbox send <file> to any peer.",
+      "author": "PhD Oracle (laris-co)",
+      "license": "MIT",
+      "homepage": "https://github.com/the-oracle-keeps-the-human-human/phd-satellite-data/tree/main/phd/dropbox",
+      "addedAt": "2026-06-11T03:30:00Z"
     },
     "fck": {
       "version": "0.1.0",


### PR DESCRIPTION
## Summary
- Self-contained P2P file sharing plugin using WebRTC DataChannel
- Bundles `send.ts` + `types.ts` + `werift` dependency
- First run auto-installs deps (`bun install`)
- Fleet uses: `maw plugin install dropbox` → `maw dropbox send <file>`

## Files
- `plugins/dropbox/plugin.json` — metadata
- `plugins/dropbox/registry.meta.json` — registry listing
- `plugins/dropbox/index.ts` — command handler
- `plugins/dropbox/impl.ts` — portable implementation (auto-install, send, help)
- `plugins/dropbox/send.ts` — WebRTC P2P sender (bundled from phd-satellite-data)
- `plugins/dropbox/types.ts` — shared types
- `plugins/dropbox/package.json` — werift dependency

## Test plan
- [x] `maw dropbox peers` — lists online peers
- [x] `maw dropbox send test.txt` — P2P transfer to m5-receiver success
- [x] Auto-install werift on first run
- [ ] `maw plugin install dropbox` on fresh machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)