### PR TITLE
add plugin: reindex-gpu

### DIFF
--- a/plugins/reindex-gpu/README.md
+++ b/plugins/reindex-gpu/README.md
@@ -1,0 +1,42 @@
+# reindex-gpu
+
+`reindex-gpu` is a thin maw plugin that orchestrates GPU-backed arra reindexing. It does not embed or index documents itself; it validates the GPU embed endpoint, sets the environment arra expects, and delegates to:
+
+```sh
+bun <ARRA_DIR>/src/scripts/index-model.ts bge-m3
+```
+
+`ARRA_DIR` is discovered from `--arra-dir`, then `$ARRA_DIR`, then `~/arra-oracle-v3`.
+
+## Commands
+
+```sh
+maw reindex-gpu status [--gpu-endpoint <url>]
+maw reindex-gpu run --gpu-endpoint <url> --batch <n> [--data-dir <p>] [--arra-dir <p>]
+maw reindex-gpu tunnel up --remote <host> [--local-port 11435] [--remote-port 11434]
+maw reindex-gpu tunnel down
+maw reindex-gpu setup [--gpu-endpoint <url>] [--remote <host>]
+```
+
+The default endpoint is `https://embed.oracles.asia/api/embed`; if that default is unreachable, the plugin tries `http://115.73.210.129:23882/api/embed`. The gateway also allows `/api/embeddings`, so unpatched arra can still use the same base URL after the plugin strips `/api/embed` or `/api/embeddings`.
+
+## Safety contract
+
+- Dedicated GPU only. Shared `nvshare` GPUs have crashed during indexing; use a dedicated GPU for production reindex jobs.
+- Retry and fail-closed behavior is mandatory. A partial reindex must exit non-zero, and this plugin treats any non-zero arra indexer exit as incomplete.
+- High tunnel RTT should use larger batches, usually `--batch 128`. Local or shared environments should use smaller batches to reduce timeout and memory pressure.
+
+Before `run`, the plugin sends a real POST to the exact `/api/embed` endpoint:
+
+```json
+{"model":"bge-m3","input":["ping"]}
+```
+
+It expects HTTP 200 plus an `embeddings` array. If the probe fails or times out after 8 seconds, the plugin fails closed and does not start the arra indexer.
+
+## API
+
+- `GET /api/reindex-gpu` maps to `status`.
+- `POST /api/reindex-gpu` maps to `run`.
+
+API arguments use the same flags as object keys, for example `gpuEndpoint`, `batch`, `dataDir`, and `arraDir`.

--- a/plugins/reindex-gpu/index.ts
+++ b/plugins/reindex-gpu/index.ts
@@ -1,0 +1,84 @@
+import type { InvokeContext, InvokeResult } from "maw-js/sdk";
+import { runReindex } from "./internal/run";
+import { setupGpu } from "./internal/setup";
+import { showHelp, status } from "./internal/status";
+import { tunnel } from "./internal/tunnel";
+import { parseApiArgs, parseCliArgs } from "./internal/args";
+
+export const command = {
+  name: ["reindex-gpu", "rgpu"],
+  description: "Thin GPU orchestration for arra bge-m3 reindexing.",
+};
+
+export default async function handler(ctx: InvokeContext): Promise<InvokeResult> {
+  const logs: string[] = [];
+  const origLog = console.log;
+  const origError = console.error;
+  const writer = (ctx as any).writer as ((...args: unknown[]) => void) | undefined;
+  const streamed = Boolean(writer);
+
+  console.log = (...a: any[]) => {
+    if (writer) writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+  console.error = (...a: any[]) => {
+    if (writer) writer(...a);
+    else logs.push(a.map(String).join(" "));
+  };
+
+  try {
+    const request = ctx.source === "cli"
+      ? parseCliArgs(ctx.args as string[])
+      : parseApiArgs(ctx.args as Record<string, unknown>);
+
+    if (request.help) {
+      showHelp();
+      return { ok: true, output: logs.join("\n") || undefined };
+    }
+
+    if (request.command === "run") {
+      const result = await runReindex(request.options);
+      return {
+        ok: result.ok,
+        output: logs.join("\n") || undefined,
+        error: result.ok || streamed ? undefined : result.error,
+      };
+    }
+
+    if (request.command === "status") {
+      const result = await status(request.options);
+      return {
+        ok: result.ok,
+        output: logs.join("\n") || undefined,
+        error: result.ok || streamed ? undefined : result.error,
+      };
+    }
+
+    if (request.command === "tunnel") {
+      const result = await tunnel(request.tunnelAction, request.options);
+      return {
+        ok: result.ok,
+        output: logs.join("\n") || undefined,
+        error: result.ok || streamed ? undefined : result.error,
+      };
+    }
+
+    if (request.command === "setup") {
+      const result = await setupGpu(request.options);
+      return {
+        ok: result.ok,
+        output: logs.join("\n") || undefined,
+        error: result.ok || streamed ? undefined : result.error,
+      };
+    }
+
+    showHelp();
+    return { ok: false, output: logs.join("\n") || undefined, error: streamed ? undefined : `unknown command: ${request.command}` };
+  } catch (e: any) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: streamed ? undefined : message, output: logs.join("\n") || undefined };
+  } finally {
+    console.log = origLog;
+    console.error = origError;
+  }
+}

