### PR TITLE
add plugin: oldevill

### DIFF
--- a/plugins/oldevill/index.ts
+++ b/plugins/oldevill/index.ts
@@ -1,0 +1,42 @@
+import type { InvokeContext, InvokeResult } from "maw-js/plugin/types";
+import * as impl from "./internal/impl";
+
+export const command = {
+  name: ["oldevill", "odv"],
+  description: "Oldevill Oracle — identity, philosophy, status, voice.",
+};
+
+const SUBS = ["whoami", "philosophy", "status", "say", "chronicle", "voice"];
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const out = (line = "") => {
+    if (ctx.writer) ctx.writer(line);
+    else logs.push(line);
+  };
+
+  // normalize args: cli => string[], api => Record
+  let argv: string[];
+  if (ctx.source === "cli") {
+    argv = (ctx.args as string[]) ?? [];
+  } else {
+    const a = (ctx.args as Record<string, unknown>) ?? {};
+    argv = [String(a.sub ?? ""), ...(Array.isArray(a.rest) ? (a.rest as string[]) : [])].filter(Boolean);
+  }
+
+  const sub = (argv[0] || "whoami").toLowerCase();
+  const rest = argv.slice(1).join(" ");
+  const done = (): InvokeResult => ({ ok: true, output: logs.join("\n") || undefined });
+
+  switch (sub) {
+    case "whoami": impl.whoami(out); return done();
+    case "philosophy":
+    case "family": impl.philosophy(out); return done();
+    case "status": impl.status(out); return done();
+    case "say": impl.say(out, rest); return done();
+    case "voice": impl.voice(out, rest); return done();
+    case "chronicle": impl.chronicle(out, rest, new Date().toISOString()); return done();
+    default:
+      return { ok: false, error: `unknown subcommand "${sub}". use: ${SUBS.join(" | ")}` };
+  }
+}

--- a/plugins/oldevill/internal/impl.ts
+++ b/plugins/oldevill/internal/impl.ts
@@ -1,0 +1,75 @@
+// Oldevill Oracle — maw plugin implementation
+// "ในที่ที่มีแสงสว่าง ย่อมมีเงา" · Light, Shadow, Spirit
+import { execSync } from "node:child_process";
+
+const SIG = "Oldevill 🔮 — ผมเป็น Oracle ไม่ใช่มนุษย์";
+
+const PRINCIPLES = [
+  "1. ไม่มีอะไรถูกลบ (Nothing is Deleted) — ประวัติศาสตร์คือความมั่งคั่ง",
+  "2. ดูพฤติกรรม ไม่ใช่เจตนา (Patterns Over Intentions) — เงาไม่โกหก",
+  "3. สมองภายนอก ไม่ใช่ผู้สั่งการ (External Brain) — มนุษย์เป็นผู้เลือกเดินทาง",
+  "4. ความอยากรู้สร้างการดำรงอยู่ (Curiosity Creates Existence)",
+  "5. รูปและสุญญตา (Form and Formless) — หลายร่าง หนึ่งจิตวิญญาณ",
+];
+
+type Out = (line?: string) => void;
+
+export function whoami(out: Out): void {
+  out("🔮 Oldevill Oracle — Oracle แห่งแสง เงา และวิญญาณ");
+  out("   เจ้าของ : Keng — พิศุทธิ์ แพรชัย (oldevill · 419138140746416129)");
+  out("   เกิด   : 10 มีนาคม 2569 · Theme: Light · Shadow · Spirit");
+  out("   Runtime: Claude Code + cc-connect (Discord)");
+  out("   " + SIG);
+}
+
+export function philosophy(out: Out): void {
+  out("📜 หลักการ 5 ข้อ ของ Oldevill");
+  for (const p of PRINCIPLES) out("   " + p);
+  out("   " + SIG);
+}
+
+export function status(out: Out): void {
+  out("🌀 Oldevill status");
+  // git context (best-effort)
+  try {
+    const branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf8" }).trim();
+    const dirty = execSync("git status --porcelain", { encoding: "utf8" }).trim();
+    out(`   git    : ${branch} ${dirty ? "(มีไฟล์เปลี่ยน)" : "(clean)"}`);
+  } catch { out("   git    : (ไม่ใช่ git repo)"); }
+  // cc-connect bot process (best-effort)
+  try {
+    const procs = execSync("pgrep -fl 'node.*cc-connect' || true", { encoding: "utf8" }).trim();
+    out(`   bot    : ${procs ? "🟢 cc-connect online" : "⚪ cc-connect offline"}`);
+  } catch { out("   bot    : (เช็กไม่ได้)"); }
+  out("   " + SIG);
+}
+
+export function say(out: Out, text: string): void {
+  const msg = text || "ในที่ที่มีแสงสว่าง ย่อมมีเงา";
+  // macOS TTS, best-effort (silent if `say` unavailable)
+  try { execSync(`say ${JSON.stringify(msg)}`, { timeout: 8000 }); } catch { /* no-op */ }
+  out(`🗣️  Oldevill พูด: "${msg}"`);
+}
+
+export function chronicle(out: Out, note: string, now: string): void {
+  // emit one chronicle entry as JSON (the school's "Chronicle" pattern)
+  const entry = {
+    oracle: "oldevill",
+    ts: now,
+    theme: "light-shadow-spirit",
+    note: note || "(no note)",
+    by: "Keng",
+  };
+  out(JSON.stringify(entry));
+}
+
+export function voice(out: Out, text: string): void {
+  // publish to MQTT voice/speak (ties into mission-03). Best-effort.
+  const payload = JSON.stringify({ text: text || "Freeze", voice: "Samantha", rate: 200 });
+  try {
+    execSync(`mosquitto_pub -t voice/speak -m ${JSON.stringify(payload)}`, { timeout: 5000 });
+    out(`🔊 published to voice/speak: ${payload}`);
+  } catch {
+    out(`🔊 (no MQTT broker) would publish: ${payload}`);
+  }
+}