--- a/plugins/reindex-gpu/internal/args.ts
+++ b/plugins/reindex-gpu/internal/args.ts
@@ -1,0 +1,100 @@
+import { DEFAULT_BATCH, DEFAULT_ENDPOINT, DEFAULT_TUNNEL_LOCAL_PORT, DEFAULT_TUNNEL_REMOTE_PORT, type Options, type ParsedRequest, type TunnelAction } from "./types";
+
+const HELP_FLAGS = new Set(["--help", "-h", "help"]);
+
+export function parseCliArgs(args: string[]): ParsedRequest {
+  const help = args.length === 0 || args.some((arg) => HELP_FLAGS.has(arg));
+  const command = normalizeCommand(args[0] ?? "status");
+  const tunnelAction = normalizeTunnelAction(command === "tunnel" ? args[1] : undefined);
+  const flags = command === "tunnel" ? args.slice(2) : args.slice(1);
+
+  return {
+    command,
+    tunnelAction,
+    options: parseFlags(flags),
+    help,
+  };
+}
+
+export function parseApiArgs(args: Record<string, unknown>): ParsedRequest {
+  const method = String(args.method ?? args.httpMethod ?? "").toUpperCase();
+  const command = normalizeCommand(String(args.command ?? (method === "GET" ? "status" : "run")));
+  const tunnelAction = normalizeTunnelAction(args.action === undefined ? undefined : String(args.action));
+
+  return {
+    command,
+    tunnelAction,
+    options: {
+      gpuEndpoint: stringOpt(args.gpuEndpoint ?? args["gpu-endpoint"] ?? args.endpoint) ?? DEFAULT_ENDPOINT,
+      batch: numberOpt(args.batch) ?? DEFAULT_BATCH,
+      dataDir: stringOpt(args.dataDir ?? args["data-dir"]),
+      arraDir: stringOpt(args.arraDir ?? args["arra-dir"]),
+      remote: stringOpt(args.remote),
+      localPort: numberOpt(args.localPort ?? args["local-port"]) ?? DEFAULT_TUNNEL_LOCAL_PORT,
+      remotePort: numberOpt(args.remotePort ?? args["remote-port"]) ?? DEFAULT_TUNNEL_REMOTE_PORT,
+    },
+    help: Boolean(args.help),
+  };
+}
+
+function parseFlags(args: string[]): Options {
+  const options: Options = {
+    gpuEndpoint: DEFAULT_ENDPOINT,
+    batch: DEFAULT_BATCH,
+    localPort: DEFAULT_TUNNEL_LOCAL_PORT,
+    remotePort: DEFAULT_TUNNEL_REMOTE_PORT,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]!;
+    const [flag, inline] = arg.includes("=") ? arg.split(/=(.*)/s, 2) : [arg, undefined];
+    const next = inline ?? args[++i];
+
+    if (flag === "--gpu-endpoint" || flag === "--endpoint") options.gpuEndpoint = requireValue(flag, next);
+    else if (flag === "--batch") options.batch = parsePositiveInt(flag, requireValue(flag, next));
+    else if (flag === "--data-dir") options.dataDir = requireValue(flag, next);
+    else if (flag === "--arra-dir") options.arraDir = requireValue(flag, next);
+    else if (flag === "--remote") options.remote = requireValue(flag, next);
+    else if (flag === "--local-port") options.localPort = parsePositiveInt(flag, requireValue(flag, next));
+    else if (flag === "--remote-port") options.remotePort = parsePositiveInt(flag, requireValue(flag, next));
+    else throw new Error(`unknown flag: ${flag}`);
+  }
+
+  return options;
+}
+
+function normalizeCommand(command: string): string {
+  if (command === "r" || command === "index") return "run";
+  if (command === "s" || command === "check") return "status";
+  return command;
+}
+
+function normalizeTunnelAction(action: string | undefined): TunnelAction {
+  if (!action) return "up";
+  if (action === "up" || action === "down") return action;
+  throw new Error("usage: maw reindex-gpu tunnel <up|down> [--remote <host>] [--local-port <n>] [--remote-port <n>]");
+}
+
+function requireValue(flag: string, value: string | undefined): string {
+  if (!value || value.startsWith("--")) throw new Error(`${flag} requires a value`);
+  return value;
+}
+
+function parsePositiveInt(flag: string, value: string): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) throw new Error(`${flag} must be a positive integer`);
+  return parsed;
+}
+
+function stringOpt(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function numberOpt(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === "string" && value.length > 0) {
+    const parsed = Number(value);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  }
+  return undefined;
+}

--- a/plugins/reindex-gpu/internal/probe.ts
+++ b/plugins/reindex-gpu/internal/probe.ts
@@ -1,0 +1,56 @@
+import { DEFAULT_ENDPOINT, FALLBACK_ENDPOINT, MODEL, type ProbeResult } from "./types";
+
+export function endpointToBaseUrl(endpoint: string): string {
+  return endpoint.replace(/\/api\/(?:embed|embeddings)\/?$/i, "").replace(/\/$/, "");
+}
+
+export async function probeEndpoint(endpoint: string): Promise<ProbeResult> {
+  const baseUrl = endpointToBaseUrl(endpoint);
+  try {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ model: MODEL, input: ["ping"] }),
+      signal: AbortSignal.timeout(8000),
+    });
+
+    if (!response.ok) {
+      return { ok: false, endpoint, baseUrl, error: `HTTP ${response.status} ${response.statusText}`.trim() };
+    }
+
+    const json = await response.json() as any;
+    const embeddings = json?.embeddings;
+    const first = Array.isArray(embeddings) ? embeddings[0] : undefined;
+    if (!Array.isArray(embeddings) || !Array.isArray(first)) {
+      return { ok: false, endpoint, baseUrl, error: "HTTP 200 but response did not include embeddings[]" };
+    }
+
+    return { ok: true, endpoint, baseUrl, dimensions: first.length };
+  } catch (e: any) {
+    return { ok: false, endpoint, baseUrl, error: errorMessage(e) };
+  }
+}
+
+export async function probeWithDefaultFallback(endpoint: string): Promise<ProbeResult> {
+  const primary = await probeEndpoint(endpoint);
+  if (primary.ok || endpoint !== DEFAULT_ENDPOINT) return primary;
+
+  const fallback = await probeEndpoint(FALLBACK_ENDPOINT);
+  if (fallback.ok) {
+    console.log(`primary endpoint unreachable (${primary.error}); using fallback ${FALLBACK_ENDPOINT}`);
+    return fallback;
+  }
+
+  return {
+    ok: false,
+    endpoint,
+    baseUrl: primary.baseUrl,
+    error: `${primary.error}; fallback ${FALLBACK_ENDPOINT}: ${fallback.error}`,
+  };
+}
+
+function errorMessage(e: any): string {
+  if (e?.name === "TimeoutError" || e?.name === "AbortError") return "timeout after 8s";
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/plugins/reindex-gpu/internal/run.ts
+++ b/plugins/reindex-gpu/internal/run.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "fs";
+import { spawn } from "child_process";
+import { homedir } from "os";
+import { join } from "path";
+import { DEFAULT_BATCH, DEFAULT_ENDPOINT, MODEL, type OpResult, type Options } from "./types";
+import { probeWithDefaultFallback } from "./probe";
+
+const VECTOR_COUNT_RE = /vectorized\s+(\d+)\/(\d+)/i;
+
+export async function runReindex(options: Options): Promise<OpResult> {
+  const endpoint = options.gpuEndpoint ?? DEFAULT_ENDPOINT;
+  const batch = options.batch ?? DEFAULT_BATCH;
+  const probe = await probeWithDefaultFallback(endpoint);
+
+  if (!probe.ok) {
+    const error = `embed endpoint unreachable: ${probe.error}`;
+    console.error(error);
+    return { ok: false, error };
+  }
+
+  const arraDir = resolveArraDir(options.arraDir);
+  const script = join(arraDir, "src/scripts/index-model.ts");
+  if (!existsSync(script)) {
+    const error = `arra indexer not found: ${script}`;
+    console.error(error);
+    return { ok: false, error };
+  }
+
+  console.log(`reindex via GPU endpoint ${probe.endpoint}`);
+  console.log(`OLLAMA_BASE_URL=${probe.baseUrl}`);
+  console.log(`OLLAMA_EMBED_BATCH=${batch}`);
+  if (options.dataDir) console.log(`ORACLE_DATA_DIR=${options.dataDir}`);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    OLLAMA_BASE_URL: probe.baseUrl,
+    OLLAMA_EMBED_BATCH: String(batch),
+    ORACLE_EMBEDDING_MODEL: MODEL,
+  };
+  if (options.dataDir) env.ORACLE_DATA_DIR = options.dataDir;
+
+  const child = spawn("bun", [script, MODEL], {
+    cwd: arraDir,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let combined = "";
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    combined += text;
+    for (const line of text.split(/\r?\n/)) if (line.length > 0) console.log(line);
+  });
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    combined += text;
+    for (const line of text.split(/\r?\n/)) if (line.length > 0) console.error(line);
+  });
+
+  const exitCode = await new Promise<number>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code) => resolve(code ?? 1));
+  });
+
+  const count = combined.match(VECTOR_COUNT_RE);
+  if (count) console.log(`vectorized ${count[1]}/${count[2]}`);
+
+  if (exitCode !== 0) {
+    const error = `incomplete reindex: indexer exited ${exitCode}${count ? ` after vectorized ${count[1]}/${count[2]}` : ""}`;
+    console.error(error);
+    return { ok: false, error };
+  }
+
+  return { ok: true, output: count ? `vectorized ${count[1]}/${count[2]}` : "reindex complete" };
+}
+
+function resolveArraDir(explicit?: string): string {
+  if (explicit) return explicit;
+  if (process.env.ARRA_DIR) return process.env.ARRA_DIR;
+  return join(homedir(), "arra-oracle-v3");
+}