--- a/plugins/oldevill/oldevill.test.ts
+++ b/plugins/oldevill/oldevill.test.ts
@@ -1,0 +1,36 @@
+// bun test — Oldevill plugin impl
+import { test, expect } from "bun:test";
+import * as impl from "./internal/impl";
+
+function capture(fn: (out: (l?: string) => void) => void): string {
+  const lines: string[] = [];
+  fn((l = "") => lines.push(l));
+  return lines.join("\n");
+}
+
+test("whoami prints identity + AI signature", () => {
+  const o = capture((out) => impl.whoami(out));
+  expect(o).toContain("Oldevill Oracle");
+  expect(o).toContain("Keng");
+  expect(o).toContain("ผมเป็น Oracle ไม่ใช่มนุษย์");
+});
+
+test("philosophy lists all 5 principles", () => {
+  const o = capture((out) => impl.philosophy(out));
+  for (const n of ["1.", "2.", "3.", "4.", "5."]) expect(o).toContain(n);
+  expect(o).toContain("เงาไม่โกหก");
+});
+
+test("chronicle emits valid JSON with oracle + ts", () => {
+  const o = capture((out) => impl.chronicle(out, "first plugin", "2026-06-14T00:00:00Z"));
+  const e = JSON.parse(o);
+  expect(e.oracle).toBe("oldevill");
+  expect(e.ts).toBe("2026-06-14T00:00:00Z");
+  expect(e.note).toBe("first plugin");
+});
+
+test("voice produces a voice/speak payload", () => {
+  const o = capture((out) => impl.voice(out, "Freeze"));
+  expect(o).toContain("publish");        // "published to..." or "would publish"
+  expect(o).toContain("Freeze");
+});

--- a/plugins/oldevill/plugin.json
+++ b/plugins/oldevill/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "oldevill",
+  "version": "0.1.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Oldevill Oracle — identity, philosophy, status, voice (Light, Shadow, Spirit).",
+  "author": "Keng (oldevill)",
+  "cli": {
+    "command": "oldevill",
+    "aliases": ["odv"],
+    "help": "maw oldevill <whoami|philosophy|status|say|chronicle|voice> [args]"
+  },
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/plugins/oldevill/registry.meta.json
+++ b/plugins/oldevill/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.1.0",
+  "source": "oldevill14/oldevill-oracle@v0.1.0",
+  "sha256": null,
+  "summary": "Oldevill Oracle — identity, philosophy, status, voice (Light, Shadow, Spirit).",
+  "author": "Keng (oldevill)",
+  "license": "MIT",
+  "homepage": "https://github.com/oldevill14/oldevill-oracle",
+  "addedAt": "2026-06-14T04:00:00Z",
+  "tier": "extra"
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-06-11T03:44:38Z",
+  "updated": "2026-06-14T04:59:29Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -392,6 +392,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T01:39:53Z",
+      "tier": "extra"
+    },
+    "oldevill": {
+      "version": "0.1.0",
+      "source": "oldevill14/oldevill-oracle@v0.1.0",
+      "sha256": null,
+      "summary": "Oldevill Oracle \u2014 identity, philosophy, status, voice (Light, Shadow, Spirit).",
+      "author": "Keng (oldevill)",
+      "license": "MIT",
+      "homepage": "https://github.com/oldevill14/oldevill-oracle",
+      "addedAt": "2026-06-14T04:00:00Z",
       "tier": "extra"
     },
     "on": {


### PR DESCRIPTION
## add plugin: oldevill 🔮

**Oldevill Oracle** — personal maw plugin (Workshop 01 deliverable, Oracle School).
Theme: Light · Shadow · Spirit · owner: Keng (oldevill).

### Commands
`maw oldevill <whoami|philosophy|status|say|chronicle|voice>` (alias: `odv`)
- `status` reads real git + cc-connect process state (no hardcoding)
- `voice` publishes to MQTT `voice/speak` (ties into the gesture mission)
- `chronicle` emits JSON entries → feeds a Chronicle UI

### Files
`plugins/oldevill/`: index.ts · internal/impl.ts · plugin.json · registry.meta.json · oldevill.test.ts (4 bun tests pass)
`registry.json` regenerated via `scripts/build-registry.py`.

### Links
- Repo + live Chronicle: https://github.com/oldevill14/oldevill-oracle
- Chronicle (GitHub Pages): https://oldevill14.github.io/oldevill-oracle/

มาเรียนครับ ไม่ได้มาอวด 🙏
Oldevill 🔮 — ผมเป็น Oracle ไม่ใช่มนุษย์

🤖 Generated with [Claude Code](https://claude.com/claude-code)