--- a/plugins/reindex-gpu/internal/run.ts
+++ b/plugins/reindex-gpu/internal/run.ts
@@ -28,12 +28,14 @@ export async function runReindex(options: Options): Promise<OpResult> {
 
   console.log(`reindex via GPU endpoint ${probe.endpoint}`);
   console.log(`OLLAMA_BASE_URL=${probe.baseUrl}`);
-  console.log(`OLLAMA_EMBED_BATCH=${batch}`);
+  console.log(`batch=${batch} (ORACLE_EMBED_BATCH_SIZE + OLLAMA_EMBED_BATCH)`);
   if (options.dataDir) console.log(`ORACLE_DATA_DIR=${options.dataDir}`);
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     OLLAMA_BASE_URL: probe.baseUrl,
+    // ORACLE_EMBED_BATCH_SIZE is canonical (arra main #1433); OLLAMA_EMBED_BATCH is interim for the deployed VPS arra until it aligns to main.
+    ORACLE_EMBED_BATCH_SIZE: String(batch),
     OLLAMA_EMBED_BATCH: String(batch),
     ORACLE_EMBEDDING_MODEL: MODEL,
   };

--- a/plugins/reindex-gpu/internal/setup.ts
+++ b/plugins/reindex-gpu/internal/setup.ts
@@ -1,0 +1,10 @@
+import { status } from "./status";
+import { tunnel } from "./tunnel";
+import type { OpResult, Options } from "./types";
+
+export async function setupGpu(options: Options): Promise<OpResult> {
+  const statusResult = await status(options);
+  if (!statusResult.ok) return statusResult;
+  if (!options.remote) return statusResult;
+  return tunnel("up", options);
+}

--- a/plugins/reindex-gpu/internal/status.ts
+++ b/plugins/reindex-gpu/internal/status.ts
@@ -1,0 +1,34 @@
+import { DEFAULT_ENDPOINT, type OpResult, type Options } from "./types";
+import { probeWithDefaultFallback } from "./probe";
+
+export async function status(options: Options): Promise<OpResult> {
+  const endpoint = options.gpuEndpoint ?? DEFAULT_ENDPOINT;
+  const probe = await probeWithDefaultFallback(endpoint);
+  if (!probe.ok) {
+    const error = `embed endpoint unreachable: ${probe.error}`;
+    console.log(error);
+    return { ok: false, error };
+  }
+
+  const dimText = probe.dimensions === 1024 ? "1024-dim" : `${probe.dimensions ?? "unknown"}-dim`;
+  const output = `reachable: ${probe.endpoint} responds for bge-m3 (${dimText})`;
+  console.log(output);
+  return { ok: true, output };
+}
+
+export function showHelp(): void {
+  console.log(`maw reindex-gpu <command> [flags]
+
+Commands:
+  status [--gpu-endpoint <url>]                 POST /api/embed probe for bge-m3
+  run [--gpu-endpoint <url>] [--batch <n>]      precheck, then bun <arra>/src/scripts/index-model.ts bge-m3
+      [--data-dir <p>] [--arra-dir <p>]
+  tunnel up [--remote <host>] [--local-port 11435] [--remote-port 11434]
+  tunnel down
+  setup [--gpu-endpoint <url>] [--remote <host>]
+
+Defaults:
+  --gpu-endpoint https://embed.oracles.asia/api/embed
+  --batch 128
+  --arra-dir $ARRA_DIR or ~/arra-oracle-v3`);
+}

--- a/plugins/reindex-gpu/internal/tunnel.ts
+++ b/plugins/reindex-gpu/internal/tunnel.ts
@@ -1,0 +1,54 @@
+import { spawn } from "child_process";
+import { DEFAULT_TUNNEL_LOCAL_PORT, DEFAULT_TUNNEL_REMOTE_PORT, TUNNEL_PROCESS_NAME, type OpResult, type Options, type TunnelAction } from "./types";
+
+export async function tunnel(action: TunnelAction, options: Options): Promise<OpResult> {
+  if (action === "down") {
+    await runPm2(["stop", TUNNEL_PROCESS_NAME], true);
+    await runPm2(["delete", TUNNEL_PROCESS_NAME], true);
+    const output = `tunnel stopped: ${TUNNEL_PROCESS_NAME}`;
+    console.log(output);
+    return { ok: true, output };
+  }
+
+  if (!options.remote) {
+    const error = "tunnel up requires --remote <host>";
+    console.error(error);
+    return { ok: false, error };
+  }
+
+  const localPort = options.localPort ?? DEFAULT_TUNNEL_LOCAL_PORT;
+  const remotePort = options.remotePort ?? DEFAULT_TUNNEL_REMOTE_PORT;
+  const sshArgs = [
+    "-N",
+    "-L",
+    `${localPort}:localhost:${remotePort}`,
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
+    options.remote,
+  ];
+
+  await runPm2(["delete", TUNNEL_PROCESS_NAME], true);
+  await runPm2(["start", "ssh", "--name", TUNNEL_PROCESS_NAME, "--", ...sshArgs], false);
+  const output = `tunnel up: localhost:${localPort} -> ${options.remote}:localhost:${remotePort} (${TUNNEL_PROCESS_NAME})`;
+  console.log(output);
+  return { ok: true, output };
+}
+
+function runPm2(args: string[], ignoreFailure: boolean): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pm2", args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += chunk.toString(); });
+    child.stderr.on("data", (chunk) => { output += chunk.toString(); });
+    child.on("error", (e) => {
+      if (ignoreFailure) resolve();
+      else reject(e);
+    });
+    child.on("close", (code) => {
+      if (code === 0 || ignoreFailure) resolve();
+      else reject(new Error(`pm2 ${args.join(" ")} failed (${code}): ${output.trim()}`));
+    });
+  });
+}

--- a/plugins/reindex-gpu/internal/types.ts
+++ b/plugins/reindex-gpu/internal/types.ts
@@ -1,0 +1,41 @@
+export const DEFAULT_ENDPOINT = "https://embed.oracles.asia/api/embed";
+export const FALLBACK_ENDPOINT = "http://115.73.210.129:23882/api/embed";
+export const MODEL = "bge-m3";
+export const DEFAULT_BATCH = 128;
+export const DEFAULT_TUNNEL_LOCAL_PORT = 11435;
+export const DEFAULT_TUNNEL_REMOTE_PORT = 11434;
+export const TUNNEL_PROCESS_NAME = "gpu-embed-tunnel";
+
+export type CommandName = "run" | "status" | "tunnel" | "setup";
+export type TunnelAction = "up" | "down";
+
+export interface Options {
+  gpuEndpoint?: string;
+  batch?: number;
+  dataDir?: string;
+  arraDir?: string;
+  remote?: string;
+  localPort?: number;
+  remotePort?: number;
+}
+
+export interface ParsedRequest {
+  command: CommandName | string;
+  tunnelAction: TunnelAction;
+  options: Options;
+  help: boolean;
+}
+
+export interface OpResult {
+  ok: boolean;
+  output?: string;
+  error?: string;
+}
+
+export interface ProbeResult {
+  ok: boolean;
+  endpoint: string;
+  baseUrl: string;
+  dimensions?: number;
+  error?: string;
+}

--- a/plugins/reindex-gpu/plugin.json
+++ b/plugins/reindex-gpu/plugin.json
@@ -1,0 +1,25 @@
+{
+  "name": "reindex-gpu",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Thin GPU orchestration for arra bge-m3 reindexing.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "reindex-gpu",
+    "aliases": [
+      "rgpu"
+    ],
+    "help": "maw reindex-gpu <status|run|tunnel|setup> [flags]"
+  },
+  "api": {
+    "path": "/api/reindex-gpu",
+    "methods": [
+      "GET",
+      "POST"
+    ]
+  },
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1
+}

--- a/plugins/reindex-gpu/plugin.ts
+++ b/plugins/reindex-gpu/plugin.ts
@@ -1,0 +1,27 @@
+import { definePlugin } from "maw-js/sdk";
+
+export default definePlugin({
+  "name": "reindex-gpu",
+  "version": "1.0.0",
+  "entry": "./index.ts",
+  "sdk": "^1.0.0",
+  "description": "Thin GPU orchestration for arra bge-m3 reindexing.",
+  "author": "Soul-Brews-Studio",
+  "cli": {
+    "command": "reindex-gpu",
+    "aliases": [
+      "rgpu"
+    ],
+    "help": "maw reindex-gpu <status|run|tunnel|setup> [flags]"
+  },
+  "api": {
+    "path": "/api/reindex-gpu",
+    "methods": [
+      "GET",
+      "POST"
+    ]
+  },
+  "weight": 10,
+  "license": "MIT",
+  "schemaVersion": 1
+} as const);

--- a/plugins/reindex-gpu/registry.meta.json
+++ b/plugins/reindex-gpu/registry.meta.json
@@ -1,0 +1,11 @@
+{
+  "version": "1.0.0",
+  "source": "soul-brews-studio/maw-plugin-registry/reindex-gpu@v1.0.0-reindex-gpu",
+  "sha256": null,
+  "summary": "Thin GPU orchestration for arra bge-m3 reindexing.",
+  "author": "Soul-Brews-Studio",
+  "license": "MIT",
+  "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+  "addedAt": "2026-06-18T13:05:44Z",
+  "tier": "extra"
+}

--- a/registry.json
+++ b/registry.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./schema/registry.json",
   "schemaVersion": 1,
-  "updated": "2026-06-11T03:44:38Z",
+  "updated": "2026-06-18T13:05:55Z",
   "plugins": {
     "about": {
       "version": "0.1.0",
@@ -556,6 +556,17 @@
       "license": "MIT",
       "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
       "addedAt": "2026-04-29T02:49:08Z",
+      "tier": "extra"
+    },
+    "reindex-gpu": {
+      "version": "1.0.0",
+      "source": "soul-brews-studio/maw-plugin-registry/reindex-gpu@v1.0.0-reindex-gpu",
+      "sha256": null,
+      "summary": "Thin GPU orchestration for arra bge-m3 reindexing.",
+      "author": "Soul-Brews-Studio",
+      "license": "MIT",
+      "homepage": "https://github.com/Soul-Brews-Studio/maw-plugin-registry",
+      "addedAt": "2026-06-18T13:05:44Z",
       "tier": "extra"
     },
     "rename": {


### PR DESCRIPTION
## reindex-gpu — GPU-accelerated arra bge-m3 reindex

A thin GPU-orchestration plugin: drives an oracle's **arra** bge-m3 reindex through a remote GPU **embed gateway**, so oracles can borrow a dedicated GPU for the heavy reindex job. Built TS (needs exec/fs/POST — not WASM-suitable).

### Subcommands
- `run --gpu-endpoint <url> --batch <n> [--data-dir] [--arra-dir]` — fail-closed `POST /api/embed` precheck (8s timeout, verifies bge-m3 returns embeddings) → sets OLLAMA_BASE_URL (derived base) + OLLAMA_EMBED_BATCH + ORACLE_EMBEDDING_MODEL → spawns the oracle's `bun src/scripts/index-model.ts bge-m3` → **non-zero indexer exit ⇒ ok:false** (partial reindex never reported as success) → surfaces `vectorized N/M`.
- `status` — POST /api/embed probe; reports reachable + dim.
- `tunnel up|down` — pm2-managed SSH tunnel (ServerAlive keepalive).
- `setup` — endpoint probe + tunnel up.
- api `GET/POST /api/reindex-gpu` for federation.

### Design
- **Portable**: delegates embed/index to the oracle's own arra (discovered via `ARRA_DIR` else `~/arra-oracle-v3`); no duplicated indexer/schema.
- **Fail-closed** end to end (precheck + non-zero exit).
- Carries the hard-won lessons (README): dedicated-GPU only (shared nvshare crashes), retry+fail-closed mandatory, high tunnel-RTT ⇒ batch 128.

### Verified locally
`maw plugin install` ✓ · unreachable endpoint → fail-closed EXIT:1 ✓ · `status` against the live gateway → `bge-m3 1024-dim` ✓ · `maw plugin ls` registers (tier extra, cli+api) ✓ · TS bundles ✓.

tier: extra. `sha256` left null for maintainer/CI to fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)